### PR TITLE
Fixes for timing issue, Avro and Bond serializers

### DIFF
--- a/GLD.SerializerBenchmark/GLD.SerializerBenchmark.csproj
+++ b/GLD.SerializerBenchmark/GLD.SerializerBenchmark.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Bond.CSharp.3.0.4\build\Bond.CSharp.props" Condition="Exists('..\packages\Bond.CSharp.3.0.4\build\Bond.CSharp.props')" />
+  <Import Project="..\packages\Bond.CSharp.3.0.6\build\Bond.CSharp.props" Condition="Exists('..\packages\Bond.CSharp.3.0.6\build\Bond.CSharp.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -12,7 +12,7 @@
     <AssemblyName>GLD.SerializerBenchmark</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>04684a2f</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>bb222ed6</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -35,25 +35,29 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bond">
-      <HintPath>..\packages\Bond.Runtime.CSharp.3.0.4\lib\net45\Bond.dll</HintPath>
+    <Reference Include="Bond, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Bond.Runtime.CSharp.3.0.6\lib\net45\Bond.dll</HintPath>
     </Reference>
-    <Reference Include="Bond.Attributes">
-      <HintPath>..\packages\Bond.Runtime.CSharp.3.0.4\lib\net45\Bond.Attributes.dll</HintPath>
+    <Reference Include="Bond.Attributes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Bond.Runtime.CSharp.3.0.6\lib\net45\Bond.Attributes.dll</HintPath>
     </Reference>
-    <Reference Include="Bond.IO">
-      <HintPath>..\packages\Bond.Runtime.CSharp.3.0.4\lib\net45\Bond.IO.dll</HintPath>
+    <Reference Include="Bond.IO, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Bond.Runtime.CSharp.3.0.6\lib\net45\Bond.IO.dll</HintPath>
     </Reference>
-    <Reference Include="Bond.JSON">
-      <HintPath>..\packages\Bond.Runtime.CSharp.3.0.4\lib\net45\Bond.JSON.dll</HintPath>
+    <Reference Include="Bond.JSON, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Bond.Runtime.CSharp.3.0.6\lib\net45\Bond.JSON.dll</HintPath>
     </Reference>
     <Reference Include="fastjson, Version=2.1.0.0, Culture=neutral, PublicKeyToken=6b75a806b86095cd, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\fastJSON.2.1.11.0\lib\net40\fastjson.dll</HintPath>
+      <HintPath>..\packages\fastJSON.2.1.12.0\lib\net40\fastjson.dll</HintPath>
     </Reference>
-    <Reference Include="Flexo, Version=1.0.20.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Flexo, Version=1.0.21.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\flexo.1.0.20.0\lib\Flexo.dll</HintPath>
+      <HintPath>..\packages\flexo.1.0.21.0\lib\Flexo.dll</HintPath>
     </Reference>
     <Reference Include="Jil, Version=2.9.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -62,9 +66,9 @@
     <Reference Include="JsonFx">
       <HintPath>..\packages\JsonFx.2.0.1209.2802\lib\net40\JsonFx.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Hadoop.Avro, Version=1.5.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Hadoop.Avro, Version=1.5.6.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Hadoop.Avro.1.5.4\lib\net45\Microsoft.Hadoop.Avro.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Hadoop.Avro.1.5.6\lib\net45\Microsoft.Hadoop.Avro.dll</HintPath>
     </Reference>
     <Reference Include="MsgPack, Version=0.5.0.0, Culture=neutral, PublicKeyToken=a2625990d5dc0167, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -86,8 +90,9 @@
     <Reference Include="Serialization">
       <HintPath>..\packages\ObjectSerialization.1.0.0.0\lib\net45\Serialization.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Text">
-      <HintPath>..\packages\ServiceStack.Text.4.0.38\lib\net40\ServiceStack.Text.dll</HintPath>
+    <Reference Include="ServiceStack.Text, Version=4.0.40.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\ServiceStack.Text.4.0.40\lib\net40\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="Sigil">
       <HintPath>..\packages\Sigil.4.4.0\lib\net45\Sigil.dll</HintPath>
@@ -104,6 +109,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Serializers\BinarySerializer.cs" />
+    <Compile Include="Serializers\BondJsonSerializer.cs" />
     <Compile Include="Serializers\BondSerializer.cs" />
     <Compile Include="Bond\Person_types.cs" />
     <Compile Include="ISerDeser.cs" />
@@ -144,10 +150,10 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Bond.CSharp.3.0.4\build\Bond.CSharp.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Bond.CSharp.3.0.4\build\Bond.CSharp.props'))" />
-    <Error Condition="!Exists('..\packages\Bond.CSharp.3.0.4\build\Bond.CSharp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Bond.CSharp.3.0.4\build\Bond.CSharp.targets'))" />
+    <Error Condition="!Exists('..\packages\Bond.CSharp.3.0.6\build\Bond.CSharp.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Bond.CSharp.3.0.6\build\Bond.CSharp.props'))" />
+    <Error Condition="!Exists('..\packages\Bond.CSharp.3.0.6\build\Bond.CSharp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Bond.CSharp.3.0.6\build\Bond.CSharp.targets'))" />
   </Target>
-  <Import Project="..\packages\Bond.CSharp.3.0.4\build\Bond.CSharp.targets" Condition="Exists('..\packages\Bond.CSharp.3.0.4\build\Bond.CSharp.targets')" />
+  <Import Project="..\packages\Bond.CSharp.3.0.6\build\Bond.CSharp.targets" Condition="Exists('..\packages\Bond.CSharp.3.0.6\build\Bond.CSharp.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/GLD.SerializerBenchmark/Person.cs
+++ b/GLD.SerializerBenchmark/Person.cs
@@ -39,7 +39,7 @@ namespace GLD.SerializerBenchmark
 
         [DataMember]
         [ProtoMember(3)]
-        [Id(2)]
+        [Id(2), global::Bond.Type(typeof(long))]
         public DateTime ExpirationDate { get; set; }
     }
 
@@ -173,6 +173,19 @@ namespace GLD.SerializerBenchmark
         {
             if (!left.Equals(right))
                 errors.Add(String.Format("\t{0}: {1} != {2}", objectName, left, right));
+        }
+    }
+
+    public static class BondTypeAliasConverter
+    {
+        public static long Convert(DateTime value, long unused)
+        {
+            return value.Ticks;
+        }
+
+        public static DateTime Convert(long value, DateTime unused)
+        {
+            return new DateTime(value);
         }
     }
 }

--- a/GLD.SerializerBenchmark/Person.cs
+++ b/GLD.SerializerBenchmark/Person.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.Serialization;
 using Bond;
 using Newtonsoft.Json;
@@ -69,28 +70,31 @@ namespace GLD.SerializerBenchmark
     public class Person
     {
         // private static int maxPoliceRecordCounter = 20;
-
         public Person()
         {
-            FirstName = Randomizer.Name;
-            LastName = Randomizer.Name;
-            Age = (uint) Randomizer.Rand.Next(120);
-            Gender = (Randomizer.Rand.Next(0, 1) == 0) ? Gender.Male : Gender.Female;
-            Passport = new Passport
+        }
+
+        public static Person Generate()
+        {
+            return new Person
             {
-                Authority = Randomizer.Phrase,
-                ExpirationDate =
-                    Randomizer.GetDate(DateTime.UtcNow, DateTime.UtcNow + TimeSpan.FromDays(1000)),
-                Number = Randomizer.Id
-            };
-            var curPoliceRecordCounter = Randomizer.Rand.Next(20);
-            PoliceRecords = new PoliceRecord[curPoliceRecordCounter];
-            for (var i = 0; i < curPoliceRecordCounter; i++)
-                PoliceRecords[i] = new PoliceRecord
+                FirstName = Randomizer.Name,
+                LastName = Randomizer.Name,
+                Age = (uint) Randomizer.Rand.Next(120),
+                Gender = (Randomizer.Rand.Next(0, 1) == 0) ? Gender.Male : Gender.Female,
+                Passport = new Passport
                 {
-                    Id = int.Parse(Randomizer.Id),
+                    Authority = Randomizer.Phrase,
+                    ExpirationDate =
+                        Randomizer.GetDate(DateTime.UtcNow, DateTime.UtcNow + TimeSpan.FromDays(1000)),
+                    Number = Randomizer.Id
+                },
+                PoliceRecords = Enumerable.Range(0, 20).Select(i => new PoliceRecord
+                {
+                    Id = i,
                     CrimeCode = Randomizer.Name
-                };
+                }).ToArray()
+            };
         }
 
         [DataMember]
@@ -180,12 +184,12 @@ namespace GLD.SerializerBenchmark
     {
         public static long Convert(DateTime value, long unused)
         {
-            return value.Ticks;
+            return value.ToBinary();
         }
 
         public static DateTime Convert(long value, DateTime unused)
         {
-            return new DateTime(value);
+            return DateTime.FromBinary(value);
         }
     }
 }

--- a/GLD.SerializerBenchmark/Program.cs
+++ b/GLD.SerializerBenchmark/Program.cs
@@ -18,7 +18,8 @@ namespace GLD.SerializerBenchmark
             {
                 {"MS Avro", new AvroSerializer(typeof(Person))}, 
                 {"MS Binary",new BinarySerializer()},
-                {"BondSerializer", new BondSerializer(typeof(Person))}, // TODO: It does not debugged yet. 
+                {"BondSerializer", new BondSerializer(typeof(Person))},
+                {"BondJson", new BondJsonSerializer(typeof(Person))},
                 {"MS DataContract", new DataContractSerializerSerializer(typeof(Person))},  
                 {"MS DataContractJson", new DataContractJsonSerializer(typeof(Person))},  
                 {"MS JavaScript", new JavaScriptSerializer()},  // TODO: DateTime format?

--- a/GLD.SerializerBenchmark/Program.cs
+++ b/GLD.SerializerBenchmark/Program.cs
@@ -18,7 +18,7 @@ namespace GLD.SerializerBenchmark
             {
                 {"MS Avro", new AvroSerializer(typeof(Person))}, 
                 {"MS Binary",new BinarySerializer()},
-                //{"BondSerializer", new BondSerializer(typeof(Person))}, // TODO: It does not debugged yet. 
+                {"BondSerializer", new BondSerializer(typeof(Person))}, // TODO: It does not debugged yet. 
                 {"MS DataContract", new DataContractSerializerSerializer(typeof(Person))},  
                 {"MS DataContractJson", new DataContractJsonSerializer(typeof(Person))},  
                 {"MS JavaScript", new JavaScriptSerializer()},  // TODO: DateTime format?

--- a/GLD.SerializerBenchmark/Report.cs
+++ b/GLD.SerializerBenchmark/Report.cs
@@ -32,11 +32,15 @@ namespace GLD.SerializerBenchmark
         private static void SingleResult(KeyValuePair<string, Measurements[]> oneTestMeasurements)
         {
             string report =
-                String.Format("{0, -22} {1,7:N0} {2,7:N0} {3,7:N0} {4,9:N0} {5,10:N0} {6,9:N0}",
-                    oneTestMeasurements.Key, AverageTime(oneTestMeasurements.Value, 10),
-                    AverageTime(oneTestMeasurements.Value, 5),
-                    AverageTime(oneTestMeasurements.Value), MinTime(oneTestMeasurements.Value),
-                    MaxTime(oneTestMeasurements.Value), AverageSize(oneTestMeasurements.Value));
+                String.Format("{0, -22} {1,7:N0} {2,7:N0} {3,7:N0} {4,7:N0} {5,9:N0} {6,10:N0} {7,9:N0}",
+                    oneTestMeasurements.Key,
+                    AverageTime(oneTestMeasurements.Value, 50),
+                    AverageTime(oneTestMeasurements.Value, 10),
+                    AverageTime(oneTestMeasurements.Value),
+                    P99Time(oneTestMeasurements.Value),
+                    MinTime(oneTestMeasurements.Value),
+                    MaxTime(oneTestMeasurements.Value),
+                    AverageSize(oneTestMeasurements.Value));
 
             Console.WriteLine(report);
             Trace.WriteLine(report);
@@ -44,65 +48,56 @@ namespace GLD.SerializerBenchmark
 
         private static void Header()
         {
-            string header = "Serializer:     Time:  Avg-80%    -90%   -100%       Min        Max  Size: Avg\n"
+            string header = "Serializer:     Time:  Avg-50%    -90%   -100%    -p99       Min        Max  Size: Avg\n"
                             +
-                            "=============================================================================";
+                            "======================================================================================";
             Console.WriteLine(header);
             Trace.WriteLine(header);
         }
 
+        private static double P99Time(Measurements[] measurements)
+        {
+            if (measurements == null || measurements.Length == 0) return 0;
+            return BottomPercent(measurements, 1).Select(m => m.Time).LastOrDefault();
+        }
      
 
         private static double MaxTime(Measurements[] measurements)
         {
             if (measurements == null || measurements.Length == 0) return 0;
-            return PrepareTimes(measurements).Max();
+            return measurements.Max(m => m.Time);
         }
 
         private static double MinTime(Measurements[] measurements)
         {
             if (measurements == null || measurements.Length == 0) return 0;
-            return PrepareTimes(measurements).Min();
+            return measurements.Min(m => m.Time);
+        }
+
+        private static IEnumerable<Measurements> BottomPercent(Measurements[] measurements, int discardedPercent)
+        {
+            if (discardedPercent == 0) return measurements;
+            var take = (int)Math.Round(measurements.Length * (100 - discardedPercent) / 100.0);
+            return measurements.OrderBy(m => m.Time).Take(take);
         }
 
         private static double AverageTime(Measurements[] measurements, int discardedPercent = 0)
         {
             if (measurements == null || measurements.Length == 0) return 0;
-            var times = PrepareTimes(measurements);
 
-            Array.Sort(times);
-            int repetitions = times.Length;
-            long totalTime = 0;
-            var discardCount = 0;
-            if (discardedPercent != 0)
-            {
-                discardCount = (int) Math.Round(repetitions*(double) discardedPercent/100);
-                if (discardCount == 0 && repetitions > 2) discardCount = 1;
-            }
-            int count = repetitions - discardCount;
-            for (int i = discardCount; i < count; i++)
-                totalTime += times[i];
-
-            return ((double) totalTime)/(count - discardCount);
+            return BottomPercent(measurements, discardedPercent).Average(m => m.Time);
         }
 
         private static long[] PrepareTimes(Measurements[] measurements)
         {
             if (measurements == null || measurements.Length == 0) return null;
-            var times = new long[measurements.Length];
-            for (int i = 0; i < measurements.Length; i++)
-                times[i] = measurements[i].Time;
-            return times;
+            return measurements.Select(m => m.Time).ToArray();
         }
 
         private static int AverageSize(Measurements[] measurements)
         {
             if (measurements == null || measurements.Length == 0) return 0;
-            long totalSizes = 0;
-            for (int i = 0; i < measurements.Length; i++)
-                totalSizes += measurements[i].Size;
-
-            return (int) (totalSizes/measurements.Length);
+            return (int)measurements.Average(m => m.Size);
         }
     }
 }

--- a/GLD.SerializerBenchmark/Serializers/AvroSerializer.cs
+++ b/GLD.SerializerBenchmark/Serializers/AvroSerializer.cs
@@ -11,25 +11,19 @@ namespace GLD.SerializerBenchmark
 {
     internal class AvroSerializer : ISerDeser
     {
-        private AvroSerializerSettings _settings = new AvroSerializerSettings {UseCache = true};
-        //private static Microsoft.Hadoop.Avro.AvroSerializer _serializer = Microsoft.Hadoop.Avro.AvroSerializer.Create<Person>();;
+        private readonly IAvroSerializer<Person> _serializer = Microsoft.Hadoop.Avro.AvroSerializer.Create<Person>();
 
         #region ISerDeser Members
 
         public AvroSerializer(Type type)
         {
-            // TODO: Hack! How to get a type of the person object? In XmlSerializer it works, not here!
-            // The serialize is typed and type should be know upfront. 
-            // The staic variable cannot be created.
-            //_serializer =  Microsoft.Hadoop.Avro.AvroSerializer.Create<Person>();
         }
 
         public string Serialize<T>(object person)
         {
-            var serializer =  Microsoft.Hadoop.Avro.AvroSerializer.Create<T>(_settings); 
             using (var ms = new MemoryStream())
             {
-                serializer.Serialize(ms, (T)person); 
+                _serializer.Serialize(ms, (Person)person); 
                 ms.Flush();
                 ms.Position = 0;
                 return Convert.ToBase64String(ms.ToArray());
@@ -38,12 +32,11 @@ namespace GLD.SerializerBenchmark
 
         public T Deserialize<T>(string serialized)
         {
-            var serializer =  Microsoft.Hadoop.Avro.AvroSerializer.Create<T>(_settings);
             var b = Convert.FromBase64String(serialized);
             using (var stream = new MemoryStream(b))
             {
                 stream.Seek(0, SeekOrigin.Begin);
-                return (T)serializer.Deserialize(stream); 
+                return (T) ((object) _serializer.Deserialize(stream));
             }
         }
 

--- a/GLD.SerializerBenchmark/Serializers/AvroSerializer.cs
+++ b/GLD.SerializerBenchmark/Serializers/AvroSerializer.cs
@@ -11,7 +11,9 @@ namespace GLD.SerializerBenchmark
 {
     internal class AvroSerializer : ISerDeser
     {
+        private AvroSerializerSettings _settings = new AvroSerializerSettings {UseCache = true};
         //private static Microsoft.Hadoop.Avro.AvroSerializer _serializer = Microsoft.Hadoop.Avro.AvroSerializer.Create<Person>();;
+
         #region ISerDeser Members
 
         public AvroSerializer(Type type)
@@ -24,7 +26,7 @@ namespace GLD.SerializerBenchmark
 
         public string Serialize<T>(object person)
         {
-            var serializer =  Microsoft.Hadoop.Avro.AvroSerializer.Create<T>(); 
+            var serializer =  Microsoft.Hadoop.Avro.AvroSerializer.Create<T>(_settings); 
             using (var ms = new MemoryStream())
             {
                 serializer.Serialize(ms, (T)person); 
@@ -36,7 +38,7 @@ namespace GLD.SerializerBenchmark
 
         public T Deserialize<T>(string serialized)
         {
-            var serializer =  Microsoft.Hadoop.Avro.AvroSerializer.Create<T>();
+            var serializer =  Microsoft.Hadoop.Avro.AvroSerializer.Create<T>(_settings);
             var b = Convert.FromBase64String(serialized);
             using (var stream = new MemoryStream(b))
             {

--- a/GLD.SerializerBenchmark/Serializers/BondJsonSerializer.cs
+++ b/GLD.SerializerBenchmark/Serializers/BondJsonSerializer.cs
@@ -1,0 +1,47 @@
+﻿///
+/// See here https://github.com/Microsoft/bond/
+/// >PM Install-Package Microsoft.Hadoop.Avro
+/// 
+using System;
+using System.IO;
+using Bond;
+using Bond.IO.Unsafe;
+using Bond.Protocols;
+
+namespace GLD.SerializerBenchmark
+{
+    internal class BondJsonSerializer : ISerDeser
+    {
+        private readonly Deserializer<SimpleJsonReader> _deserializer;
+        private readonly Serializer<SimpleJsonWriter> _serializer;
+
+        public BondJsonSerializer(Type personType)
+        {
+            _serializer = new Serializer<SimpleJsonWriter>(personType);
+            _deserializer = new Deserializer<SimpleJsonReader>(personType);
+        }
+
+        #region ISerDeser Members
+
+        public string Serialize<T>(object person)
+        {
+            using (var tw = new StringWriter())
+            {
+                var writer = new SimpleJsonWriter(tw);
+                _serializer.Serialize((T) person, writer);
+                return tw.ToString();
+            }
+        }
+
+        public T Deserialize<T>(string serialized)
+        {
+            using (var tr = new StringReader(serialized))
+            {
+                var reader = new SimpleJsonReader(tr);
+                return _deserializer.Deserialize<T>(reader);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/GLD.SerializerBenchmark/Serializers/BondSerializer.cs
+++ b/GLD.SerializerBenchmark/Serializers/BondSerializer.cs
@@ -4,7 +4,7 @@
 /// 
 using System;
 using Bond;
-using Bond.IO.Safe;
+using Bond.IO.Unsafe;
 using Bond.Protocols;
 
 namespace GLD.SerializerBenchmark

--- a/GLD.SerializerBenchmark/Serializers/BondSerializer.cs
+++ b/GLD.SerializerBenchmark/Serializers/BondSerializer.cs
@@ -9,19 +9,6 @@ using Bond.Protocols;
 
 namespace GLD.SerializerBenchmark
 {
-    public static class BondTypeAliasConverter
-    {
-        public static long Convert(DateTime value, long unused)
-        {
-            return value.Ticks;
-        }
-
-        public static DateTime Convert(long value, DateTime unused)
-        {
-            return new DateTime(value);
-        }
-    }
-
     internal class BondSerializer : ISerDeser
     {
         private readonly Deserializer<CompactBinaryReader<InputBuffer>> _deserializer;
@@ -37,10 +24,10 @@ namespace GLD.SerializerBenchmark
 
         public string Serialize<T>(object person)
         {
-            var output = new OutputBuffer();
+            var output = new OutputBuffer(2 * 1024);
             var writer = new CompactBinaryWriter<OutputBuffer>(output);
             _serializer.Serialize((T)person, writer);
-            return Convert.ToBase64String(output.Data.Array);
+            return Convert.ToBase64String(output.Data.Array, output.Data.Offset, output.Data.Count);
         }
 
         public T Deserialize<T>(string serialized)

--- a/GLD.SerializerBenchmark/Tester.cs
+++ b/GLD.SerializerBenchmark/Tester.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 
 namespace GLD.SerializerBenchmark
 {
@@ -18,12 +17,13 @@ namespace GLD.SerializerBenchmark
             var measurements = new Dictionary<string, Measurements[]>();
             foreach (var serializer in serializers)
                 measurements[serializer.Key] = new Measurements[repetitions];
-            var original = new Person(); // the same data for all serializers
-            for (int i = 0; i < repetitions; i++)
+            var original = Person.Generate(); // the same data for all serializers
+            for (var i = 0; i < repetitions; i++)
+            {
                 foreach (var serializer in serializers)
                 {
                     var sw = Stopwatch.StartNew();
-                    string serialized = serializer.Value.Serialize<Person>(original);
+                    var serialized = serializer.Value.Serialize<Person>(original);
 
                     measurements[serializer.Key][i].Size = serialized.Length;
 
@@ -36,6 +36,10 @@ namespace GLD.SerializerBenchmark
                     errors[0] = serializer.Key + errors[0];
                     Report.Errors(errors);
                 }
+                GC.Collect();
+                GC.WaitForFullGCComplete();
+                GC.Collect();
+            }
             Report.AllResults(measurements);
         }
 

--- a/GLD.SerializerBenchmark/packages.config
+++ b/GLD.SerializerBenchmark/packages.config
@@ -1,19 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 
 <packages>
-  <package id="Bond.CSharp" version="3.0.4" targetFramework="net45" />
-  <package id="Bond.Runtime.CSharp" version="3.0.4" targetFramework="net45" />
-  <package id="fastJSON" version="2.1.11.0" targetFramework="net45" />
-  <package id="flexo" version="1.0.20.0" targetFramework="net45" />
+  <package id="Bond.CSharp" version="3.0.6" targetFramework="net45" />
+  <package id="Bond.Runtime.CSharp" version="3.0.6" targetFramework="net45" />
+  <package id="fastJSON" version="2.1.12.0" targetFramework="net45" />
+  <package id="flexo" version="1.0.21.0" targetFramework="net45" />
   <package id="Jil" version="2.9.0" targetFramework="net45" />
   <package id="JsonFx" version="2.0.1209.2802" targetFramework="net45" />
-  <package id="Microsoft.Hadoop.Avro" version="1.5.4" targetFramework="net45" />
+  <package id="Microsoft.Hadoop.Avro" version="1.5.6" targetFramework="net45" />
   <package id="MsgPack.Cli" version="0.5.11" targetFramework="net45" />
   <package id="NetSerializer" version="3.0.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="ObjectSerialization" version="1.0.0.0" targetFramework="net45" />
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
-  <package id="ServiceStack.Text" version="4.0.38" targetFramework="net45" />
+  <package id="ServiceStack.Text" version="4.0.40" targetFramework="net45" />
   <package id="SharpSerializer" version="2.20" targetFramework="net45" />
   <package id="Sigil" version="4.4.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
After fixing the `Person` constructor (which apparently `NetSerializer` bypasses) the timing for a lot of the other serializers decreased by quite a bit.
- Fixed the serializer for Avro so that it is cached vs. recreated every time.
- Fixed the Bond attribute for the DateTime
- Fixed the BondSerializer performance issues by specifying a smaller size for OutputBuffer (default is 64k) and changing to the Unsafe version of the Buffers.
- Updated the reported stats to be a little more meaningful (for what I was looking at) and added P99 stat to get a better idea of "max" w/o the serializer compiler overhead mixed in.
- Added GC collect call between runs of serializers in the `Tester` class to reduce GCs interfering with results.

Based on these tests, Avro and Bond both beat NetSerializer on performance --
Bond is the winner on fastest serialization,
Avro has the smallest payload

Avro: 132ms avg, 888 bytes
Bond: 111ms avg, 976 bytes
NetSerializer: 138ms avg, 948 bytes
