### PR TITLE
⚡ Optimize report generation lookup performance

### DIFF
--- a/GLD.SerializerBenchmark/Report.cs
+++ b/GLD.SerializerBenchmark/Report.cs
@@ -20,9 +20,10 @@ namespace GLD.SerializerBenchmark
                 : logs; // include warmup when only 1 rep
             
             var aggregatedResults = filteredLogs
-                .GroupBy(a => new {a.TestDataName, a.SerializerName, a.StringOrStream})
-                .Select(g =>
-                    new AggregateLogs
+                .GroupBy(a => new { a.TestDataName, a.SerializerName, a.StringOrStream })
+                .ToDictionary(
+                    g => (g.Key.TestDataName, g.Key.SerializerName, g.Key.StringOrStream),
+                    g => new AggregateLogs
                     {
                         StringOrStream = g.Key.StringOrStream,
                         TestDataName = g.Key.TestDataName,
@@ -30,25 +31,20 @@ namespace GLD.SerializerBenchmark
                         OpPerSecDeserAver = g.Average(kg => kg.OpPerSecDeser),
                         OpPerSecSerAver = g.Average(kg => kg.OpPerSecSer),
                         OpPerSecSerAndDeserAver = g.Average(kg => kg.OpPerSecSerAndDeser),
-                        SizeAver = (int) g.Average(kg => kg.Size)
-                    }).ToList();
+                        SizeAver = (int)g.Average(kg => kg.Size)
+                    });
 
             // for each Test Data type
             foreach (var testData in testDataDescriptions)
             {
                 HeaderTestData(testData.Name);
-                
+
                 // For each serializer, show result or FAILURE
                 foreach (var serializer in serializers)
                 {
                     foreach (var mode in new[] { "string", "Stream" })
                     {
-                        var result = aggregatedResults.FirstOrDefault(r => 
-                            r.TestDataName == testData.Name && 
-                            r.SerializerName == serializer.Name && 
-                            r.StringOrStream == mode);
-
-                        if (result != null)
+                        if (aggregatedResults.TryGetValue((testData.Name, serializer.Name, mode), out var result))
                         {
                             OnAggregator(result);
                         }


### PR DESCRIPTION
### 💡 What:
The optimization replaces a repeated linear search (`FirstOrDefault`) within a triple-nested loop in `GLD.SerializerBenchmark/Report.cs` with a dictionary-based lookup using a composite key.

### 🎯 Why:
The previous implementation performed an $O(N)$ search on `aggregatedResults` for every combination of test data, serializer, and mode (string/Stream). This led to redundant scanning of the same data, with an overall complexity of $O(D \cdot S \cdot M \cdot N)$. By using a dictionary, the lookup time is reduced to constant time $O(1)$.

### 📊 Measured Improvement:
While environmental limitations (timeouts during build) prevented running the full benchmark to obtain concrete timing data, the theoretical algorithmic improvement is significant:
- **Baseline Complexity:** $O(D \cdot S \cdot M \cdot N)$
- **Optimized Complexity:** $O(N + D \cdot S \cdot M)$
For a benchmark with 38 serializers, 7 test data types, and 2 modes, this eliminates up to 532 redundant scans of the results list per report generation.

---
*PR created automatically by Jules for task [1505009957254407683](https://jules.google.com/task/1505009957254407683) started by @leo-gan*