### PR TITLE
Improve msgspec benchmarks

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,13 +1,13 @@
 # Python Serializer Benchmark
 
-A Dockerized benchmarking suite evaluating **9 Python serializers** across 7 realistic data structures, designed to match the methodology and output format of the companion [.NET (C#) benchmark](../c-sharp/).
+A Dockerized benchmarking suite evaluating **10 Python serializers** across 7 realistic data structures, designed to match the methodology and output format of the companion [.NET (C#) benchmark](../c-sharp/).
 
 ## Serializer Groups
 
 | Group | Serializers | Notes |
 | :--- | :--- | :--- |
 | **JSON** | `orjson`, `msgspec`, `rapidjson` | Text-based, schema-optional. |
-| **Binary** | `msgpack`, `cbor2` | Compact binary, schema-optional. |
+| **Binary** | `msgpack`, `msgspec-msgpack`, `cbor2` | Compact binary, schema-optional. |
 | **Schema** | `protobuf`, `avro` | Requires `.proto`/`.avsc` schemas and code generation. |
 | **Python-native** | `pickle`, `cloudpickle` | Built-in serialization, handles arbitrary objects. |
 

--- a/python/docs/serializers.md
+++ b/python/docs/serializers.md
@@ -93,7 +93,10 @@ JSON (JavaScript Object Notation) serializers convert Python objects to human-re
 
 **Benchmark Notes:**
 - Excellent memory efficiency (lowest memory usage among JSON serializers ~5KB vs 28KB for orjson)
-- Native dataclass support eliminates conversion overhead
+- Uses msgspec `Struct` models generated from the canonical dataclasses with `array_like=True`
+- Converts the shared dataclass fixtures to `Struct` instances before timed repetitions
+- Uses reusable `Encoder` and pre-built typed `Decoder` instances per benchmark data type
+- Stream mode uses `encode_into` with a reusable `bytearray` buffer
 - Slightly slower than orjson but significantly faster than standard library
 - Excludes `ObjectGraph` by design
 - Strong type validation prevents runtime errors
@@ -165,6 +168,40 @@ Binary serializers convert Python objects to compact byte representations. They 
 - High-throughput data pipelines
 - Caching layers (Redis with binary values)
 - Mobile apps where bandwidth matters
+
+---
+
+### msgspec-msgpack
+**Library:** `msgspec`
+**Type:** MessagePack encoder/decoder with schema validation
+**Description:** The MessagePack side of msgspec's API. It uses the same generated array-like `Struct` models, reusable encoder, and pre-built typed decoders as the JSON msgspec benchmark while producing compact binary MessagePack payloads.
+
+**Key Features:**
+- Uses msgspec `Struct` models generated from the canonical dataclasses with `array_like=True`
+- Reusable `msgspec.msgpack.Encoder` and typed `Decoder` instances
+- Converts shared dataclass fixtures to `Struct` instances before timed repetitions
+- Smaller binary payloads than JSON for object-heavy data
+
+**When to Use:**
+- Internal APIs where both sides can share schema/model definitions
+- High-throughput Python services that need validation and compact binary payloads
+- Workloads where JSON readability is not required
+
+**Pros:**
+- **Speed:** Avoids custom Python conversion hooks in the timed path
+- **Type safety:** Decodes directly into typed msgspec Struct objects
+- **Compact output:** Uses MessagePack rather than text JSON
+- **Memory efficiency:** Reuses encoder/decoder objects and stream buffers
+
+**Cons:**
+- **Not human-readable:** Harder to inspect than JSON
+- **Schema-oriented:** Best results require shared model definitions
+- **No circular reference support:** MessagePack cannot represent object identity cycles
+
+**Benchmark Notes:**
+- Registered separately from `msgspec` JSON as `msgspec-msgpack`
+- Uses typed decoder pre-compilation and Struct fixture preparation outside timed repetitions
+- Excludes `ObjectGraph` by design
 
 ---
 
@@ -554,6 +591,7 @@ Same security concerns as pickle - can execute arbitrary code. Only use with tru
 | orjson | JSON | ★★★★★ | ★★★☆☆ | No | No | Yes |
 | msgspec | JSON | ★★★★☆ | ★★★☆☆ | No | Optional | Yes |
 | rapidjson | JSON | ★★★☆☆ | ★★★☆☆ | No | No | Yes |
+| msgspec-msgpack | Binary | ★★★★★ | ★★★★☆ | No | Optional | Yes |
 | msgpack | Binary | ★★★★☆ | ★★★★☆ | No | No | Yes |
 | cbor2 | Binary | ★★★☆☆ | ★★★★★ | No | No | Yes |
 | protobuf | Schema | ★★★☆☆ | ★★★★★ | No | Yes | Yes |

--- a/python/src/benchmark/runner.py
+++ b/python/src/benchmark/runner.py
@@ -42,6 +42,7 @@ from .serializers import (
     AvroSerializer,
     Cbor2Serializer,
     CloudpickleSerializer,
+    MsgspecMessagePackSerializer,
     MsgpackSerializer,
     MsgspecSerializer,
     OrjsonSerializer,
@@ -59,6 +60,7 @@ ALL_SERIALIZERS: List[Serializer] = [
     OrjsonSerializer(),
     MsgspecSerializer(),
     RapidjsonSerializer(),
+    MsgspecMessagePackSerializer(),
     MsgpackSerializer(),
     Cbor2Serializer(),
     ProtobufSerializer(),
@@ -148,22 +150,25 @@ def _test_on_data(
         if not serializer.supports(td_name):
             continue
 
-        # Set type hint for schema-based serializers that need it during deserialization
+        # Set type hint and let serializers pre-build per-type codecs/schemas outside timing.
         setattr(serializer, "_last_type", td_cls)
+        serializer.prepare(td_name, td_cls)
+        serializer_original = serializer.prepare_data(original, td_name, td_cls)
 
         print(f"[DEBUG] Starting {serializer.name} (bytes)")
         _run_repetitions(
-            serializer, original, td_name, td_cls, repetitions, "bytes", storage, errors
+            serializer, serializer_original, original, td_name, td_cls, repetitions, "bytes", storage, errors
         )
         print(f"[DEBUG] Starting {serializer.name} (stream)")
         _run_repetitions(
-            serializer, original, td_name, td_cls, repetitions, "stream", storage, errors
+            serializer, serializer_original, original, td_name, td_cls, repetitions, "stream", storage, errors
         )
 
 
 def _run_repetitions(
     serializer: Serializer,
-    original: Any,
+    serializable: Any,
+    expected: Any,
     td_name: str,
     td_cls: type,
     repetitions: int,
@@ -184,7 +189,7 @@ def _run_repetitions(
         )
 
         try:
-            _single_test(serializer, original, mode, log, td_cls)
+            _single_test(serializer, serializable, expected, mode, log, td_cls)
         except Exception as exc:
             if not was_error:
                 err = BenchmarkError(
@@ -204,7 +209,8 @@ def _run_repetitions(
 
 def _single_test(
     serializer: Serializer,
-    original: Any,
+    serializable: Any,
+    expected: Any,
     mode: str,
     log: BenchmarkLog,
     td_cls: type,
@@ -215,7 +221,7 @@ def _single_test(
     if mode == "bytes":
         # Serialize
         t0 = time.perf_counter_ns()
-        data = serializer.serialize_bytes(original)
+        data = serializer.serialize_bytes(serializable)
         t1 = time.perf_counter_ns()
         log.time_ser_ns = t1 - t0
         log.size_bytes = len(data)
@@ -230,7 +236,7 @@ def _single_test(
 
         # Serialize
         t0 = time.perf_counter_ns()
-        serializer.serialize_stream(original, stream)
+        serializer.serialize_stream(serializable, stream)
         t1 = time.perf_counter_ns()
         log.time_ser_ns = t1 - t0
         log.size_bytes = stream.tell()
@@ -246,7 +252,7 @@ def _single_test(
     log.memory_peak_bytes = peak
 
     # Semantic comparison
-    ok, err_text = compare(original, processed)
+    ok, err_text = compare(expected, processed)
     log.fidelity_score = 1.0 if ok else 0.0
     if not ok:
         raise RuntimeError(f"Roundtrip mismatch: {err_text}")

--- a/python/src/benchmark/serializers/__init__.py
+++ b/python/src/benchmark/serializers/__init__.py
@@ -1,6 +1,6 @@
 from .base import Serializer
 from .json_orjson import OrjsonSerializer
-from .json_msgspec import MsgspecSerializer
+from .json_msgspec import MsgspecMessagePackSerializer, MsgspecSerializer
 from .json_rapidjson import RapidjsonSerializer
 from .binary_msgpack import MsgpackSerializer
 from .binary_cbor2 import Cbor2Serializer
@@ -13,6 +13,7 @@ __all__ = [
     "Serializer",
     "OrjsonSerializer",
     "MsgspecSerializer",
+    "MsgspecMessagePackSerializer",
     "RapidjsonSerializer",
     "MsgpackSerializer",
     "Cbor2Serializer",

--- a/python/src/benchmark/serializers/base.py
+++ b/python/src/benchmark/serializers/base.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import io
 from abc import ABC, abstractmethod
-from typing import Any, Optional
+from typing import Any
 
 
 class Serializer(ABC):
@@ -27,6 +27,24 @@ class Serializer(ABC):
         Default is True (optimistic).
         """
         return True
+
+    def prepare(self, test_data_name: str, test_data_type: type) -> None:
+        """
+        Prepare reusable serializer state for one benchmark data type.
+
+        Implementations can use this to pre-build schemas/codecs outside the
+        timed loop. The default is a no-op.
+        """
+        return None
+
+    def prepare_data(self, obj: Any, test_data_name: str, test_data_type: type) -> Any:
+        """
+        Convert the shared benchmark fixture into a serializer-native object.
+
+        The default is identity. Serializers with their own recommended model
+        types can override this to avoid measuring conversion inside the timed loop.
+        """
+        return obj
 
     @abstractmethod
     def serialize_bytes(self, obj: Any) -> bytes:

--- a/python/src/benchmark/serializers/json_msgspec.py
+++ b/python/src/benchmark/serializers/json_msgspec.py
@@ -1,39 +1,218 @@
 """
-msgspec benchmark wrapper.
+msgspec benchmark wrappers.
 
-msgspec natively supports dataclasses, enums, and datetime objects
-since v0.18, making it one of the most "Python-native" JSON serializers.
+The shared benchmark fixtures are stdlib dataclasses. For the msgspec entries we
+convert those fixtures to array-like msgspec.Struct models before timing,
+matching the documented high-performance usage pattern instead of measuring
+dataclass support.
+
+The dataclass-to-Struct conversion is intentionally outside the timed loop. This
+models an application written with msgspec's recommended Struct types, while
+still letting the shared benchmark generator own the canonical input data.
+Struct types are generated from the canonical dataclasses in benchmark.data.models
+with msgspec.defstruct to keep the benchmark schema in sync with the shared models.
+Using array-like Structs also matches schema-oriented serializers in this suite
+that rely on field order/IDs rather than repeating field names in each payload.
+For example, protobuf writes numbered field tags and the Avro wrapper uses
+schemaless encoding with a shared schema.
 """
 
 from __future__ import annotations
 
 import io
-from typing import Any
+from dataclasses import fields, is_dataclass
+from types import UnionType
+from typing import Any, Union, get_args, get_origin, get_type_hints
 
 import msgspec
 
 from .base import Serializer
+from ..data import models
 
 
-class MsgspecSerializer(Serializer):
+_UNSUPPORTED_STRUCT_TYPES: set[type[Any]] = {models.GraphNode}
+_STRUCT_TYPES: dict[type[Any], type[msgspec.Struct]] = {}
+
+
+def _model_dataclasses() -> set[type[Any]]:
+    return {
+        value
+        for value in vars(models).values()
+        if isinstance(value, type)
+        and is_dataclass(value)
+        and value.__module__ == models.__name__
+        and value not in _UNSUPPORTED_STRUCT_TYPES
+    }
+
+
+def _dataclass_dependencies(typ: Any, candidates: set[type[Any]]) -> set[type[Any]]:
+    if typ in candidates:
+        return {typ}
+
+    deps: set[type[Any]] = set()
+    for arg in get_args(typ):
+        deps.update(_dataclass_dependencies(arg, candidates))
+    return deps
+
+
+def _ordered_model_dataclasses(candidates: set[type[Any]]) -> list[type[Any]]:
+    ordered: list[type[Any]] = []
+    visiting: set[type[Any]] = set()
+    visited: set[type[Any]] = set()
+
+    def visit(cls: type[Any]) -> None:
+        if cls in visited:
+            return
+        if cls in visiting:
+            raise TypeError(f"Recursive dataclass model is not supported for msgspec Struct generation: {cls!r}")
+
+        visiting.add(cls)
+        hints = get_type_hints(cls)
+        for field in fields(cls):
+            for dependency in _dataclass_dependencies(hints[field.name], candidates):
+                if dependency is not cls:
+                    visit(dependency)
+        visiting.remove(cls)
+        visited.add(cls)
+        ordered.append(cls)
+
+    for cls in sorted(candidates, key=lambda c: c.__name__):
+        visit(cls)
+
+    return ordered
+
+
+def _translate_type(typ: Any) -> Any:
+    """Translate dataclass annotations to their generated Struct equivalents."""
+    if typ in _STRUCT_TYPES:
+        return _STRUCT_TYPES[typ]
+
+    origin = get_origin(typ)
+    args = get_args(typ)
+
+    if origin is list:
+        return list[_translate_type(args[0])]
+
+    if origin in (Union, UnionType):
+        return Union[tuple(_translate_type(arg) for arg in args)]
+
+    if is_dataclass(typ):
+        raise TypeError(
+            f"No generated msgspec Struct for dataclass type {typ!r}; "
+            "ensure it is defined in benchmark.data.models and not excluded"
+        )
+
+    return typ
+
+
+def _build_struct_types() -> None:
+    for cls in _ordered_model_dataclasses(_model_dataclasses()):
+        hints = get_type_hints(cls)
+        struct_fields = [
+            (field.name, _translate_type(hints[field.name]))
+            for field in fields(cls)
+        ]
+        _STRUCT_TYPES[cls] = msgspec.defstruct(
+            f"Msgspec{cls.__name__}",
+            struct_fields,
+            module=__name__,
+            array_like=True,
+        )
+
+
+_build_struct_types()
+
+
+class _MsgspecStructSerializer(Serializer):
+    codec_name = "msgspec"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._encoder = self._make_encoder()
+        self._decoders: dict[Any, Any] = {}
+        self._decoder = self._decoder_for(Any)
+        self._buffer = bytearray()
+
     @property
     def name(self) -> str:
-        return "msgspec"
+        return self.codec_name
 
     def supports(self, test_data_name: str) -> bool:
-        # msgspec does not support circular references in JSON mode
         return test_data_name != "ObjectGraph"
 
+    def prepare(self, test_data_name: str, test_data_type: type) -> None:
+        self._decoder = self._decoder_for(_msgspec_type_for(test_data_type))
+        self._buffer = bytearray()
+
+    def prepare_data(self, obj: Any, test_data_name: str, test_data_type: type) -> Any:
+        return _to_msgspec_struct(obj)
+
     def serialize_bytes(self, obj: Any) -> bytes:
-        return msgspec.json.encode(obj)
+        return self._encoder.encode(obj)
 
     def deserialize_bytes(self, data: bytes) -> Any:
-        return msgspec.json.decode(data)
+        return self._decoder.decode(data)
 
     def serialize_stream(self, obj: Any, stream: io.BytesIO) -> None:
-        # msgspec has no native stream API; write bytes to BytesIO
-        stream.write(self.serialize_bytes(obj))
+        self._encoder.encode_into(obj, self._buffer)
+        stream.write(self._buffer)
 
     def deserialize_stream(self, stream: io.BytesIO) -> Any:
-        stream.seek(0)
-        return self.deserialize_bytes(stream.read())
+        view = stream.getbuffer()
+        try:
+            return self._decoder.decode(view)
+        finally:
+            view.release()
+
+    def _make_encoder(self) -> Any:
+        raise NotImplementedError
+
+    def _make_decoder(self, typ: Any) -> Any:
+        raise NotImplementedError
+
+    def _decoder_for(self, typ: Any) -> Any:
+        decoder = self._decoders.get(typ)
+        if decoder is None:
+            decoder = self._make_decoder(typ)
+            self._decoders[typ] = decoder
+        return decoder
+
+
+class MsgspecSerializer(_MsgspecStructSerializer):
+    codec_name = "msgspec"
+
+    def _make_encoder(self) -> msgspec.json.Encoder:
+        return msgspec.json.Encoder()
+
+    def _make_decoder(self, typ: Any) -> msgspec.json.Decoder:
+        return msgspec.json.Decoder(type=typ)
+
+
+class MsgspecMessagePackSerializer(_MsgspecStructSerializer):
+    codec_name = "msgspec-msgpack"
+
+    def _make_encoder(self) -> msgspec.msgpack.Encoder:
+        return msgspec.msgpack.Encoder()
+
+    def _make_decoder(self, typ: Any) -> msgspec.msgpack.Decoder:
+        return msgspec.msgpack.Decoder(type=typ)
+
+
+def _msgspec_type_for(typ: type) -> Any:
+    return _STRUCT_TYPES.get(typ, typ)
+
+
+def _to_msgspec_struct(obj: Any) -> Any:
+    if isinstance(obj, list):
+        return [_to_msgspec_struct(item) for item in obj]
+
+    if is_dataclass(obj) and not isinstance(obj, type):
+        typ = _msgspec_type_for(type(obj))
+        if typ is type(obj):
+            raise TypeError(f"Unsupported type for msgspec Struct conversion: {type(obj)}")
+        return typ(*(
+            _to_msgspec_struct(getattr(obj, field.name))
+            for field in fields(obj)
+        ))
+
+    return obj

--- a/python/src/benchmark/serializers/json_msgspec.py
+++ b/python/src/benchmark/serializers/json_msgspec.py
@@ -155,12 +155,20 @@ class _MsgspecStructSerializer(Serializer):
 
     def serialize_stream(self, obj: Any, stream: io.BytesIO) -> None:
         self._encoder.encode_into(obj, self._buffer)
-        stream.write(self._buffer)
+        view = memoryview(self._buffer)
+        try:
+            stream.write(view)
+        finally:
+            view.release()
 
     def deserialize_stream(self, stream: io.BytesIO) -> Any:
         view = stream.getbuffer()
         try:
-            return self._decoder.decode(view)
+            data = view[:stream.tell()]
+            try:
+                return self._decoder.decode(data)
+            finally:
+                data.release()
         finally:
             view.release()
 


### PR DESCRIPTION
## Summary

This updates the Python `msgspec` benchmark to use the API patterns recommended for high-performance msgspec applications, and adds a separate native MessagePack benchmark using `msgspec.msgpack`.

The existing `msgspec` benchmark encoded the shared stdlib dataclass fixtures directly. While msgspec supports dataclasses, its documented and most efficient modeling API is `msgspec.Struct`. This PR changes the benchmark to convert the canonical dataclass fixtures to generated `Struct` models before timed repetitions, then measures serialization/deserialization of those `Struct` instances.

## Changes

- Generate msgspec `Struct` types dynamically from the canonical dataclasses in `benchmark.data.models`.
- Use `array_like=True` for the generated Structs.
- Pre-build and reuse `msgspec.json.Encoder` / typed `msgspec.json.Decoder` instances per benchmark data type.
- Use `encode_into` with a reusable `bytearray` for stream serialization.
- Add a new `msgspec-msgpack` serializer using `msgspec.msgpack.Encoder` / typed `msgspec.msgpack.Decoder`.
- Add serializer lifecycle hooks so serializers can prepare schemas/codecs and serializer-native fixture objects outside the timed loop.
- Keep correctness comparison against the original canonical dataclass fixture, rather than the serializer-native prepared object.
- Update Python serializer docs and summary counts to include `msgspec-msgpack`.

## Why

The goal is to benchmark idiomatic, high-performance msgspec usage rather than compatibility-path dataclass handling.

Moving fixture conversion outside the timed loop models an application that already uses msgspec `Struct` types in its data model. The timed region still measures the important runtime costs: encoding, decoding, payload size, allocation, and semantic roundtrip correctness.

Generating Structs from the existing dataclasses avoids maintaining parallel hand-written msgspec models, which would be easy to let drift from the canonical benchmark fixtures.

## About `array_like=True`

`array_like=True` encodes Struct instances as positional arrays instead of maps keyed by field name. This reduces payload size and avoids repeatedly writing field names for every object.

This is not intended to artificially boost msgspec at the expense of idiomatic usage. It is a documented msgspec option for schema-oriented workloads where both sides share the model definition. That matches other schema-based serializers already in the suite:

- protobuf encodes numbered field tags rather than full field names.
- Avro uses a shared schema for schemaless binary encoding.

For a benchmark suite that includes schema-aware formats, array-like Structs are a fair representation of msgspec's compact schema-oriented mode.

## Limitations

`ObjectGraph` remains unsupported for msgspec and `msgspec-msgpack`. The fixture contains circular references/object identity cycles, which JSON and MessagePack formats do not represent.

## Benchmark Results

I compared this branch against the previous implementation using:

```powershell
python -m benchmark.runner 100 msgspec
```

The first repetition was excluded as warmup, matching the benchmark runner's reporting logic.

Overall:

- Current `msgspec` JSON: `1.11x` geomean faster for serialize+deserialize, average payload size `0.74x` of the previous implementation.
- New `msgspec-msgpack`: `1.24x` geomean faster than the previous JSON baseline, average payload size `0.53x` of the previous implementation.

| Data / mode | Old msgspec ops/s | Current JSON ops/s | JSON speedup | JSON size | msgspec-msgpack ops/s | msgpack speedup | msgpack size |
|---|---:|---:|---:|---:|---:|---:|---:|
| EDI_835 bytes | 23,102 | 29,109 | 1.26x | 591 vs 1,730 | 34,055 | 1.47x | 644 |
| EDI_835 stream | 20,893 | 25,701 | 1.23x | 591 vs 1,730 | 31,008 | 1.48x | 644 |
| Integer bytes | 385,899 | 410,281 | 1.06x | 10 vs 10 | 399,707 | 1.04x | 5 |
| Integer stream | 220,591 | 206,503 | 0.94x | 10 vs 10 | 203,534 | 0.92x | 5 |
| Person bytes | 37,319 | 37,909 | 1.02x | 466 vs 917 | 42,494 | 1.14x | 363 |
| Person stream | 32,325 | 32,735 | 1.01x | 466 vs 917 | 34,379 | 1.06x | 363 |
| SimpleObject bytes | 156,629 | 212,551 | 1.36x | 67 vs 102 | 234,831 | 1.50x | 56 |
| SimpleObject stream | 129,110 | 147,000 | 1.14x | 67 vs 102 | 124,659 | 0.97x | 56 |
| StringArray bytes | 21,090 | 21,205 | 1.01x | 1,893 vs 1,901 | 22,454 | 1.06x | 1,694 |
| StringArray stream | 19,459 | 19,041 | 0.98x | 1,893 vs 1,901 | 19,929 | 1.02x | 1,694 |
| Telemetry bytes | 33,807 | 40,416 | 1.20x | 2,070 vs 2,185 | 59,339 | 1.76x | 1,024 |
| Telemetry stream | 33,698 | 40,845 | 1.21x | 2,070 vs 2,185 | 61,395 | 1.82x | 1,024 |

## Validation

Ran:

```powershell
uv run --no-sync python -m compileall src
uv run --no-sync python -m benchmark.runner 5 msgspec
uv run --no-sync python -m benchmark.runner 1
uv run --no-sync python -m benchmark.runner 100 msgspec
git diff --check
```

## Disclaimer

I coaxed Codex 5.5 xhigh into achieving what I wanted throughout the day when I had some downtime.