### PR TITLE
docs(theory): student-friendly prose rewrite for Serialization 101–401

### DIFF
--- a/docs/theory/101/data_science_perspective.md
+++ b/docs/theory/101/data_science_perspective.md
@@ -3,180 +3,181 @@
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/leo-gan/GLD.SerializerBenchmark/blob/master/docs/theory/notebooks/101/data_science_perspective.ipynb)
 **Lab notebook:** [Data science lab](../notebooks/101/data_science_perspective.ipynb)
 
+## Who this page is for
 
-## Audience
+This lens is written for people who move **tables, events, features, and models**—not only single API messages:
 
-- Analysts and analytics engineers moving data between warehouses, lakes, and notebooks  
-- ML engineers checkpointing models, features, and batch scores  
-- Data platform folks choosing formats for [Kafka](https://en.wikipedia.org/wiki/Apache_Kafka "Apache Kafka — distributed event streaming platform")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> topics, [S3](https://en.wikipedia.org/wiki/Amazon_S3 "Amazon S3 — object storage service")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> layouts, and interchange with [Spark](https://en.wikipedia.org/wiki/Apache_Spark "Apache Spark — unified analytics engine")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />/[DuckDB](https://en.wikipedia.org/wiki/DuckDB "DuckDB — in-process analytical SQL database")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />/Polars  
+- Analysts and analytics engineers who move data between warehouses, lakes, and notebooks  
+- Machine-learning engineers who checkpoint models, features, and batch scores  
+- Data platform engineers who choose formats for [Kafka](https://en.wikipedia.org/wiki/Apache_Kafka "Apache Kafka — distributed event streaming platform")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> topics, [S3](https://en.wikipedia.org/wiki/Amazon_S3 "Amazon S3 — object storage service")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> layouts, and interchange with [Spark](https://en.wikipedia.org/wiki/Apache_Spark "Apache Spark — unified analytics engine")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />, [DuckDB](https://en.wikipedia.org/wiki/DuckDB "DuckDB — in-process analytical SQL database")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />, or Polars  
 - Scientists who currently “just pickle everything” and want a safer mental model  
 
 ---
 
-## In data work
+## How data work differs from service work
 
-In services, [serialization](https://en.wikipedia.org/wiki/Serialization "Serialization — converting structures to a byte sequence and back")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> often means **one message in, one message out**. In data work it usually means one or more of:
+In services, [serialization](https://en.wikipedia.org/wiki/Serialization "Serialization — converting structures to a byte sequence and back")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> often means **one message in, one message out**. In data work it usually means one or more of the following:
 
-| Workload | Typical unit | What you optimize for |
-|----------|--------------|------------------------|
-| **Batch tables** | Partitions of rows/columns on object storage | Scan cost, compression, schema evolution over years |
-| **Streaming events** | Records on a log (Kafka, etc.) | Compatibility between old/new producers & consumers |
-| **Notebook ↔ production** | [DataFrames](https://en.wikipedia.org/wiki/pandas_%28software%29 "pandas — tabular data library commonly used via DataFrames")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />, dicts, artifacts | Friction vs portability and safety |
-| **Model artifacts** | Weights + preprocessing graph | Load speed, versioning, who may load the file |
-| **Feature interchange** | Training/serving feature payloads | Stable types, low skew, predictable nulls |
+| Workload | Typical unit | What you usually optimize for |
+|----------|--------------|-------------------------------|
+| **Batch tables** | Partitions of rows or columns on object storage | Scan cost, compression, schema evolution over years |
+| **Streaming events** | Records on a log (Kafka and similar) | Compatibility between old and new producers and consumers |
+| **Notebook ↔ production** | [DataFrames](https://en.wikipedia.org/wiki/pandas_%28software%29 "pandas — tabular data library commonly used via DataFrames")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />, dictionaries, artifacts | Friction versus portability and safety |
+| **Model artifacts** | Weights plus preprocessing graph | Load speed, versioning, who is allowed to load the file |
+| **Feature interchange** | Training and serving feature payloads | Stable types, low training/serving skew, predictable nulls |
 
-Different workloads want different points on the [core trade-off axes](index.md#core-trade-offs) (text/binary, schema, row/columnar, portable/native).
+Different workloads want different points on the [core trade-off axes](index.md#core-trade-offs): text versus binary, schema versus schemaless, row versus columnar, portable versus language-native.
 
 ---
 
-## Brief history
+## A short history of formats in data work
 
-1. **Fixed-width & [CSV](https://en.wikipedia.org/wiki/Comma-separated_values "CSV — Comma-Separated Values")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />** — still everywhere for exports and simple tables; weak typing; awkward nesting.  
-2. **Language-native blobs (`pickle`, joblib, many ML checkpoints)** — maximum Python convenience; poor multi-language story; **unsafe on untrusted bytes**. See [pickle](https://en.wikipedia.org/wiki/Serialization#Python "pickle — Python object serialization")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> under language-native formats.  
-3. **JSON lines / JSON documents** — universal glue; fine for small/medium configs and APIs; painful as a primary lake format at huge scale.  
-4. **[Avro](https://en.wikipedia.org/wiki/Apache_Avro "Apache Avro — row-oriented binary with schemas")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> (+ schema registry patterns)** — row-oriented binary with a serious **evolution** story for event streams.  
+1. **Fixed-width layouts and [CSV](https://en.wikipedia.org/wiki/Comma-separated_values "CSV — Comma-Separated Values")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />** — still everywhere for exports and simple tables; weak typing; awkward nesting.  
+2. **Language-native blobs (`pickle`, joblib, many machine-learning checkpoints)** — maximum Python convenience; poor multi-language story; **unsafe on untrusted bytes**. See [pickle](https://en.wikipedia.org/wiki/Serialization#Python "pickle — Python object serialization")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> under language-native formats.  
+3. **JSON documents and JSON Lines** — universal glue; fine for small or medium configs and APIs; painful as a primary lake format at huge scale.  
+4. **[Avro](https://en.wikipedia.org/wiki/Apache_Avro "Apache Avro — row-oriented binary with schemas")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> (plus schema registry patterns)** — row-oriented binary with a serious **evolution** story for event streams.  
 5. **[Parquet](https://en.wikipedia.org/wiki/Apache_Parquet "Apache Parquet — columnar storage format")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> / [ORC](https://en.wikipedia.org/wiki/Apache_ORC "Apache ORC — Optimized Row Columnar")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />** — **columnar** on-disk formats for analytic scans.  
-6. **[Arrow](https://en.wikipedia.org/wiki/Apache_Arrow "Apache Arrow — in-memory columnar format")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />** — shared **in-memory** columnar layout so engines exchange tables without endless convert/copy.  
-7. **Validators ([JSON Schema](https://en.wikipedia.org/wiki/JSON#Schema_and_metadata "JSON Schema — vocabulary for validating JSON")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />, Pydantic, msgspec, …)** — structure and types when the wire format stays JSON or [MessagePack](https://en.wikipedia.org/wiki/MessagePack "MessagePack — binary serialization of JSON-like values")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />.
+6. **[Arrow](https://en.wikipedia.org/wiki/Apache_Arrow "Apache Arrow — in-memory columnar format")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />** — shared **in-memory** columnar layout so engines exchange tables without endless convert-and-copy cycles.  
+7. **Validators ([JSON Schema](https://en.wikipedia.org/wiki/JSON#Schema_and_metadata "JSON Schema — vocabulary for validating JSON")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />, Pydantic, msgspec, and similar)** — structure and types when the wire format stays JSON or [MessagePack](https://en.wikipedia.org/wiki/MessagePack "MessagePack — binary serialization of JSON-like values")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />.
 
 ---
 
-## Common formats
+## Common formats in plain language
 
 ### CSV
 
-**Use when:** humans edit data; quick export/import; smallest common denominator.
+**Use it when** humans edit data, you need a quick export or import, or you need the smallest common denominator between tools.
 
-**Avoid as system of record when:** types matter (dates, nulls vs empty strings), nesting appears, or multiple producers change columns silently.
+**Avoid it as the system of record when** types matter (dates, nulls versus empty strings), nesting appears, or multiple producers change columns silently.
 
-CSV is not “wrong”—it is a **lossy social format**. Treat it as an edge adapter, not a lake core.
+CSV is not “wrong.” It is a **lossy social format**. Treat it as an edge adapter, not as the core of a data lake.
 
-### JSON / JSONL
+### JSON and JSON Lines
 
-**Use when:** semi-structured logs, configs, small-to-medium interchange, landing zones before a typed table format.
+**Use them when** you need semi-structured logs, configuration, small-to-medium interchange, or a landing zone before a typed table format.
 
-**Costs:** repeated keys; number/date ambiguity; large files compress well but still parse slower than columnar binary for analytics.
+**Costs include** repeated keys on every object, ambiguity around numbers and dates, and parse cost that stays higher than mature columnar binary formats for large analytics—even when compression shrinks the file.
 
-**JSONL** (one JSON object per line) is a pragmatic streaming/batch compromise: append-friendly, parallelizable by line, still text.
+**JSON Lines** (one JSON object per line, often abbreviated JSONL) is a pragmatic compromise for streaming and batch: append-friendly, parallelizable by line, still text.
 
-### Pickle & friends
+### Pickle and friends
 
-**Trust boundary check (do this every time):**
+**Trust boundary check—do this every time:**
 
 - Is the byte stream from a fully trusted source you control?
-  - **No** → do not unpickle / do not use native deserialize
-  - **Yes** → still prefer portable formats for anything long-lived or multi-language
+  - **No** → do not unpickle and do not use other native “deserialize anything” APIs.
+  - **Yes** → still prefer portable formats for anything long-lived or multi-language.
 
 | Approach | Strength | Risk |
 |----------|----------|------|
 | `pickle` / `cloudpickle` | Almost any Python object graph | Code execution on load; Python-only |
-| `joblib` | Convenient for [scikit-learn](https://en.wikipedia.org/wiki/Scikit-learn "scikit-learn — Python ML library")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />-style arrays/pipelines | Same trust issues when backed by pickle-like protocols |
-| Framework checkpoints (often pickle-based) | One-command save/load in that stack | Environment coupling; supply-chain & tampering risk |
+| `joblib` | Convenient for [scikit-learn](https://en.wikipedia.org/wiki/Scikit-learn "scikit-learn — Python ML library")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />-style arrays and pipelines | Same trust issues when backed by pickle-like protocols |
+| Framework checkpoints (often pickle-based) | One-command save and load inside that stack | Environment coupling; supply-chain and tampering risk |
 
-**Practical rule:** use native formats for **ephemeral, trusted, same-environment** artifacts. For sharing, audit, or multi-year storage, prefer **explicit weights formats** (framework-specific safe loaders), **Arrow/Parquet tables**, or **versioned model registries**—not a raw pickle in an open bucket.
+**Practical rule:** use native formats for **ephemeral, trusted, same-environment** artifacts. For sharing, audit, or multi-year storage, prefer **explicit weight formats** (framework-specific safe loaders), **Arrow or Parquet tables**, or **versioned model registries**—not a raw pickle file in an open bucket.
 
 ### Avro
 
-**Avro** stores values compactly and treats the **schema as a first-class object** (in file headers or an external registry). Reader and writer schemas can differ under documented compatibility rules (defaults, field addition/removal policies).
+**Avro** stores values compactly and treats the **schema as a first-class object** (in file headers or an external registry). Reader and writer schemas can differ under documented compatibility rules (defaults, field addition and removal policies).
 
-**Prefer when:**
+**Prefer Avro when:**
 
 - Producers and consumers change on different schedules  
 - You need a long-lived event log with compatibility checks  
 - Row-oriented access (full events) matters more than wide analytic scans  
 
-**Operational reality:** schema **process** (registry, CI checks, compatibility mode) matters as much as the binary encoding.
+**Operational reality:** the schema **process** (registry, continuous-integration checks, compatibility mode) matters as much as the binary encoding itself.
 
-### Parquet & ORC
+### Parquet and ORC
 
-**Columnar** layout stores each column’s values together, enabling:
+**Columnar** layout stores each column’s values together. That enables:
 
 - Reading only the columns a query needs  
-- Better compression (similar values co-located)  
-- Predicate pushdown / page skipping in mature engines  
+- Better compression, because similar values sit next to each other  
+- Predicate pushdown and page skipping in mature engines  
 
-**Prefer when:** data lakes, warehouse extracts, Spark/DuckDB/Polars/[Athena](https://en.wikipedia.org/wiki/Amazon_Athena "Amazon Athena — serverless SQL over data lakes")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />-style scans, wide tables, read-heavy analytics.
+**Prefer these when** you run data lakes, warehouse extracts, Spark/DuckDB/Polars/[Athena](https://en.wikipedia.org/wiki/Amazon_Athena "Amazon Athena — serverless SQL over data lakes")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />-style scans, wide tables, or read-heavy analytics.
 
-**Avoid when:** you mostly fetch one nested document by key at low latency—that is still a **row/document** problem (or a specialized store), not Parquet’s sweet spot.
+**Avoid them when** you mostly fetch one nested document by key at low latency. That is still a **row or document** problem (or a specialized store), not Parquet’s sweet spot.
 
 ### Arrow
 
-**Arrow** (project co-founded with **[Wes McKinney](https://en.wikipedia.org/wiki/Wes_McKinney "Wes McKinney — creator of pandas; co-founder of Apache Arrow")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />** and others) standardizes **in-memory** columnar buffers (types, null bitmaps, nested layouts). When two tools speak Arrow, transfer can be a pointer handoff or a cheap [IPC](https://en.wikipedia.org/wiki/Inter-process_communication "IPC — Inter-process communication")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> stream instead of “to_csv → parse again.”
+**Arrow** (the project was co-founded with **[Wes McKinney](https://en.wikipedia.org/wiki/Wes_McKinney "Wes McKinney — creator of pandas; co-founder of Apache Arrow")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />** and others) standardizes **in-memory** columnar buffers: types, null bitmaps, nested layouts. When two tools speak Arrow, transfer can be a pointer handoff or a cheap [inter-process communication (IPC)](https://en.wikipedia.org/wiki/Inter-process_communication "IPC — Inter-process communication")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> stream instead of “write CSV, then parse again.”
 
-**Prefer when:**
+**Prefer Arrow when:**
 
-- Crossing process boundaries in a data plane (Python ↔ DuckDB ↔ Polars ↔ Spark components, etc.)  
-- Building zero-copy or low-copy pipelines  
+- You cross process boundaries in a data plane (Python ↔ DuckDB ↔ Polars ↔ Spark components, for example)  
+- You build zero-copy or low-copy pipelines  
 - You want one logical table type across languages  
 
-Arrow is complementary to Parquet: **Parquet on disk / in the lake**, **Arrow in memory / between engines** is a common modern pattern.
+Arrow is complementary to Parquet. A common modern pattern is **Parquet on disk in the lake**, **Arrow in memory between engines**. Arrow is not usually your only long-term archive format by itself.
 
-### MessagePack / BSON / CBOR
+### MessagePack, BSON, and CBOR
 
 These are **schemaless binary** encodings of JSON-like values:
 
-| Format | Data-relevant note |
+| Format | Note for data work |
 |--------|--------------------|
 | **MessagePack** | Compact caches, internal service payloads, some feature buses |
-| **BSON** | Document DB heritage ([MongoDB](https://en.wikipedia.org/wiki/MongoDB "MongoDB — document-oriented database")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />); extra types (datetime, binary) |
-| **CBOR** | Standards-track; constrained devices and some security/[IoT](https://en.wikipedia.org/wiki/Internet_of_things "IoT — Internet of Things")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> stacks |
+| **BSON** | Document database heritage ([MongoDB](https://en.wikipedia.org/wiki/MongoDB "MongoDB — document-oriented database")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />); extra types such as datetime and binary |
+| **CBOR** | Standards-track; strong story for constrained devices and some security/[IoT](https://en.wikipedia.org/wiki/Internet_of_things "IoT — Internet of Things")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> stacks |
 
-They help when JSON is too slow/large but you still want a **dynamic** model. They do **not** replace Parquet for lake analytics.
+They help when JSON is too slow or large but you still want a **dynamic** model. They do **not** replace Parquet for lake analytics.
 
-### Protobuf & Thrift
+### Protocol Buffers and Thrift
 
-Schema-driven RPC formats show up when ML **serving** or feature stores talk to microservices. They are excellent **online** contracts; they are usually a poor **sole** lake format compared with Parquet for bulk analytics. Many platforms use **both**: Protobuf online, columnar offline.
+Schema-driven remote-procedure-call formats show up when machine-learning **serving** or feature stores talk to microservices. They are excellent **online** contracts. They are usually a poor **sole** lake format compared with Parquet for bulk analytics. Many platforms use **both**: Protocol Buffers online, columnar formats offline.
 
 ---
 
-## Schema evolution
+## Schema evolution in data platforms
 
 “We added a field” is easy in a notebook and hard in a multi-year lake or event bus.
 
 | Strategy | Idea | Typical home |
 |----------|------|--------------|
-| **Positional fixed width** | Every field has a byte offset | Legacy finance/mainframe feeds |
-| **Writer schema + resolution** | Old/new schemas reconciled by rules | Avro + registry |
-| **Field numbers** | Stable tags; ignore unknown | Protobuf-style systems |
-| **Table schemas in the catalog** | Lakehouse table metadata + file footers | Parquet + Glue/Hive/Unity-style catalogs |
-| **“Only append columns, never reuse names”** | Social contract | JSONL / ad-hoc pipelines (fragile) |
+| **Positional fixed width** | Every field has a byte offset | Legacy finance and mainframe feeds |
+| **Writer schema plus resolution** | Old and new schemas reconciled by rules | Avro plus a registry |
+| **Field numbers** | Stable numeric tags; ignore unknown fields | Protocol Buffers-style systems |
+| **Table schemas in the catalog** | Lakehouse table metadata plus file footers | Parquet plus Glue/Hive/Unity-style catalogs |
+| **“Only append columns, never reuse names”** | A social contract | JSON Lines and ad-hoc pipelines (fragile) |
 
-**Data science takeaway:** pick a format whose **evolution story matches your retention**. Ephemeral experiment? JSONL is fine. Seven years of events? Invest in Avro/registry or an equivalent contract process. Analytic tables? Plan column adds carefully and document null/default semantics.
+**Takeaway for data science:** pick a format whose **evolution story matches your retention**. Ephemeral experiment? JSON Lines is often fine. Seven years of events? Invest in Avro plus a registry (or an equivalent contract process). Analytic tables? Plan column adds carefully and document null and default semantics.
 
 ---
 
-## ML guidance
+## Machine-learning guidance
 
-### Features & tables
+### Features and tables
 
-- Store large training/feature tables as **Parquet** (or equivalent columnar) with explicit dtypes and partitioned layout (time, region, etc.).  
+- Store large training and feature tables as **Parquet** (or an equivalent columnar format) with explicit data types and a partitioned layout (time, region, and so on).  
 - Interchange between training jobs with **Arrow** where the stack supports it.  
-- Keep a **data contract** (schema + meaning of nulls, units, categorical encodings)—format choice cannot replace documentation.
+- Keep a **data contract** (schema plus the meaning of nulls, units, and categorical encodings). Format choice cannot replace documentation.
 
 ### Model artifacts
 
 | Need | Prefer |
 |------|--------|
-| Same machine, trusted, rapid iteration | Framework native checkpoint (understand its trust model) |
-| Portable inference, multi-language runtimes | [ONNX](https://en.wikipedia.org/wiki/Open_Neural_Network_Exchange "ONNX — Open Neural Network Exchange")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> / framework export formats / dedicated model servers |
-| Bundle preprocessing + model for one Python service | Still better with versioned registry + immutable artifact IDs than ad-hoc pickles in chat threads |
-| Audit / compliance | Formats and stores that support signing, lineage, and non-executable weights where possible |
+| Same machine, trusted, rapid iteration | Framework-native checkpoint (understand its trust model) |
+| Portable inference across languages | [ONNX](https://en.wikipedia.org/wiki/Open_Neural_Network_Exchange "ONNX — Open Neural Network Exchange")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />, framework export formats, or dedicated model servers |
+| Bundle preprocessing and model for one Python service | Still better with a versioned registry and immutable artifact IDs than ad-hoc pickles in chat threads |
+| Audit and compliance | Formats and stores that support signing, lineage, and non-executable weights where possible |
 
-### Experiments vs production
+### Experiments versus production
 
-Experiment trackers often accept pickles and arbitrary blobs. **Production promotion** should re-materialize critical data into **portable tables** and **reviewed model formats**, not “whatever was in `/tmp`.”
+Experiment trackers often accept pickles and arbitrary blobs. **Production promotion** should re-materialize critical data into **portable tables** and **reviewed model formats**, not “whatever was left in `/tmp`.”
 
 ---
 
 ## JSON validation
 
-Data platforms still emit JSON for APIs, webhooks, and config. Pair text/schemaless payloads with an explicit contract:
+Data platforms still emit JSON for APIs, webhooks, and configuration. Pair text or schemaless payloads with an explicit contract:
 
-- **JSON Schema / [OpenAPI](https://en.wikipedia.org/wiki/OpenAPI_Specification "OpenAPI — standard for HTTP API descriptions")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />** for cross-team [HTTP](https://en.wikipedia.org/wiki/HTTP "HTTP — Hypertext Transfer Protocol")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> boundaries  
-- **Pydantic / msgspec / similar** for Python services that ingest JSON or MessagePack  
+- **JSON Schema** or **[OpenAPI](https://en.wikipedia.org/wiki/OpenAPI_Specification "OpenAPI — standard for HTTP API descriptions")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />** for cross-team [HTTP](https://en.wikipedia.org/wiki/HTTP "HTTP — Hypertext Transfer Protocol")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> boundaries  
+- **Pydantic, msgspec, or similar** for Python services that ingest JSON or MessagePack  
 - Table-level quality checks (orthogonal to wire format, but part of the same reliability story)
 
-Validation is how you keep the flexibility of schemaless formats without surprise `null`s in production training jobs.
+Validation is how you keep the flexibility of schemaless formats without surprise `null` values in production training jobs.
 
 ---
 
@@ -186,38 +187,38 @@ Validation is how you keep the flexibility of schemaless formats without surpris
 
 | If you need… | Prefer… |
 |--------------|---------|
-| Analytic scans over many rows, few columns | **Parquet** (disk/lake) + **Arrow** (memory/engines) |
-| Event stream with long retention and multiple consumer versions | **Avro** (or similar) + schema registry + compatibility policy |
+| Analytic scans over many rows and few columns | **Parquet** (disk/lake) plus **Arrow** (memory/engines) |
+| Event stream with long retention and multiple consumer versions | **Avro** (or similar) plus a schema registry and a compatibility policy |
 | Human-edited or lowest-common-denominator export | **CSV** (document the schema separately) |
-| Application/API interchange, semi-structured, multi-language | **JSON** (+ schema/validation if the contract matters) |
-| Compact internal dynamic payloads (not a lake table) | **MessagePack** / **CBOR** (still validate at boundaries) |
-| Online low-latency service contract (features, inference I/O) | **Schema-driven** (Protobuf/…) — see [engineering perspective](engineer_perspective.md) |
-| Python-only, trusted, short-lived object graph | **pickle** / **joblib** only with eyes open; plan a portable exit path |
+| Application or API interchange, semi-structured, multi-language | **JSON** (plus schema or validation if the contract matters) |
+| Compact internal dynamic payloads (not a lake table) | **MessagePack** or **CBOR** (still validate at boundaries) |
+| Online low-latency service contract (features, inference input/output) | **Schema-driven** formats (Protocol Buffers and similar)—see the [engineering perspective](engineer_perspective.md) |
+| Python-only, trusted, short-lived object graph | **pickle** or **joblib** only with eyes open; plan a portable exit path |
 
 ### Quick comparison
 
 | Format family | Human-readable | Best at | Weak at |
 |---------------|----------------|---------|---------|
-| CSV | Yes | Exchange with humans/tools | Types, nesting, evolution |
-| JSON / JSONL | Yes | Universal semi-structured glue | Huge analytic tables |
+| CSV | Yes | Exchange with humans and tools | Types, nesting, evolution |
+| JSON / JSON Lines | Yes | Universal semi-structured glue | Huge analytic tables |
 | pickle / native | No | Rich Python graphs | Trust, portability, longevity |
 | Avro | No | Evolving event records | “Just open in Excel” |
 | Parquet / ORC | No | Lake analytics | Point lookups of one blob |
-| Arrow | No (binary IPC) | In-memory multi-engine share | Being your only on-disk archive format (usually paired with Parquet) |
+| Arrow | No (binary IPC) | In-memory multi-engine share | Being your only on-disk archive format (usually pair with Parquet) |
 | MessagePack / CBOR | No | Compact dynamic messages | Replacing columnar lakes |
-| Protobuf (etc.) | No | Online contracts / RPC | Sole format for wide analytics |
+| Protocol Buffers and similar | No | Online contracts and RPC | Sole format for wide analytics |
 
 ---
 
-## This suite
+## How this suite helps (and what it does not)
 
-This repository benchmarks **serializers** across languages and categories (JSON family, schemaless binary, schema-driven, language-native). That is invaluable for **encode/decode cost** of in-memory objects.
+This repository benchmarks **serializers** across languages and categories (JSON family, schemaless binary, schema-driven, language-native). That is invaluable for **encode and decode cost** of in-memory objects.
 
-Data platform success also depends on **I/O layout, compression, partitioning, cluster execution, and schema governance**—topics larger than a single serialize call. Use suite **Results** to compare libraries; use this page to pick the **paradigm** before you micro-optimize a codec.
+Data platform success also depends on **input/output layout, compression, partitioning, cluster execution, and schema governance**—topics larger than a single serialize call. Use suite **Results** to compare libraries; use this page to pick the **paradigm** before you micro-optimize a codec.
 
 ---
 
 ## Further reading
 
-- Kleppmann, *Designing Data-Intensive Applications* — systems view of encoding & evolution  
+- Kleppmann, *Designing Data-Intensive Applications* — a systems view of encoding and evolution  
 - Apache Parquet, Arrow, and Avro official documentation  

--- a/docs/theory/101/engineer_perspective.md
+++ b/docs/theory/101/engineer_perspective.md
@@ -1,71 +1,73 @@
 # Engineering Perspective
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/leo-gan/GLD.SerializerBenchmark/blob/master/docs/theory/notebooks/101/engineering_perspective.ipynb)
-**Lab notebook:** [Engineering mini lab](../notebooks/101/engineering_perspective.ipynb) · JS companion: [api_decision_sketch.mjs](../notebooks/companions/js/api_decision_sketch.mjs)
+**Lab notebook:** [Engineering mini lab](../notebooks/101/engineering_perspective.ipynb) · JavaScript companion: [api_decision_sketch.mjs](../notebooks/companions/js/api_decision_sketch.mjs)
 
 ## Who this page is for
 
-- Backend and platform engineers choosing API and [RPC](https://en.wikipedia.org/wiki/Remote_procedure_call "RPC — Remote Procedure Call")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> payloads  
-- Performance-minded developers caring about CPU, allocations, and latency tails  
+- Backend and platform engineers choosing API and [remote procedure call (RPC)](https://en.wikipedia.org/wiki/Remote_procedure_call "RPC — Remote Procedure Call")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> payloads  
+- Performance-minded developers who care about processor time, allocations, and latency tails  
 - Anyone who must deserialize **untrusted** input  
 - Engineers aligning local choices with a multi-language estate  
 
 ---
 
-## Four families (suite-aligned)
+## Four families (aligned with this suite)
 
-The benchmark suite groups serializers into paradigms. Compare **within a paradigm and within one language** before crowning a global winner.
+The benchmark suite groups serializers into paradigms. Compare **within one paradigm and within one language** before crowning a global winner.
 
-| Family | Examples | Schema on wire | Human-readable | Typical home |
-|--------|----------|----------------|----------------|--------------|
-| **Text / [JSON](https://en.wikipedia.org/wiki/JSON "JSON — JavaScript Object Notation")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> family** | JSON, sometimes [XML](https://en.wikipedia.org/wiki/XML "XML — Extensible Markup Language")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />/[YAML](https://en.wikipedia.org/wiki/YAML "YAML — human-friendly data serialization language")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> at edges | Optional / external | Yes | Public APIs, config, debug-friendly logs |
-| **Schemaless binary** | [MessagePack](https://en.wikipedia.org/wiki/MessagePack "MessagePack — binary serialization of JSON-like values")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />, [CBOR](https://en.wikipedia.org/wiki/CBOR "CBOR — Concise Binary Object Representation")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />, [BSON](https://en.wikipedia.org/wiki/BSON "BSON — Binary JSON (MongoDB)")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />, many “binary JSON” codecs | Type tags / field names often present | No | Internal services, caches, queues |
-| **Schema-driven** | [Protobuf](https://en.wikipedia.org/wiki/Protocol_Buffers "Protocol Buffers — schema-driven binary format")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />, [Avro](https://en.wikipedia.org/wiki/Apache_Avro "Apache Avro — row-oriented binary with schemas")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />, [FlatBuffers](https://en.wikipedia.org/wiki/FlatBuffers "FlatBuffers — zero-copy serialization library")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />, Bond, many [IDL](https://en.wikipedia.org/wiki/Interface_description_language "IDL — Interface Description Language")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> tools | Numbers/layout from schema | No | Stable contracts, high-throughput RPC/streams |
+| Family | Examples | Schema on the wire | Human-readable | Typical home |
+|--------|----------|--------------------|----------------|--------------|
+| **Text / [JSON](https://en.wikipedia.org/wiki/JSON "JSON — JavaScript Object Notation")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> family** | JSON; sometimes [XML](https://en.wikipedia.org/wiki/XML "XML — Extensible Markup Language")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> or [YAML](https://en.wikipedia.org/wiki/YAML "YAML — human-friendly data serialization language")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> at edges | Optional or external | Yes | Public APIs, configuration, debug-friendly logs |
+| **Schemaless binary** | [MessagePack](https://en.wikipedia.org/wiki/MessagePack "MessagePack — binary serialization of JSON-like values")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />, [CBOR](https://en.wikipedia.org/wiki/CBOR "CBOR — Concise Binary Object Representation")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />, [BSON](https://en.wikipedia.org/wiki/BSON "BSON — Binary JSON (MongoDB)")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />, many “binary JSON” codecs | Type tags or field names often present | No | Internal services, caches, queues |
+| **Schema-driven** | [Protocol Buffers](https://en.wikipedia.org/wiki/Protocol_Buffers "Protocol Buffers — schema-driven binary format")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />, [Avro](https://en.wikipedia.org/wiki/Apache_Avro "Apache Avro — row-oriented binary with schemas")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />, [FlatBuffers](https://en.wikipedia.org/wiki/FlatBuffers "FlatBuffers — zero-copy serialization library")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />, Bond, many [interface description language (IDL)](https://en.wikipedia.org/wiki/Interface_description_language "IDL — Interface Description Language")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> tools | Numbers or layout from a schema | No | Stable contracts, high-throughput RPC and streams |
 | **Language-native** | [pickle](https://en.wikipedia.org/wiki/Serialization#Python "pickle — Python object serialization")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />, [Java serialization](https://en.wikipedia.org/wiki/Java_serialization "Java object serialization — JVM native object encoding")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />, legacy .NET binary formatters | Runtime type metadata | No | Same-stack caches and graphs (**trust carefully**) |
 
-### Decision sketch (services)
+### Decision sketch for services
 
-1. **Need humans to read/edit the payload on the wire?**
-   - **Yes** → JSON family (add JSON Schema / OpenAPI when contracts matter)
-   - **No** → continue below
-2. **Need shared IDL/schema and multi-language evolution rules?**
-   - **Yes** → Schema-driven (Protobuf-like, Avro-like, or zero-copy IDL)
-   - **No** → continue below
-3. **Single language/runtime, complex graphs, fully trusted data?**
-   - **Yes** → Language-native only inside a hard trust boundary
-   - **No** → Schemaless binary (MessagePack / CBOR / …) **and** validation at edges
+Work through these questions in order:
+
+1. **Do people need to read or edit the payload on the wire?**  
+   - **Yes** → stay in the JSON family (add JSON Schema or OpenAPI when contracts matter).  
+   - **No** → continue.  
+2. **Do you need a shared IDL or schema and multi-language evolution rules?**  
+   - **Yes** → schema-driven (Protocol Buffers-like, Avro-like, or zero-copy IDL designs).  
+   - **No** → continue.  
+3. **Is this a single language and runtime, with complex graphs and fully trusted data?**  
+   - **Yes** → language-native formats only inside a hard trust boundary.  
+   - **No** → schemaless binary (MessagePack, CBOR, and similar) **and** validation at the edges.
 
 ---
 
 ## Text-based interchange
 
-**JSON** is the default public contract: universal parsers, easy logging, mediocre density and parse cost. Gaps (dates, binary, int vs float) are managed by **convention** or by a validation layer ([JSON Schema](https://en.wikipedia.org/wiki/JSON#Schema_and_metadata "JSON Schema — vocabulary for validating JSON")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />, [OpenAPI](https://en.wikipedia.org/wiki/OpenAPI_Specification "OpenAPI — standard for HTTP API descriptions")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />, typed request models).
+**JSON** is the default public contract: universal parsers, easy logging, mediocre density and parse cost. Gaps (dates, binary data, integer versus floating-point numbers) are managed by **convention** or by a validation layer ([JSON Schema](https://en.wikipedia.org/wiki/JSON#Schema_and_metadata "JSON Schema — vocabulary for validating JSON")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />, [OpenAPI](https://en.wikipedia.org/wiki/OpenAPI_Specification "OpenAPI — standard for HTTP API descriptions")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />, typed request models).
 
-**XML** remains in enterprise and document systems; prefer it when the ecosystem already demands it, not as a greenfield API default.
+**XML** remains in enterprise and document systems. Prefer it when the ecosystem already demands it, not as a greenfield API default.
 
-**YAML / [TOML](https://en.wikipedia.org/wiki/TOML "TOML — Tom’s Obvious Minimal Language (config format)")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />** are configuration formats more than wire formats. YAML’s complexity has a long security history with “load untrusted YAML” mistakes—prefer safe loaders and locked-down schemas for untrusted input.
+**YAML** and **[TOML](https://en.wikipedia.org/wiki/TOML "TOML — Tom’s Obvious Minimal Language (config format)")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />** are configuration formats more than wire formats. YAML’s complexity has a long security history with “load untrusted YAML” mistakes—prefer safe loaders and locked-down schemas for untrusted input.
 
 ## Schemaless binary
 
-**MessagePack**, **CBOR**, and **BSON** keep a dynamic data model while dropping text parsing. Field names or type tags usually still appear, so they are typically larger than a tight Protobuf encoding but smaller/faster than JSON.
+**MessagePack**, **CBOR**, and **BSON** keep a dynamic data model while dropping text parsing. Field names or type tags usually still appear, so they are typically larger than a tight Protocol Buffers encoding but smaller and often faster than JSON.
 
-**Engineering uses:** internal [HTTP](https://en.wikipedia.org/wiki/HTTP "HTTP — Hypertext Transfer Protocol")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />/RPC bodies, [Redis](https://en.wikipedia.org/wiki/Redis "Redis — in-memory data structure store")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />-style values, multi-language without an IDL mandate.
+**Typical engineering uses:** internal [HTTP](https://en.wikipedia.org/wiki/HTTP "HTTP — Hypertext Transfer Protocol")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> or RPC bodies, [Redis](https://en.wikipedia.org/wiki/Redis "Redis — in-memory data structure store")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />-style values, multi-language payloads without an IDL mandate.
 
-**You still own:** validation, compatibility, and documentation.
+**You still own** validation, compatibility, and documentation.
 
 ## Schema-driven binary
 
-**Protocol Buffers** — field numbers, codegen, strong multi-language story, explicit evolution discipline (don’t reuse field numbers; reserve deleted ids).
+**Protocol Buffers** use field numbers, code generation, a strong multi-language story, and explicit evolution discipline (do not reuse field numbers; reserve deleted identifiers).
 
-**[Apache Thrift](https://en.wikipedia.org/wiki/Apache_Thrift "Apache Thrift — IDL and RPC framework")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />** — IDL + pluggable protocols/transports; historically RPC-centric polyglot stacks.
+**[Apache Thrift](https://en.wikipedia.org/wiki/Apache_Thrift "Apache Thrift — IDL and RPC framework")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />** pairs an IDL with pluggable protocols and transports. Historically it appears in RPC-centric polyglot stacks.
 
-**Apache Avro** — often chosen when **schema resolution** and data-platform interoperability matter (also covered under [data science](data_science_perspective.md)); appears in event pipelines as much as in classical RPC.
+**Apache Avro** is often chosen when **schema resolution** and data-platform interoperability matter (also covered under the [data science perspective](data_science_perspective.md)). It appears in event pipelines as much as in classical RPC.
 
-**FlatBuffers / [Cap’n Proto](https://en.wikipedia.org/wiki/Cap%27n_Proto "Cap’n Proto — zero-copy serialization and RPC")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />** — design for **low-parse / zero-copy** access; excellent read paths; different mutation and tooling ergonomics than classic “build a struct → serialize” Protobuf style.
+**FlatBuffers** and **[Cap’n Proto](https://en.wikipedia.org/wiki/Cap%27n_Proto "Cap’n Proto — zero-copy serialization and RPC")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />** aim for **low-parse or zero-copy** access: excellent read paths, with different mutation and tooling ergonomics than classic “build a struct, then serialize” Protocol Buffers style.
 
-## Language-native
+## Language-native formats
 
-Convenient for object graphs inside one runtime. Treat as **unsafe by default** on the network or any multi-tenant input path. Prefer portable formats whenever data leaves the process trust domain.
+These are convenient for object graphs inside one runtime. Treat them as **unsafe by default** on the network or any multi-tenant input path. Prefer portable formats whenever data leaves the process trust domain.
 
 ---
 
@@ -73,38 +75,38 @@ Convenient for object graphs inside one runtime. Treat as **unsafe by default** 
 
 Numbers belong on **Results** pages. These are the mechanisms those numbers come from.
 
-### Data locality and CPU caches
+### Data locality and processor caches
 
-Modern CPUs are fast; **random memory access** is not. Serializers that scatter fields via pointer-rich object graphs cause cache misses. Designs that keep related bytes **contiguous** (and zero-copy formats that read from a single buffer) reduce stalls.
+Modern processors are fast; **random memory access** is not. Serializers that scatter fields through pointer-rich object graphs cause cache misses. Designs that keep related bytes **contiguous** (and zero-copy formats that read from a single buffer) reduce stalls.
 
-When you benchmark, payload **shape** matters as much as codec brand: deep pointer graphs punish every language; dense structs favor contiguous layouts.
+When you benchmark, payload **shape** matters as much as codec brand: deep pointer graphs punish every language; dense structures favor contiguous layouts.
 
 ### Allocations and [garbage collection](https://en.wikipedia.org/wiki/Garbage_collection_%28computer_science%29 "Garbage collection — automatic memory reclamation")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />
 
-In managed runtimes (C#, Java, Python, JS, Go), **allocation rate** drives GC work and latency spikes.
+In managed runtimes (C#, Java, Python, JavaScript, Go), **allocation rate** drives garbage-collector work and latency spikes.
 
 | Pattern | Effect |
 |---------|--------|
-| Allocate a new string/array per field | High GC pressure under load |
-| Decode into reused buffers / pooling | Lower allocator traffic |
-| `Span`-like views over existing memory | Avoid copies when APIs allow |
+| Allocate a new string or array per field | High garbage-collector pressure under load |
+| Decode into reused buffers or pools | Lower allocator traffic |
+| Span-like views over existing memory | Avoid copies when APIs allow |
 | Zero-copy formats | “Deserialize” may mean bounds-checked views, not new objects |
 
-“Faster serializer” often means **fewer allocations**, not only fewer CPU instructions in the encode loop.
+“Faster serializer” often means **fewer allocations**, not only fewer processor instructions in the encode loop.
 
 ### Zero-copy deserialization
 
-Traditional path: bytes → parse → **new** language objects (copy).
+The traditional path is: bytes → parse → **new** language objects (a copy).
 
-**Zero-copy** path (FlatBuffers, Cap’n Proto, and some buffer-oriented APIs): wire layout is arranged so fields are readable **in place**. Trade-offs include validation discipline (skipping a parse can skip structural checks if you are careless), less friendly partial mutation, and operational tooling differences.
+A **zero-copy** path (FlatBuffers, Cap’n Proto, and some buffer-oriented APIs) arranges the wire layout so fields are readable **in place**. Trade-offs include validation discipline (skipping a parse can skip structural checks if you are careless), less friendly partial mutation, and different operational tooling.
 
 ### Text parsing cost
 
-JSON/XML must discover tokens, unescape strings, and convert decimal text to binary numbers. Binary formats largely avoid that. At scale this is both **CPU** and **energy/cost** in the datacenter—not just academic microbenchmarks.
+JSON and XML must discover tokens, unescape strings, and convert decimal text to binary numbers. Binary formats largely avoid that work. At scale this is both **processor time** and **energy cost** in the datacenter—not only an academic microbenchmark.
 
-### Size vs speed
+### Size versus speed
 
-Smaller payloads help networks and storage; the fastest codec is not always the smallest. Measure **your** payloads (see suite topologies) rather than blog leaderboards alone.
+Smaller payloads help networks and storage; the fastest codec is not always the smallest. Measure **your** payloads (see the suite topologies) rather than blog leaderboards alone.
 
 ---
 
@@ -114,11 +116,11 @@ Untrusted bytes are **hostile input**.
 
 | Risk | Where it shows up | Mitigation |
 |------|-------------------|------------|
-| **Remote code execution via native deserialize** | Java serialization, pickle, some legacy binary formatters, careless YAML `load` | Never deserialize untrusted native formats; prefer pure data formats + explicit allowlists |
+| **Remote code execution via native deserialize** | Java serialization, pickle, some legacy binary formatters, careless YAML `load` | Never deserialize untrusted native formats; prefer pure data formats plus explicit allowlists |
 | **[Billion laughs](https://en.wikipedia.org/wiki/Billion_laughs_attack "Billion laughs — XML entity expansion DoS")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> / entity expansion** | XML | Disable external entities; use safe parser settings |
-| **Resource exhaustion** | Huge nested JSON, deeply nested CBOR/msgpack, unbounded collections | Limits on depth, size, and allocations |
+| **Resource exhaustion** | Huge nested JSON, deeply nested CBOR or MessagePack, unbounded collections | Limits on depth, size, and allocations |
 | **Logic bugs from type confusion** | Schemaless JSON (“number or string?”) | Validate with a schema or typed model at the trust boundary |
-| **Skipping verification in zero-copy** | FlatBuffers-style buffers used without a verifier | Always verify untrusted buffers before use |
+| **Skipping verification in zero-copy paths** | FlatBuffers-style buffers used without a verifier | Always verify untrusted buffers before use |
 
 **Rule of thumb:** the more powerful the deserializer (arbitrary types, dynamic code), the smaller the set of inputs it may see.
 
@@ -126,26 +128,26 @@ Untrusted bytes are **hostile input**.
 
 ## Schema evolution for services
 
-Services rarely deploy atomically. Plan for **old readers + new writers** and the reverse.
+Services rarely deploy all at once. Plan for **old readers with new writers** and the reverse.
 
 | Approach | Practical guidance |
 |----------|-------------------|
-| **Protobuf field numbers** | Add optional fields; never repurpose numbers; `reserved` deleted ids |
-| **JSON + consumers** | Additive changes are safer; renames break silently; use API versioning when removing fields |
-| **Avro compatibility modes** | Encode policy in a registry/CI (backward/forward/full) |
-| **“We’ll fix it in the client”** | Does not scale past one team |
+| **Protocol Buffers field numbers** | Add optional fields; never repurpose numbers; mark deleted identifiers as reserved |
+| **JSON and its consumers** | Additive changes are safer; renames break silently; use API versioning when removing fields |
+| **Avro compatibility modes** | Encode policy in a registry and continuous integration (backward, forward, or full) |
+| **“We will fix it in the client”** | Does not scale past one team |
 
-Document whether fields are required, defaulted, or nullable—**wire format cannot invent product semantics**.
+Document whether fields are required, defaulted, or nullable. A **wire format cannot invent product semantics** by itself.
 
 ---
 
 ## Operational concerns
 
-- **Debuggability:** JSON in logs vs binary needing decoders and schema versions in observability tooling  
-- **Gateways and mesh:** some exotic RPC framings interact poorly with vanilla [HTTP/2](https://en.wikipedia.org/wiki/HTTP/2 "HTTP/2 — major revision of HTTP")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> load balancers and serverless edges  
-- **Codegen in CI:** schema-driven stacks need stable `protoc`/IDL pipelines and versioned generated artifacts  
-- **Polyglot drift:** “we use Protobuf” is incomplete without a shared style guide (well-known types, error model, timestamp policy)  
-- **Partial failure:** corrupts and truncated frames need clear errors, not hung parsers  
+- **Debuggability:** JSON in logs versus binary that needs decoders and schema versions in observability tooling  
+- **Gateways and service meshes:** some exotic RPC framings interact poorly with ordinary [HTTP/2](https://en.wikipedia.org/wiki/HTTP/2 "HTTP/2 — major revision of HTTP")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> load balancers and serverless edges  
+- **Code generation in continuous integration:** schema-driven stacks need stable `protoc` or IDL pipelines and versioned generated artifacts  
+- **Polyglot drift:** “we use Protocol Buffers” is incomplete without a shared style guide (well-known types, error model, timestamp policy)  
+- **Partial failure:** corrupt and truncated frames need clear errors, not hung parsers  
 
 ---
 
@@ -153,18 +155,18 @@ Document whether fields are required, defaulted, or nullable—**wire format can
 
 | Scenario | Reasonable default | Why |
 |----------|--------------------|-----|
-| Public HTTP API for third parties | JSON + OpenAPI | Ecosystem and debuggability dominate |
-| Internal microservice RPC, multi-language | Protobuf (or similar) over your standard transport | Compact, typed, evolvable |
-| Hot cache of dynamic documents | MessagePack/CBOR or JSON depending on clients | Schemaless binary if all consumers agree |
-| Same-process or same-runtime trusted cache | Language-native **only if** threat model allows | Otherwise portable binary |
+| Public HTTP API for third parties | JSON plus OpenAPI | Ecosystem and debuggability dominate |
+| Internal microservice RPC, multi-language | Protocol Buffers (or similar) over your standard transport | Compact, typed, evolvable |
+| Hot cache of dynamic documents | MessagePack, CBOR, or JSON depending on clients | Schemaless binary if all consumers agree |
+| Same-process or same-runtime trusted cache | Language-native **only if** the threat model allows | Otherwise portable binary |
 | Ultra-low-latency read of large immutable messages | FlatBuffers / Cap’n Proto-class design | In-place access |
-| Analytics export from a service | Write **[Parquet](https://en.wikipedia.org/wiki/Apache_Parquet "Apache Parquet — columnar storage format")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />** (or ship to a pipeline that does)—see [data science](data_science_perspective.md) | Do not force OLTP message formats to be your lake |
+| Analytics export from a service | Write **[Parquet](https://en.wikipedia.org/wiki/Apache_Parquet "Apache Parquet — columnar storage format")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />** (or ship to a pipeline that does)—see [data science](data_science_perspective.md) | Do not force online message formats to be your lake |
 
 ---
 
 ## Illustrative snippets
 
-Orientation only—not library endorsements. (Site-wide fenced code uses plain highlighting; see `mkdocs.yml`.)
+These snippets are for orientation only—not library endorsements. (Site-wide fenced code uses plain highlighting; see `mkdocs.yml`.)
 
 ### JSON (public API style)
 
@@ -185,14 +187,10 @@ packed = msgpack.packb({"nums": [1, 2, 3]})
 assert msgpack.unpackb(packed) == {"nums": [1, 2, 3]}
 ```
 
-### Protobuf-style (after codegen)
+### Protocol Buffers style (after code generation)
 
 ```python
 # Generated module provides message classes (illustrative Google tutorial names).
-
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/leo-gan/GLD.SerializerBenchmark/blob/master/docs/theory/notebooks/101/engineering_perspective.ipynb)
-**Lab notebook:** [Engineering mini lab](../notebooks/101/engineering_perspective.ipynb)
-
 person = addressbook_pb2.Person(id=1234, name="Alice")
 data = person.SerializeToString()
 person2 = addressbook_pb2.Person()
@@ -203,11 +201,11 @@ person2.ParseFromString(data)
 
 ## Key takeaways
 
-1. **Pick a paradigm first**, then a library—suite categories exist to prevent unfair cross-paradigm comparisons.  
-2. **Public edge ≠ internal hot path**—JSON at the boundary and binary inside is a normal, historical pattern.  
-3. **Performance is layout + allocations + parsing**, not a single brand name.  
-4. **Untrusted deserialize is a security boundary**—native serializers are not “just faster JSON.”  
-5. **Evolution is a process** (IDs, registries, API versions), not only a file format.  
+1. **Pick a paradigm first**, then a library. The suite categories exist to prevent unfair cross-paradigm comparisons.  
+2. **Public edge is not the same as an internal hot path.** JSON at the boundary and binary inside is a normal, historical pattern.  
+3. **Performance is layout, allocations, and parsing**—not a single brand name.  
+4. **Untrusted deserialize is a security boundary.** Native serializers are not “just faster JSON.”  
+5. **Evolution is a process** (identifiers, registries, API versions), not only a file format.  
 6. **Measure on your payloads** with this suite’s topologies and your language’s **Results**.
 
 ---
@@ -218,5 +216,5 @@ person2.ParseFromString(data)
 - MessagePack specification; CBOR RFC 8949  
 - Protocol Buffers language guide and style guides  
 - Apache Thrift and Apache Avro project docs  
-- Cap’n Proto and FlatBuffers documentation (encoding + security/verification notes)  
-- Language security docs for pickle / Java serialization / legacy binary formatters  
+- Cap’n Proto and FlatBuffers documentation (encoding plus security and verification notes)  
+- Language security docs for pickle, Java serialization, and legacy binary formatters  

--- a/docs/theory/101/historical_perspective.md
+++ b/docs/theory/101/historical_perspective.md
@@ -1,12 +1,14 @@
 # Historical Perspective
 
+This page is the “big picture” lens of Serialization 101. You do not need to memorize every product name. The goal is to see **pressure → response**: each era’s formats answer the constraints people felt most strongly at the time.
+
 ## The problem that never goes away
 
-Programs hold **rich in-memory structure**: nested records, arrays, graphs of objects, different integer widths, and different byte orders. Disks, networks, and many caches only store **linear sequences of bytes**.
+Programs hold **rich structure in memory**: nested records, arrays, graphs of objects, different integer widths, and different byte orders. Disks, networks, and many caches only store **linear sequences of bytes**.
 
-[Serialization](https://en.wikipedia.org/wiki/Serialization "Serialization — converting structures to a byte sequence and back")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> is the durable answer to: *how do we flatten meaning into bytes and recover it later—possibly on another machine, in another language, years later?*
+[Serialization](https://en.wikipedia.org/wiki/Serialization "Serialization — converting structures to a byte sequence and back")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> is the durable answer to a simple question with hard consequences: *how do we flatten meaning into bytes and recover it later—possibly on another machine, in another language, years later?*
 
-Every major format is a bet on which constraints matter most at the time: human readability, portability across CPUs, schema evolution, CPU cost, memory pressure, or analytics I/O. History is the story of those bets.
+Every major format is a bet on which constraints matter most: human readability, portability across CPU architectures, schema evolution, processor cost, memory pressure, or analytics input/output. History is the story of those bets.
 
 ---
 
@@ -23,7 +25,7 @@ Every major format is a bet on which constraints matter most at the time: human 
 | 2010s onward | Analytics & zero-copy | Scan huge tables; avoid copy/[GC](https://en.wikipedia.org/wiki/Garbage_collection_%28computer_science%29 "Garbage collection — automatic memory reclamation")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> | [Parquet](https://en.wikipedia.org/wiki/Apache_Parquet "Apache Parquet — columnar storage format")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />/[ORC](https://en.wikipedia.org/wiki/Apache_ORC "Apache ORC — Optimized Row Columnar")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />; [Arrow](https://en.wikipedia.org/wiki/Apache_Arrow "Apache Arrow — in-memory columnar format")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />; [FlatBuffers](https://en.wikipedia.org/wiki/FlatBuffers "FlatBuffers — zero-copy serialization library")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />; [Cap’n Proto](https://en.wikipedia.org/wiki/Cap%27n_Proto "Cap’n Proto — zero-copy serialization and RPC")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> |
 | ~2015 onward | Validation as product | Correctness of dynamic JSON at scale | [JSON Schema](https://en.wikipedia.org/wiki/JSON#Schema_and_metadata "JSON Schema — vocabulary for annotating and validating JSON")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />; typed validators (e.g. Pydantic, msgspec) |
 
-You do not need to memorize every name. Learn the **pressure → response** pattern.
+You do not need to memorize every name in the table. Learn the **pressure → response** pattern: what was expensive or broken, and what idea fixed it.
 
 ---
 
@@ -36,7 +38,7 @@ When magnetic tape and disk arrived, two durable ideas competed:
 1. **Raw memory image** — write the bytes exactly as the CPU lays them out ([FORTRAN](https://en.wikipedia.org/wiki/Fortran "Fortran — early scientific programming language")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />-era binary I/O). Fast on one machine; useless or wrong on another word size or [endianness](https://en.wikipedia.org/wiki/Endianness "Endianness — byte order of multi-byte values")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />.
 2. **Explicit record layout** — declare field widths and types once (COBOL `DATA DIVISION` fixed-width records). Any program that shares the layout can read the bytes. Interoperable, rigid: insert a field and every reader must change or mis-parse the rest of the record.
 
-**Lesson still true today:** a format is a **writer–reader contract**. The simpler and more positional the layout, the harder it is to extend without breaking old readers.
+**Lesson still true today:** a format is a **contract between writer and reader**. The simpler and more positional the layout, the harder it is to extend without breaking old readers. That tension still shows up in modern APIs and event schemas.
 
 ---
 
@@ -60,7 +62,7 @@ Telecom and [ISO](https://en.wikipedia.org/wiki/International_Organization_for_S
 
 Sun’s **XDR** (External Data Representation; RFC 1014, later RFC 4506) powered [NFS](https://en.wikipedia.org/wiki/Network_File_System "NFS — Network File System")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> and Sun [RPC](https://en.wikipedia.org/wiki/Remote_procedure_call "RPC — Remote Procedure Call")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />: fixed alignment rules, big-endian integers, length-prefixed strings and arrays. Portable and efficient for its time; **not self-describing**—you needed the agreed procedure/types (often an `.x` description) to interpret the stream.
 
-**Lesson:** networks demand a **canonical** representation and push industry toward **IDL + generated codecs**.
+**Lesson:** networks demand a **canonical** representation that every machine can agree on. That pressure still pushes industry toward an interface description language (IDL) and **generated** encode/decode code.
 
 ---
 
@@ -72,7 +74,7 @@ Object-oriented runtimes introduced **graphs**: shared references, cycles, inher
 - **Java serialization (1995)** — language work associated with **[James Gosling](https://en.wikipedia.org/wiki/James_Gosling "James Gosling — co-creator of the Java language")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />** and the Java platform; implement a marker interface; the runtime reflects fields. Ergonomic inside the [JVM](https://en.wikipedia.org/wiki/Java_virtual_machine "JVM — Java Virtual Machine")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />; **not portable** to other languages; versioning via `serialVersionUID` is brittle; **unsafe** on untrusted bytes (gadget chains → remote code execution).
 - **Python** (created by **[Guido van Rossum](https://en.wikipedia.org/wiki/Guido_van_Rossum "Guido van Rossum — creator of Python")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />**): **[pickle](https://en.wikipedia.org/wiki/Serialization#Python "pickle — Python’s built-in object serialization (see Serialization § Python)")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> (mid-1990s)** — opcode stream for a small VM; can reconstruct rich Python objects (and, with `cloudpickle`, many dynamic callables). Central to much scientific Python; **Python-only** and **unsafe** on untrusted input.
 
-**Lesson:** language-native formats maximize convenience **inside one trust and language boundary**. They repeatedly fail as universal interchange and as a security boundary.
+**Lesson:** language-native formats maximize convenience **inside one trust boundary and one language**. They repeatedly fail as universal interchange, and they are a poor security boundary when input is untrusted.
 
 ---
 
@@ -82,7 +84,7 @@ The public web needed something **language-neutral, hierarchical, and human-insp
 
 Enterprise systems layered **SOAP** and the WS-\* stack on XML over [HTTP](https://en.wikipedia.org/wiki/HTTP "HTTP — Hypertext Transfer Protocol")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />: universal in theory, verbose and complex in practice. Parse cost and document weight became obvious at scale.
 
-**Lesson:** **self-description and universality have real CPU and bandwidth costs.** The industry would spend the next decades trying to keep interoperability while shedding XML’s tax.
+**Lesson:** **self-description and universality have real processor and bandwidth costs.** The industry spent the following decades trying to keep interoperability while reducing that “XML tax.”
 
 ---
 
@@ -96,7 +98,7 @@ REST-style HTTP APIs (architectural style articulated by **[Roy Fielding](https:
 - Numbers are not a full [IEEE 754](https://en.wikipedia.org/wiki/IEEE_754 "IEEE 754 — floating-point arithmetic standard")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> taxonomy of int vs float.
 - Schema is optional (later filled by **JSON Schema**, [OpenAPI](https://en.wikipedia.org/wiki/OpenAPI_Specification "OpenAPI — standard for HTTP API descriptions")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />, and language validators).
 
-**Lesson:** the “winning” format is often the one that minimizes **integration friction**, not the one that wins microbenchmarks.
+**Lesson:** the “winning” format is often the one that minimizes **integration friction** for many teams and tools—not the one that wins a microbenchmark on one machine.
 
 ---
 
@@ -122,7 +124,7 @@ Not every team wanted a compiler in the loop:
 | **BSON** | ~2009 ([MongoDB](https://en.wikipedia.org/wiki/MongoDB "MongoDB — document-oriented database")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />) | Document storage/wire types (dates, binary) with length prefixes |
 | **CBOR** | 2013 (RFC 7049 / 8949) | Standards-track concise binary objects; strong [IoT](https://en.wikipedia.org/wiki/Internet_of_things "IoT — Internet of Things")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> / constrained-device story |
 
-**Lesson:** once JSON locked the *data model* in people’s heads, the industry cloned that model into **binary** and reintroduced **schemas** where evolution and efficiency dominated.
+**Lesson:** once JSON locked a simple *data model* in people’s heads, the industry cloned that model into **binary** for speed and size, and reintroduced **schemas** where long-lived evolution and efficiency dominated.
 
 ---
 
@@ -134,7 +136,7 @@ Batch and streaming platforms ([Hadoop](https://en.wikipedia.org/wiki/Apache_Had
 - **Columnar storage** — Google’s **[Dremel](https://en.wikipedia.org/wiki/Dremel_%28software%29 "Dremel — Google interactive analytic query system")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />** paper (2010) popularized nested columnar layout for analytic queries that touch few columns of wide tables. **Apache Parquet** (open-sourced ~2013; Julien Le Dem, Nong Li, and community) and **ORC** made that idea the backbone of data lakes.
 - **Apache Arrow** (from ~2016; [Wes McKinney](https://en.wikipedia.org/wiki/Wes_McKinney "Wes McKinney — creator of pandas; co-founder of Arrow")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> and co-founders/community) — standard **in-memory** columnar layout so systems can share tables with minimal or zero copy instead of endlessly converting.
 
-**Lesson:** **transactional messaging** and **analytical scanning** optimize different layouts. History splits “messages on the wire” from “tables on disk / in memory.”
+**Lesson:** **transactional messaging** and **analytical scanning** want different layouts. History gradually splits “messages on the wire” from “tables on disk or in memory for analytics.”
 
 ---
 
@@ -145,7 +147,7 @@ Even fast encode/decode still **copies** into language objects. Domains with tig
 - **Cap’n Proto** (Kenton Varda, ~2013) — layout designed so the buffer *is* the in-memory form; encode/decode can approach a no-op for simple access patterns.
 - **FlatBuffers** (Wouter van Oortmerssen, Google, ~2014) — similar zero-copy access goals with vtable-based optional fields; strong mobile/game heritage; also appears in [ML](https://en.wikipedia.org/wiki/Machine_learning "ML — Machine learning")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> runtime ecosystems.
 
-**Trade-off theme:** less parse work often means more care around **validation**, mutability, and operational tooling (debugability, proxies, HTTP-centric infrastructure).
+**Trade-off theme:** less parse work often means more care around **validation**, how you mutate data, and day-to-day tooling (debuggability, proxies, HTTP-centric infrastructure).
 
 ---
 
@@ -156,7 +158,7 @@ Public and internal APIs stayed on JSON for reach, while teams paid for **ad-hoc
 - **JSON Schema** and **OpenAPI** — contracts and generated clients/servers for HTTP JSON.
 - Runtime validators bound to language types (in Python, notably **Pydantic** and high-performance tools like **msgspec**) — treat annotations as schema, validate on the way in/out.
 
-**Lesson:** schemaless popularity created demand for **optional, enforceable structure** without always switching the wire format.
+**Lesson:** the popularity of schemaless JSON created demand for **optional, enforceable structure**—contracts and validators—without always switching the bytes on the wire.
 
 ---
 
@@ -175,9 +177,9 @@ History does not converge on a single winner. It accumulates niches along recurr
 
 ## Using this history
 
-1. When someone says “just use X,” ask **which pressure** they are optimizing (debug? polyglot? retention? scan speed? unsafe input?).
-2. Prefer portable, explicit formats when data **crosses** a language or trust boundary.
-3. Expect **multiple** formats in one organization: JSON at the edge, binary RPC inside, Parquet in the lake—that is historical normal, not failure.
+1. When someone says “just use X,” ask **which pressure** they are optimizing: debugging, multi-language support, long retention, scan speed, or safety under untrusted input.
+2. Prefer portable, explicit formats when data **crosses** a language boundary or a trust boundary.
+3. Expect **multiple** formats in one healthy organization: JSON at the public edge, binary remote procedure calls inside, Parquet in the data lake. That pattern is historically normal, not a sign of failure.
 
 ---
 

--- a/docs/theory/101/index.md
+++ b/docs/theory/101/index.md
@@ -1,21 +1,23 @@
 # Serialization 101
 
-A starting point for **anyone** who wants to understand data serialization—students, data scientists, backend engineers, and systems architects. You do not need prior expertise. By the end of this theory track you should be able to:
+This is a starting point for **anyone** who wants to understand data serialization—students, data scientists, backend engineers, and systems architects. You do not need prior expertise.
+
+By the end of this theory track you should be able to:
 
 1. Explain what serialization is and why it exists.
-2. Read a format’s history as a response to real constraints (not a list of brand names).
-3. Choose a format *for a workload* using the right lens (data work vs services).
+2. Read a format’s history as a response to real constraints (not as a list of brand names).
+3. Choose a format *for a workload* using the right lens (data work versus services).
 4. Connect concepts to **measured** libraries in this multi-language benchmark suite.
 
-Theory alone does not decide production choices. Use this course to build vocabulary and judgment, then validate with [Benchmarks](../../analysis/index.md) and language **Results**.
+Theory alone does not decide production choices. Use this course to build vocabulary and judgment, then check numbers with [Benchmarks](../../analysis/index.md) and each language’s **Results** pages.
 
 ---
 
 ## What is serialization?
 
-**Serialization** turns an in-memory data structure (objects, records, graphs) into a **linear sequence of bytes** that can be stored, cached, or sent across a network. **Deserialization** rebuilds a usable structure from those bytes—often in another process, machine, or language.
+**Serialization** turns an in-memory data structure (objects, records, graphs) into a **linear sequence of bytes** that can be stored, cached, or sent across a network. **Deserialization** rebuilds a usable structure from those bytes—often in another process, machine, or programming language.
 
-Memory is a web of pointers and types. The wire and the disk only understand bytes. Every format is a **contract** between a writer and a reader about how that collapse and rebuild work.
+Memory is a web of pointers and types. The network and the disk only understand bytes. Every format is a **contract** between a writer and a reader about how that collapse and rebuild work.
 
 ---
 
@@ -25,17 +27,17 @@ The same formats appear under three perspectives on purpose. Each document answe
 
 | Lens | Primary question | Best if you care about… |
 |------|------------------|-------------------------|
-| **[Historical](historical_perspective.md)** | *Why do these formats exist?* | Eras, people, constraints, paradigm shifts |
-| **[Data science](data_science_perspective.md)** | *What should I use for data & ML work?* | Lakes, pipelines, notebooks, models, columnar I/O |
-| **[Engineering](engineer_perspective.md)** | *What should I ship in services & systems?* | APIs, RPC, performance, security, evolution |
+| **[Historical](historical_perspective.md)** | *Why do these formats exist?* | Eras, people, constraints, and paradigm shifts |
+| **[Data science](data_science_perspective.md)** | *What should I use for data and machine-learning work?* | Lakes, pipelines, notebooks, models, columnar input/output |
+| **[Engineering](engineer_perspective.md)** | *What should I ship in services and systems?* | APIs, remote procedure calls (RPC), performance, security, evolution |
 
 **Suggested order for a first pass**
 
-1. Skim the **shared trade-offs** below (10 minutes).
-2. Read the **[historical perspective](historical_perspective.md)** once (big picture).
+1. Skim the **shared trade-offs** below (about ten minutes).
+2. Read the **[historical perspective](historical_perspective.md)** once for the big picture.
 3. Deep-dive the lens that matches your work (**[data science](data_science_perspective.md)** or **[engineering](engineer_perspective.md)**).
-4. Open [Serialization categories](../../analysis/serialization_categories.md) and a language **Overview** / **Results** page for libraries you might actually use.
-5. When you need *mechanisms*, work the **[Serialization 201](../201/index.md)** track:
+4. Open [Serialization categories](../../analysis/serialization_categories.md) and a language **Overview** or **Results** page for libraries you might actually use.
+5. When you need *mechanisms*, work through the **[Serialization 201](../201/index.md)** track:
     1. [Memory layout](../201/memory-layout.md)
     2. [Encode/decode cost](../201/encode-decode-cost.md)
     3. [Self-describing vs schema](../201/self-describing-vs-schema-dependent.md)
@@ -46,58 +48,60 @@ The same formats appear under three perspectives on purpose. Each document answe
 
 You can reverse steps 2 and 3 if you already have a concrete problem (“I need Parquet for analytics” or “I need an internal RPC format”). Jump to a single 201 article when you already know the question.
 
-When mechanisms are solid and you need **production multi-constraint judgment**, continue to [Serialization 301](../301/index.md).
+When mechanisms feel solid and you need **production judgment under several constraints at once**, continue to [Serialization 301](../301/index.md).
 
 ---
 
 ## Core trade-offs
 
-These axes appear in every lens. Learn the *names*; details live in the perspective docs.
+These axes appear in every lens. Learn the *names* here; details live in the perspective documents.
 
-### Text vs binary
+### Text versus binary
 
-| | Text (JSON, XML, YAML, …) | Binary (MessagePack, Protobuf, Parquet, …) |
+| | Text (JSON, XML, YAML, and similar) | Binary (MessagePack, Protocol Buffers, Parquet, and similar) |
 |--|---------------------------|-----------------------------------------------|
-| **Strength** | Human-readable; easy to debug and log | Compact; often much faster to encode/decode |
-| **Cost** | Larger payloads; string parsing | Opaque without tools; harder ad-hoc inspection |
+| **Strength** | Humans can read it; easier to debug and log | Compact; often much faster to encode and decode |
+| **Cost** | Larger payloads; parsing character by character | Opaque without tools; harder ad-hoc inspection |
 
-### Schema vs schemaless
+### Schema versus schemaless
 
-| | Schemaless (JSON, MessagePack, …) | Schema-driven (Protobuf, Avro, FlatBuffers, …) |
+| | Schemaless (JSON, MessagePack, and similar) | Schema-driven (Protocol Buffers, Avro, FlatBuffers, and similar) |
 |--|-----------------------------------|--------------------------------------------------|
-| **Strength** | Flexible; ship data without an IDL step | Compact wire form; codegen; clearer evolution rules |
+| **Strength** | Flexible; you can ship data without an interface-description step | Compact on the wire; code generation; clearer evolution rules when you invest in process |
 | **Cost** | Validation and compatibility are *your* job | Up-front schema design and tooling |
 
-### Row-oriented vs columnar
+### Row-oriented versus columnar
 
-| | Row (JSON objects, Protobuf messages, Avro records) | Columnar (Parquet, ORC, Arrow tables) |
+| | Row (JSON objects, Protocol Buffers messages, Avro records) | Columnar (Parquet, ORC, Arrow tables) |
 |--|-----------------------------------------------------|----------------------------------------|
-| **Strength** | Natural for whole records (APIs, RPC, OLTP-style access) | Scan few columns over huge tables with far less I/O |
-| **Cost** | Poor for wide analytical queries | Wrong default for “fetch one document by id” |
+| **Strength** | Natural for whole records (APIs, RPC, online transaction-style access) | Scan a few columns over huge tables with far less input/output |
+| **Cost** | Poor for wide analytical queries | Wrong default when you mostly “fetch one document by id” |
 
-### Self-describing vs schema-dependent
+### Self-describing versus schema-dependent
 
-- **Self-describing-ish:** field names or type tags travel with the data (JSON, MessagePack, CBOR). Easier to inspect; more metadata on the wire.
-- **Schema-dependent:** wire data is nearly meaningless without a shared schema (classic Protobuf, raw Avro). Smaller and faster when both ends agree.
+- **Self-describing (to varying degrees):** field names or type tags travel with the data (JSON, MessagePack, CBOR). Easier to inspect; more metadata on the wire.
+- **Schema-dependent:** the wire data is nearly meaningless without a shared schema (classic Protocol Buffers, raw Avro). Smaller and faster when both ends already agree on the contract.
 
-### Portable vs language-native
+### Portable versus language-native
 
-- **Portable:** designed for multi-language interchange (JSON, Protobuf, MessagePack, …).
-- **Language-native:** tied to one runtime (`pickle`, Java serialization, …). Convenient inside a trust boundary; dangerous or unusable across languages and untrusted inputs.
+- **Portable:** designed for multi-language interchange (JSON, Protocol Buffers, MessagePack, and similar).
+- **Language-native:** tied to one runtime (`pickle`, Java serialization, and similar). Convenient inside a tight trust boundary; dangerous or unusable across languages and on untrusted inputs.
 
 ---
 
 ## Lab notebooks (Python / Colab)
+
+Hands-on companions for two of the lenses:
 
 | Notebook | Article |
 |----------|---------|
 | [Data science lab](../notebooks/101/data_science_perspective.ipynb) | [Data science perspective](data_science_perspective.md) |
 | [Engineering mini lab](../notebooks/101/engineering_perspective.ipynb) | [Engineering perspective](engineer_perspective.md) |
 
-Notes: [notebooks README](../notebooks/README.md).
+Install and layout notes live in the [notebooks README](../notebooks/README.md).
 
 ## Scope and honesty
 
 - This theory track is a **map**, not an encyclopedia of every library.
 - Performance claims in prose are **illustrative**. Prefer suite **Results** for numbers on *this* harness and hardware.
-- “Best format” always means **best under your constraints** (team, trust boundary, retention, latency budget, polyglot needs).
+- “Best format” always means **best under your constraints** (team, trust boundary, retention, latency budget, multi-language needs).

--- a/docs/theory/201/compression-is-not-a-format.md
+++ b/docs/theory/201/compression-is-not-a-format.md
@@ -8,17 +8,21 @@
 
 When bandwidth or storage is expensive, a common sequence of decisions is:
 
-1. Payloads are observed to be large.  
-2. A general-purpose compressor (**gzip**, **brotli**, **zstd**, or similar) is enabled on the HTTP connection or on stored files.  
+1. Payloads are observed to be large.
+2. A general-purpose compressor (**gzip**, **brotli**, **zstd**, or similar) is enabled on the HTTP connection or on stored files.
 3. The organization concludes that the serialization format “no longer matters” because compression “repairs” size.
 
-That conclusion is sometimes operationally adequate. More often it conceals **processor cost**, **latency effects**, and **forgone structure-aware savings**, or creates the incorrect impression that an inefficient encoding is free of consequence.
+That conclusion is sometimes operationally adequate. More often it hides **processor cost**, **latency effects**, and **forgone structure-aware savings**, or creates the incorrect impression that an inefficient encoding is free of consequence.
 
 ---
 
 ## Short answer
 
-**Serialization** defines *which bytes* represent which values (types, field identity, layout). **Compression** is a largely **semantics-agnostic** transform that exploits redundancy in a byte sequence. Compression can reduce verbose encodings (for example JSON with repeated keys) substantially, yet it consumes processor time, can increase latency on small messages, and does not provide schema evolution, type safety, or zero-copy field access. Format-aware techniques (variable-length integers, dictionary encoding, columnar layouts, omission of field names) remove redundancy **using knowledge of the data model**. Prefer first to select a format suited to the contract and access pattern; **then** apply compression when the network or storage tier still requires it and measurement supports the trade-off.
+**Serialization** defines *which bytes* represent which values—types, field identity, and layout. **Compression** is a largely **semantics-agnostic** transform: it exploits redundancy in a byte sequence without understanding the fields.
+
+Compression can shrink verbose encodings (for example JSON with repeated keys) substantially. It also consumes processor time, can increase latency on small messages, and does not provide schema evolution, type safety, or zero-copy field access. Format-aware techniques—variable-length integers, dictionary encoding, columnar layouts, omission of field names—remove redundancy **using knowledge of the data model**.
+
+Prefer first to select a format suited to the contract and access pattern. **Then** apply compression when the network or storage tier still needs it and measurement supports the trade-off.
 
 ---
 
@@ -37,7 +41,7 @@ That conclusion is sometimes operationally adequate. More often it conceals **pr
   Network or storage
 ```
 
-Layering is legitimate and common (for example `Content-Type: application/json` with `Content-Encoding: gzip`). Collapsing the two mechanisms into a single decision is the error.
+Layering is legitimate and common—for example `Content-Type: application/json` with `Content-Encoding: gzip`. Collapsing the two mechanisms into a single decision is the error.
 
 ---
 
@@ -59,7 +63,7 @@ Three logical records as JSON Lines:
 
 The substrings `"city"`, `"temp_c"`, `"unit"`, and `","unit":"C"}` recur. A compressor can replace repeated sequences with shorter references. After decompression, the receiver again holds the original JSON text and must still **parse** it.
 
-**Dense binary with little repetition** may shrink only modestly: there is less redundancy left to exploit. **Very small messages** may grow slightly (format headers and dictionaries) or fail to justify the processor cost of compression and decompression.
+**Dense binary with little repetition** may shrink only modestly, because there is less redundancy left to exploit. **Very small messages** may grow slightly (format headers and dictionaries) or fail to justify the processor cost of compression and decompression.
 
 ### Format-aware density (without a second codec stage)
 
@@ -68,7 +72,7 @@ Examples of structure reducing size **using knowledge of the model**:
 | Technique | Idea | Example context |
 |-----------|------|-----------------|
 | Omit repeated field names | Names live in a schema, not in every record | Schema-dependent encodings |
-| Variable-length integers | Small numbers use fewer bytes than fixed 64-bit fields | Many RPC binary formats |
+| Variable-length integers | Small numbers use fewer bytes than fixed 64-bit fields | Many RPC (remote procedure call) binary formats |
 | Enumerations | Store a small integer instead of a long string label | Status codes, units |
 | Columnar layout | Store one column contiguously; encode and compress per column | Parquet, ORC ([data science perspective](../101/data_science_perspective.md)) |
 | Domain encoding | Differences of timestamps; dictionary codes for categories | Analytics and telemetry |
@@ -77,7 +81,7 @@ These representations remain **interpretable under format rules**. A gzip bitstr
 
 ### Worked size intuition (order-of-magnitude, not a benchmark)
 
-Consider *N* identical logical records, each with the same three field names.
+Consider *N* identical logical records, each with the same three field names. Numbers in this table are teaching intuition only; suite **Results** own harness truth for measured codecs.
 
 | Approach | What is repeated *N* times | Typical implication |
 |----------|----------------------------|---------------------|
@@ -86,7 +90,7 @@ Consider *N* identical logical records, each with the same three field names.
 | Schema-dependent binary | Field numbers, not Unicode names | Often small before any compressor |
 | Schema-dependent binary + light compression | Residual redundancy only | Diminishing returns if already dense |
 
-Exact ratios depend on data and implementations; the table clarifies **which mechanism** removes which redundancy.
+Exact ratios depend on data and implementations. The table clarifies **which mechanism** removes which redundancy.
 
 ### Processor time and latency
 
@@ -98,7 +102,7 @@ Compression shifts cost from **bandwidth** to **processor time** at both ends. O
 
 ### Security and framing
 
-Compressed untrusted data has a history of **decompression bombs** (small inputs that expand to enormous outputs). Limits on decoded size matter whether the outer wrapper is HTTP or a custom stream. Compression also interacts with encryption (classical lessons such as CRIME/BREACH concern secrets adjacent to attacker-controlled plaintext under compression). Threat models for transport security must be considered explicitly when enabling compression.
+Compressed untrusted data has a history of **decompression bombs**—small inputs that expand to enormous outputs. Limits on decoded size matter whether the outer wrapper is HTTP or a custom stream. Compression also interacts with encryption; classical lessons such as CRIME/BREACH concern secrets adjacent to attacker-controlled plaintext under compression. Threat models for transport security must be considered explicitly when enabling compression.
 
 ---
 
@@ -106,7 +110,7 @@ Compressed untrusted data has a history of **decompression bombs** (small inputs
 
 | Axis | Compression applied to a verbose format | Denser format (with optional light compression) |
 |------|------------------------------------------|--------------------------------------------------|
-| Size | Often large reductions on JSON-like data | Competitive; less trivial redundancy |
+| Size | Often large reductions on JSON-like data | Competitive; less trivial redundancy left |
 | Processor time | Extra work on every message | More work in encode/decode; less in compress |
 | Latency | Can harm small, frequent messages; can help large transfers on slow links | Depends on the codec; no universal rule |
 | Random access | Often requires decompressing a stream or block first | Some formats permit field- or column-level access |
@@ -117,38 +121,38 @@ Compressed untrusted data has a history of **decompression bombs** (small inputs
 
 ## Illustrative scenarios
 
-**A. Public API.** JSON is retained for partners. Enabling gzip at the edge reduces transfer size enough that a format migration can be deferred—appropriate **if** processor capacity is sufficient and payloads are large enough.
+**A. Public API.** JSON is retained for partners. Enabling gzip at the edge reduces transfer size enough that a format migration can be deferred. That is appropriate **if** processor capacity is sufficient and payloads are large enough.
 
 **B. Internal high-frequency path.** Multi-megabyte JSON arrays move between services on a high-speed local network with gzip enabled by default. Profiles show processors busy in deflate while network interfaces remain underutilized. A dense binary schema **without** compression (or with a cheaper algorithm applied only to larger batches) may improve tail latency more than further gzip tuning.
 
-**C. Analytical lake.** Gzip-compressed JSON lines accumulate for a year. Query engines scan far more data than a Parquet layout with columnar encodings would require. Compression was applied; **the format remained poorly matched to analytical access**.
+**C. Analytical lake.** Gzip-compressed JSON lines accumulate for a year. Query engines scan far more data than a Parquet layout with columnar encodings would require. Compression was applied, but **the format remained poorly matched to analytical access**.
 
 ---
 
 ## In this suite
 
-The harness measures **serializer** behaviour (encode and decode of logical fixtures), not a full matrix of compress-wrapped transports. **Results** should not be read as “gzip is unnecessary” or “binary is mandatory.” Use them to select a codec family and implementation; evaluate compression on the deployment path separately (or as an explicit follow-on experiment outside the core tables).
+The harness measures **serializer** behaviour—encode and decode of logical fixtures—not a full matrix of compress-wrapped transports. **Results** should not be read as “gzip is unnecessary” or “binary is mandatory.” Use them to select a codec family and implementation; evaluate compression on the deployment path separately (or as an explicit follow-on experiment outside the core tables).
 
 ---
 
 ## Common errors of reasoning
 
-- Treating `gzip(JSON)` as architecturally equivalent to a schema-driven binary protocol.  
-- Compressing tiny, high-frequency remote calls by default “for consistency.”  
-- Ignoring the combined processor budget of encryption, compression, and encoding.  
-- Expecting already-compressed media (images, video) to benefit from another general-purpose compression layer on the same bytes.  
+- Treating `gzip(JSON)` as architecturally equivalent to a schema-driven binary protocol.
+- Compressing tiny, high-frequency remote calls by default “for consistency.”
+- Ignoring the combined processor budget of encryption, compression, and encoding.
+- Expecting already-compressed media (images, video) to benefit from another general-purpose compression layer on the same bytes.
 - Interpreting successful compression as permission to omit validation and evolution design.
 
 ---
 
 ## Key takeaways
 
-- Serialization chooses a **meaning-bearing layout**; compression exploits **byte-level redundancy**.  
-- Both can reduce size; only the format defines types, evolution, and access patterns.  
-- JSON with gzip can be a valid edge strategy; it is not a universal architecture.  
-- Dense, schema-aware encodings remove redundancy that a compressor would otherwise re-discover—often with better access properties.  
-- Account for **processor time and latency**, not only compressed size.  
-- Columnar and format-aware encoding for analytics differ from message codecs for remote procedure calls.  
+- Serialization chooses a **meaning-bearing layout**; compression exploits **byte-level redundancy**.
+- Both can reduce size; only the format defines types, evolution, and access patterns.
+- JSON with gzip can be a valid edge strategy; it is not a universal architecture.
+- Dense, schema-aware encodings remove redundancy that a compressor would otherwise re-discover—often with better access properties.
+- Account for **processor time and latency**, not only compressed size.
+- Columnar and format-aware encoding for analytics differ from message codecs for remote procedure calls.
 - Suite **Results** inform codec choice; re-measure with compression on the actual wire if compression is part of the design.
 
 ---

--- a/docs/theory/201/dynamic-vs-idl-binary.md
+++ b/docs/theory/201/dynamic-vs-idl-binary.md
@@ -6,18 +6,22 @@
 
 ## Problem
 
-Suppose text JSON is already judged unsuitable for a particular hop—payloads are large enough, or the path is sufficiently performance-sensitive, that a binary encoding is under consideration. Two frequent alternatives are:
+Suppose text JSON is already judged unsuitable for a particular hop—payloads are large enough, or the path is performance-sensitive enough, that a binary encoding is under consideration. Two frequent alternatives are:
 
-1. **Dynamic (schemaless) binary** — MessagePack, CBOR, and related formats: a data model similar to JSON, a binary encoding, little or no interface description language.  
-2. **IDL / schema-driven binary** — Protocol Buffers and related systems: a shared schema, field numbers, code generation, and explicit evolution discipline.
+1. **Dynamic (schemaless) binary** — MessagePack, CBOR, and related formats. They keep a data model similar to JSON, use a binary encoding, and need little or no interface description language (IDL = a formal shared description of messages and field types).
+2. **IDL / schema-driven binary** — Protocol Buffers and related systems. They use a shared schema, field numbers, code generation, and explicit evolution discipline.
 
-Selections are often driven by popularity or by a single latency chart. A durable choice instead tracks **how flexible the data model must remain** and **how much investment will be made in a shared contract**.
+Selections are often driven by popularity or by a single latency chart. A durable choice instead tracks **how flexible the data model must remain** and **how much investment you will make in a shared contract**.
 
 ---
 
 ## Short answer
 
-**Dynamic binary** encodings preserve a flexible model of maps, arrays, and scalars, and usually place **type tags** and often **string keys** on the wire. They are a reasonable default for internal services and caches that seek smaller or faster-than-JSON payloads without operating a full IDL toolchain—**validation and compatibility remain the organization’s responsibility**. **IDL binary** encodings move names into a schema, encode **field numbers** (or equivalent identifiers), and support code generation, higher density, and multi-language stubs—at the cost of schema design, generation in continuous integration, and a process for change. Prefer dynamic binary when document shapes vary and consumers are loosely coupled; prefer IDL binary when the record shape is a product interface that will be versioned for years across languages.
+**Dynamic binary** encodings preserve a flexible model of maps, arrays, and scalars, and usually place **type tags** and often **string keys** on the wire. They are a reasonable default for internal services and caches that want smaller or faster-than-JSON payloads without operating a full IDL toolchain. **Validation and compatibility remain the organization’s responsibility.**
+
+**IDL binary** encodings move names into a schema, encode **field numbers** (or equivalent identifiers), and support code generation, higher density, and multi-language stubs. The cost is schema design, generation in continuous integration, and a process for change.
+
+Prefer dynamic binary when document shapes vary and consumers are loosely coupled. Prefer IDL binary when the record shape is a product interface that will be versioned for years across languages.
 
 ---
 
@@ -40,7 +44,7 @@ Selections are often driven by popularity or by a single latency chart. A durabl
    document compatibility    + compatibility rules
 ```
 
-Related dynamic formats (CBOR, BSON, and others) differ in type systems and ecosystem fit; the **decision axis relative to IDL binary** remains the same.
+Related dynamic formats (CBOR, BSON, and others) differ in type systems and ecosystem fit. The **decision axis relative to IDL binary** remains the same.
 
 ---
 
@@ -58,17 +62,17 @@ Related dynamic formats (CBOR, BSON, and others) differ in type systems and ecos
     [tag: small integer]    42
 ```
 
-Exact tags differ by format; the pedagogical point is:
+Exact tags differ by format. The teaching points are:
 
-- structure is discovered from **tags in the stream**;  
-- **keys often remain strings**, so messages stay self-describing at the cost of repeating those keys;  
+- structure is discovered from **tags in the stream**;
+- **keys often remain strings**, so messages stay self-describing at the cost of repeating those keys;
 - decimal digit conversion is avoided relative to JSON text.
 
 **Evolution.** Change control is largely a social and testing process, optionally assisted by external schemas (for example JSON Schema–like definitions or shared types in source control).
 
 ### IDL binary encodings (Protocol Buffers class)
 
-**Interface description.** Designers declare messages in an IDL; tools generate types and encoders for each supported language.
+**Interface description.** Designers declare messages in an IDL. Tools generate types and encoders for each supported language.
 
 **Encoding idea (beginner sketch).** With schema
 
@@ -95,8 +99,8 @@ Logical value: `id = 42`, `label = "x"`.
 
 ### What this comparison is not
 
-- Not “Protocol Buffers versus Avro” (both are schema-centric; operational cultures differ—see the [data science perspective](../101/data_science_perspective.md) for Avro-oriented workloads).  
-- Not “binary versus zero-copy” (FlatBuffers-class designs are a separate point—[zero-copy layouts](zero-copy.md)).  
+- Not “Protocol Buffers versus Avro.” Both are schema-centric; operational cultures differ—see the [data science perspective](../101/data_science_perspective.md) for Avro-oriented workloads.
+- Not “binary versus zero-copy.” FlatBuffers-class designs are a separate point; see [zero-copy layouts](zero-copy.md).
 - Not a guarantee that any MessagePack library outperforms any Protocol Buffers library in a given language.
 
 ---
@@ -109,7 +113,7 @@ Logical value: `id = 42`, `label = "x"`.
 | Processor time | Efficient parsers exist; tag and key handling remain | Excellent with code generation; weaker if used only reflectively |
 | Flexibility | High—maps and optional keys are natural | Schema changes are deliberate |
 | Multiple languages | Broad library support without a single IDL | Strong when all languages participate in code generation |
-| Operability | Pretty-printing tools required for support | Schema versions required on debug paths |
+| Operability | Pretty-printing tools are needed for support | Schema versions are needed on debug paths |
 | Process cost | Low ceremony; risk of silent divergence | Higher ceremony; clearer shared types |
 | Security | Depth and size limits; validate untrusted data | Same; generated types do not authenticate the sender |
 
@@ -136,21 +140,21 @@ Compare **within one language**, and prefer same-family charts when asking wheth
 
 ## Common errors of reasoning
 
-- Selecting Protocol Buffers “for speed” when the primary difficulty was public API inspectability (JSON at the edge may remain appropriate).  
-- Adopting MessagePack without validation of untrusted input.  
-- Expecting dynamic binary encodings that carry long Unicode keys to match IDL density.  
-- Adopting an IDL without continuous-integration checks for compatibility or clear ownership of schema files.  
+- Selecting Protocol Buffers “for speed” when the primary difficulty was public API inspectability. JSON at the edge may remain appropriate.
+- Adopting MessagePack without validation of untrusted input.
+- Expecting dynamic binary encodings that carry long Unicode keys to match IDL density.
+- Adopting an IDL without continuous-integration checks for compatibility or clear ownership of schema files.
 - Mixing dynamic maps and generated types on one hop without an explicit translation boundary.
 
 ---
 
 ## Key takeaways
 
-- After rejecting JSON for a hop, the principal fork is **flexible documents** versus **stable multi-language records**.  
-- Dynamic binary ≈ JSON-like data model with a binary encoding; the organization still owns the contract.  
-- IDL binary ≈ shared schema, field numbers, code generation, and an evolution process.  
-- Size and speed depend on implementation and on whether keys or names remain on the wire.  
-- Use suite **Results** per language; do not treat informal ranking articles as policy.  
+- After rejecting JSON for a hop, the principal fork is **flexible documents** versus **stable multi-language records**.
+- Dynamic binary is roughly a JSON-like data model with a binary encoding; the organization still owns the contract.
+- IDL binary is a shared schema, field numbers, code generation, and an evolution process.
+- Size and speed depend on implementation and on whether keys or names remain on the wire.
+- Use suite **Results** per language; do not treat informal ranking articles as policy.
 - Match process cost to the lifetime of the contract and the number of languages that share it.
 
 ---

--- a/docs/theory/201/encode-decode-cost.md
+++ b/docs/theory/201/encode-decode-cost.md
@@ -6,13 +6,17 @@
 
 ## Problem
 
-Informal comparisons frequently declare a format “winner” from a single chart (“replace text with binary and improve performance by an order of magnitude”). Organizations then change codecs and observe little improvement—or a regression—because the limiting factor was never “text versus binary” as an abstract dichotomy. The dominant costs are typically **tokenization**, **numeric conversion**, **memory allocation**, **copying**, and **payload shape**.
+People sometimes declare a format “winner” from a single chart—“replace text with binary and improve performance by an order of magnitude.” Organizations then change codecs and see little improvement, or even a regression, because the limiting factor was never “text versus binary” as an abstract dichotomy. The dominant costs are typically **tokenization** (finding structure in the bytes), **numeric conversion**, **memory allocation**, **copying**, and **payload shape**.
 
 ---
 
 ## Short answer
 
-The cost of encoding and decoding is the sum of several mechanisms. Text formats (notably JSON) expend work on scanning character encodings such as UTF-8, recognizing structural tokens, unescaping strings, and converting **decimal digit sequences** into the binary integer and floating-point representations used by the processor. Binary formats ordinarily avoid decimal text and often omit repeated field *names*, yet they still incur cost for length prefixes, type tags or field numbers, validation, and construction of language-level objects. In managed runtimes, **allocation rate and garbage collection** frequently dominate the time spent in the encode or decode routine itself. A carefully engineered JSON implementation may outperform an inefficient binary stack; a payload composed of many small, pointer-linked objects stresses every codec.
+The cost of encoding and decoding is the sum of several mechanisms, not one magic property of “text” or “binary.”
+
+Text formats—especially JSON—spend work scanning character encodings such as UTF-8, recognizing structural tokens, unescaping strings, and converting **decimal digit sequences** into the binary integer and floating-point forms the processor actually uses. Binary formats usually avoid decimal text and often omit repeated field *names*, yet they still pay for length prefixes, type tags or field numbers, validation, and construction of language-level objects.
+
+In managed runtimes, **allocation rate and garbage collection** (GC = automatic reclamation of unused memory) often dominate the time spent inside the encode or decode routine itself. A carefully engineered JSON implementation may outperform an inefficient binary stack. A payload made of many small, pointer-linked objects stresses every codec.
 
 ---
 
@@ -35,10 +39,10 @@ The cost of encoding and decoding is the sum of several mechanisms. Text formats
   In-memory values again
 ```
 
-For any performance-critical path, the useful questions are:
+For any performance-critical path, useful questions include:
 
-1. How many times is each byte examined?  
-2. How many distinct heap objects are created?  
+1. How many times is each byte examined?
+2. How many distinct heap objects are created?
 3. How often are values converted between **decimal text** and **binary numeric forms**?
 
 ---
@@ -53,20 +57,20 @@ Consider a minimal JSON object:
 {"id": 42, "temp_c": 21.5, "label": "sensor-7"}
 ```
 
-As **text**, this is a sequence of characters (commonly UTF-8 bytes). The processor does not “natively” understand braces or the decimal notation `21.5`. A JSON decoder must, among other steps:
+As **text**, this is a sequence of characters, commonly stored as UTF-8 bytes. The processor does not “natively” understand braces or the decimal notation `21.5`. A JSON decoder must, among other steps:
 
-1. **Discover structure** — locate `{`, `:`, `,`, `}`, and string delimiters. Simple parsers do this with many conditional branches; highly optimized parsers may use SIMD instructions, but the logical task remains structure discovery.
-2. **Interpret strings** — read the bytes between quotes; apply escape rules (for example, `\n`); often allocate a string object in the language runtime.
-3. **Interpret numbers** — read the characters `2`, `1`, `.`, `5` and compute the binary floating-point value that the CPU will use in arithmetic. That conversion is non-trivial and can dominate runtime on numeric-heavy payloads.
+1. **Discover structure** — locate `{`, `:`, `,`, `}`, and string delimiters. Simple parsers do this with many conditional branches. Highly optimized parsers may use SIMD (single instruction, multiple data) instructions, but the logical task remains structure discovery.
+2. **Interpret strings** — read the bytes between quotes; apply escape rules (for example `\n`); often allocate a string object in the language runtime.
+3. **Interpret numbers** — read the characters `2`, `1`, `.`, `5` and compute the binary floating-point value the CPU will use in arithmetic. That conversion is non-trivial and can dominate runtime on numeric-heavy payloads.
 4. **On encode (printing)** — convert binary integers and floats back into decimal digit characters; escape strings; emit punctuation.
 
 **Worked contrast for one integer.** The logical value forty-two may appear as:
 
 | Representation | Illustrative bytes (concept) | Work to obtain a machine integer |
 |----------------|------------------------------|----------------------------------|
-| JSON text `"id": 42` | characters `4` and `2` (plus structural context) | scan digits; multiply/accumulate to form 42 |
-| Fixed 32-bit little-endian binary | four bytes, e.g. `2a 00 00 00` | load four bytes with a known byte order |
-| Compact binary “varint” (sketch) | one or more bytes encoding small integers densely | loop over continuation bits; shift and combine |
+| JSON text `"id": 42` | characters `4` and `2`, plus surrounding structure | Scan the digits, then multiply and accumulate to form 42 |
+| Fixed 32-bit little-endian binary | four bytes, for example `2a 00 00 00` | Load four bytes with a known byte order |
+| Compact binary “varint” (sketch) | one or more bytes encoding small integers densely | Loop over continuation bits, then shift and combine |
 
 No row is universally “best.” The table only makes visible **where processor time goes**.
 
@@ -74,14 +78,14 @@ No row is universally “best.” The table only makes visible **where processor
 
 Even without human-oriented punctuation, many binary formats still carry **descriptive metadata**:
 
-- **Type tags** — e.g. “the next value is a 32-bit integer,” “the next value is a UTF-8 string of length *n*.”  
-- **Field names** — string keys such as `"temp_c"` repeated for every record (common in MessagePack maps and in JSON).
+- **Type tags** — for example “the next value is a 32-bit integer,” or “the next value is a UTF-8 string of length *n*.”
+- **Field names** — string keys such as `"temp_c"` repeated for every record. This is common in MessagePack maps and in JSON.
 
-Schema-dependent formats such as Protocol Buffers typically replace names on the wire with **small field numbers** defined in a shared schema, reducing per-message metadata at the cost of an out-of-band contract. See [Self-describing vs schema](self-describing-vs-schema-dependent.md).
+Schema-dependent formats such as Protocol Buffers typically replace names on the wire with **small field numbers** defined in a shared schema. That reduces per-message metadata at the cost of an out-of-band contract. See [Self-describing vs schema](self-describing-vs-schema-dependent.md).
 
 ### Memory allocation and copying
 
-A common decode path in managed languages (Python, Java, C#, JavaScript, and similar environments) is:
+A common decode path in managed languages (Python, Java, C#, JavaScript, and similar environments) looks like this:
 
 ```text
   byte buffer
@@ -90,13 +94,13 @@ A common decode path in managed languages (Python, Java, C#, JavaScript, and sim
       → return a fully populated graph
 ```
 
-Each allocation has a direct cost and contributes to later **garbage collection** work, which can increase latency variability (tail latency). Alternative designs reduce that cost:
+Each allocation has a direct cost and contributes to later **garbage collection** work, which can increase latency variability (tail latency—the slowest requests). Alternative designs reduce that cost:
 
-- decode into a preallocated structure;  
-- reuse buffers across requests;  
+- decode into a preallocated structure;
+- reuse buffers across requests;
 - expose **views** into the existing byte buffer (related to [zero-copy layouts](zero-copy.md)).
 
-Empirically, “a faster serializer” in managed languages often means **fewer allocations**, not merely fewer arithmetic instructions inside the encode loop.
+In practice, “a faster serializer” in managed languages often means **fewer allocations**, not merely fewer arithmetic instructions inside the encode loop.
 
 ### Payload shape
 
@@ -104,10 +108,10 @@ Two messages with the same logical “size in fields” can behave very differen
 
 | Shape (illustrative) | Characteristic cost |
 |----------------------|---------------------|
-| One flat record: a few large integers and one large binary blob | Fewer objects; more bulk memory copy bandwidth |
+| One flat record: a few large integers and one large binary blob | Fewer objects; more bulk memory-copy bandwidth |
 | A deep tree: hundreds of small nested objects and short strings | Many allocations; poor locality (scattered memory access) |
 
-**Shape can matter as much as the choice of format family.** This suite uses controlled fixtures so comparisons remain interpretable within a language; see [Test Data](../../analysis/test_data_configuration.md).
+**Shape can matter as much as the choice of format family.** This suite uses controlled fixtures so comparisons stay interpretable within a language; see [Test Data](../../analysis/test_data_configuration.md).
 
 ### Implementation quality
 
@@ -119,19 +123,19 @@ The label “JSON” covers both pedagogical recursive parsers and highly optimi
 
 | Axis | Factors that often dominate | Attribution that is often too coarse |
 |------|------------------------------|--------------------------------------|
-| Processor time | Numeric parse/print; token scanning; UTF-8 handling; varint loops | “We used JSON” treated as a single boolean |
-| Memory / allocations | Per-field objects; intermediate strings; map nodes | Format family alone |
-| Size / bandwidth | Repeated keys; decimal digits; optional whitespace | Assuming binary is always superior on a high-speed local network |
-| Latency tails | Garbage-collection pauses after allocation spikes | Mean encode time alone |
+| Processor time | Numeric parse and print; token scanning; UTF-8 handling; varint loops | Treating “we used JSON” as a single yes/no fact |
+| Memory / allocations | Per-field objects; intermediate strings; map nodes | Blaming only the format family |
+| Size / bandwidth | Repeated keys; decimal digits; optional whitespace | Assuming binary is always better on a high-speed local network |
+| Latency tails | Garbage-collection pauses after allocation spikes | Looking only at mean encode time |
 | Operability | Text logs versus the need for binary decoders | — |
 
 ---
 
 ## Illustrative scenarios
 
-**Scenario A — numeric telemetry over a wide-area network.** An internal service returns large JSON arrays of floating-point measurements. A schemaless binary encoding reduces transfer size and can help distant clients. On a CPU-bound service on a local high-speed network, gains may remain modest if each request still **materializes thousands of small objects**. Object reuse or a code-generated schema codec may change performance more than substituting “binary” as a slogan.
+**Scenario A — numeric telemetry over a wide-area network.** An internal service returns large JSON arrays of floating-point measurements. A schemaless binary encoding reduces transfer size and can help distant clients. On a CPU-bound service on a local high-speed network, gains may stay modest if each request still **materializes thousands of small objects**. Object reuse or a code-generated schema codec may change performance more than substituting “binary” as a slogan.
 
-**Scenario B — public HTTP API.** An organization may retain JSON for inspectability and interoperability, and still meet latency objectives by adopting a more efficient JSON implementation, without changing the public contract.
+**Scenario B — public HTTP API.** An organization may keep JSON for inspectability and interoperability, and still meet latency goals by adopting a more efficient JSON implementation, without changing the public contract.
 
 ---
 
@@ -145,21 +149,21 @@ Methodology and metric definitions: [Analysis methodology](../../analysis/ANALYS
 
 ## Common errors of reasoning
 
-- Concluding that “JSON is slow” without specifying **which library** and **which payload**.  
-- Expecting a schemaless binary format that still carries string keys to match the density of a schema-dependent encoding.  
-- Changing only the codec while allocating a new object graph on every request.  
-- Extrapolating from microbenchmarks on tiny messages to multi-megabyte documents (or the reverse).  
+- Concluding that “JSON is slow” without saying **which library** and **which payload**.
+- Expecting a schemaless binary format that still carries string keys to match the density of a schema-dependent encoding.
+- Changing only the codec while still allocating a new object graph on every request.
+- Extrapolating from microbenchmarks on tiny messages to multi-megabyte documents (or the reverse).
 - Comparing a fully warmed, code-generated path with a cold, reflective path and treating the result as a law of formats.
 
 ---
 
 ## Key takeaways
 
-- Total cost comprises parse and print work, metadata handling, allocations and copies, payload shape, and implementation quality.  
-- Distinctive costs of text formats often arise from **structure discovery** and **decimal numeric conversion**, not from “using characters” in the abstract.  
-- Binary encodings remove some costs and introduce others (tags, variable-length integers, schema tooling).  
-- In managed languages, **allocation rate** is a first-class performance consideration.  
-- Prefer paradigm-local, same-language evidence from **Results** over informal ranking articles.  
-- Format choice should reflect the full constraint set (debugging, evolution, multiple languages), not processor time alone.
+- Total cost includes parse and print work, metadata handling, allocations and copies, payload shape, and implementation quality.
+- Distinctive costs of text formats often come from **structure discovery** and **decimal numeric conversion**, not from “using characters” in the abstract.
+- Binary encodings remove some costs and introduce others (tags, variable-length integers, schema tooling).
+- In managed languages, **allocation rate** is a first-class performance concern.
+- Prefer paradigm-local, same-language evidence from **Results** over informal ranking articles.
+- Format choice should reflect the full constraint set—debugging, evolution, multiple languages—not processor time alone.
 
 ---

--- a/docs/theory/201/index.md
+++ b/docs/theory/201/index.md
@@ -1,19 +1,19 @@
 # Serialization 201
 
-Short, problem-driven essays on **how serialization mechanisms work**. They sit between the [101 home](../101/index.md) / three lenses and later courses (**301** production judgment, **401** implementers) plus suite [categories](../../analysis/serialization_categories.md) + language **Results**.
+These short essays explain **how serialization mechanisms work**. They sit between the [101 home](../101/index.md) and its three lenses on one side, and later courses on the other: **301** for production judgment and **401** for people who implement codecs. You will also want the suite [categories](../../analysis/serialization_categories.md) and language **Results** pages when you care about measured numbers.
 
-Theory alone does not decide production choices. Use these pages to build mechanism-level models, then validate with measured libraries and—when choosing under multi-constraint production pressure—continue to advanced courses as they ship.
+Theory alone does not decide what you should ship. Use these pages to build clear mental models of the mechanisms, then check those models against real libraries. When you must choose under several production constraints at once, continue into the advanced courses as they become available.
 
 ---
 
 ## How to use this track
 
-1. Skim [Serialization 101](../101/index.md) (definitions and trade-off axes).
-2. Optionally read one lens: [Historical](../101/historical_perspective.md), [Data science](../101/data_science_perspective.md), or [Engineering](../101/engineer_perspective.md).
-3. Work the articles below when you need *how* or *why*.
-4. Open [Serialization categories](../../analysis/serialization_categories.md) and a language **Results** page for numbers on *this* harness.
+1. Skim [Serialization 101](../101/index.md) so the basic definitions and trade-off axes feel familiar.
+2. Optionally read one lens that matches your work: [Historical](../101/historical_perspective.md), [Data science](../101/data_science_perspective.md), or [Engineering](../101/engineer_perspective.md).
+3. Work through the articles below when you need a clearer *how* or *why* for a mechanism.
+4. Open [Serialization categories](../../analysis/serialization_categories.md) and a language **Results** page for numbers measured on *this* harness.
 
-**Honesty rules (same as Serialization 101):** no universal winners; implementation beats brand name; payload shape matters; compare within paradigm and language; prose numbers are illustrative—**Results** own suite truth.
+**Honesty rules (same as Serialization 101):** there are no universal winners. Implementation quality often matters more than the brand name of a format. Payload shape changes costs a lot. Compare within one paradigm and one language when you can. Numbers that appear in prose are only illustrations; the suite **Results** pages own the truth for this harness.
 
 ---
 
@@ -21,13 +21,13 @@ Theory alone does not decide production choices. Use these pages to build mechan
 
 | Step | Article | You should be able to… |
 |------|---------|------------------------|
-| 1 | [Memory layout](memory-layout.md) | Explain why a raw memory dump is not a portable format |
-| 2 | [Encode/decode cost](encode-decode-cost.md) | Name the real cost centers (parse, numbers, alloc, copy)—not an unqualified claim that JSON is slow |
-| 3 | [Self-describing vs schema](self-describing-vs-schema-dependent.md) | Say who carries field identity: payload or shared contract |
-| 4 | [Schema evolution](schema-evolution.md) | Plan additive change without breaking old readers/writers |
-| 5 | [Dynamic vs IDL binary](dynamic-vs-idl-binary.md) | Choose MessagePack/CBOR-class vs Protobuf-class for a workload |
-| 6 | [Zero-copy](zero-copy.md) | Explain what “no deserialize” means—and what it still costs |
-| 7 | [Compression vs format](compression-is-not-a-format.md) | Separate gzip-on-the-wire from format-aware density |
+| 1 | [Memory layout](memory-layout.md) | Explain why dumping raw process memory is not a portable interchange format |
+| 2 | [Encode/decode cost](encode-decode-cost.md) | Name the real cost centers (parsing structure, converting numbers, allocating, copying)—instead of saying only that “JSON is slow” |
+| 3 | [Self-describing vs schema](self-describing-vs-schema-dependent.md) | Say whether field identity lives in the payload itself or in a shared contract outside the message |
+| 4 | [Schema evolution](schema-evolution.md) | Plan additive changes that keep older readers and writers working during a rollout |
+| 5 | [Dynamic vs IDL binary](dynamic-vs-idl-binary.md) | Choose a MessagePack/CBOR-class encoding versus a Protocol Buffers–class encoding for a given workload (IDL = interface description language) |
+| 6 | [Zero-copy](zero-copy.md) | Explain what “no deserialize” usually means in marketing language—and what that design still costs |
+| 7 | [Compression vs format](compression-is-not-a-format.md) | Separate gzip-style compression on the wire from density that comes from the format itself |
 
 ---
 
@@ -64,10 +64,10 @@ Theory alone does not decide production choices. Use these pages to build mechan
 | [Dynamic vs IDL binary](../notebooks/201/dynamic_vs_idl_binary.ipynb) | [Dynamic vs IDL binary](dynamic-vs-idl-binary.md) |
 | [Compression vs format](../notebooks/201/compression_vs_format.ipynb) | [Compression vs format](compression-is-not-a-format.md) |
 
-Install notes: [notebooks README](../notebooks/README.md).
+Install notes live in the [notebooks README](../notebooks/README.md).
 
 ## Where to go next
 
-- **Core path:** [Serialization 301](../301/index.md) — production judgment under constraints  
-- **Implementer elective:** [Serialization 401](../401/index.md) — wire + language paths + lab  
-- [Serialization categories](../../analysis/serialization_categories.md) · [Engineering](../101/engineer_perspective.md) · [Data science](../101/data_science_perspective.md) · [Benchmarks](../../analysis/index.md)
+- **Core path:** [Serialization 301](../301/index.md) — production judgment when several constraints pull at once.
+- **Implementer elective:** [Serialization 401](../401/index.md) — wire formats, language-specific paths, and a hands-on lab.
+- Related reference pages: [Serialization categories](../../analysis/serialization_categories.md), [Engineering](../101/engineer_perspective.md), [Data science](../101/data_science_perspective.md), and [Benchmarks](../../analysis/index.md).

--- a/docs/theory/201/memory-layout.md
+++ b/docs/theory/201/memory-layout.md
@@ -2,21 +2,23 @@
 
 ## Problem
 
-A structure in C, a record in Go, or an object graph in a managed language occupies a region of the process’s address space. Writing that region to disk or to a network socket appears inexpensive: no schema file, no serialization library, and high throughput on *this* machine.
+A structure in C, a record in Go, or an object graph in a managed language sits somewhere in the process’s address space—the region of memory that process can use. Writing that region to disk or to a network socket can look very cheap: you need no schema file, no serialization library, and you can get high throughput on *this* machine.
 
-A second process—implemented in another language, running on another processor architecture, or built with different structure-packing rules—may then read those bytes and obtain incorrect values, fail abruptly, or interpret numbers silently wrong. Serialization exists largely because **in-memory layout is not a contract between machines**.
+A second process may then try to read those same bytes. That second process might be written in another language, run on another processor architecture, or use different structure-packing rules. It can then obtain incorrect values, crash, or silently misread numbers. Serialization exists largely because **in-memory layout is not a contract between machines**.
 
 ---
 
 ## Short answer
 
-Compilers and language runtimes place fields in memory for **the local processor and operating environment**: native integer widths, pointer sizes, alignment padding, and often **host byte order**. Those placement rules are part of how a given platform expects machine code and data to look in RAM; they are chosen for local efficiency, not for exchange with other machines. Networks and durable storage exchange only a **linear sequence of bytes under an agreed interpretation**. A portable format must define field order, sizes (or length prefixes), padding (or its absence), and endianness—or it must be self-describing enough that readers need not assume the writer’s in-memory layout. Raw memory dumps optimise for one process image; interchange formats optimise for a shared contract.
+Compilers and language runtimes place fields in memory for **the local processor and operating environment**. That includes native integer widths, pointer sizes, alignment padding (unused bytes inserted so fields sit on convenient addresses), and often **host byte order**—the order in which multi-byte numbers are stored. Those placement rules exist so *this* machine can run efficiently. They are not designed so that another machine can understand the same bytes.
+
+Networks and durable storage only exchange a **linear sequence of bytes under an agreed interpretation**. A portable format must define field order, sizes (or length prefixes), padding (or its absence), and endianness (byte order for multi-byte values). Alternatively, the format must be self-describing enough that readers do not need to assume the writer’s in-memory layout. Raw memory dumps optimize for one process image. Interchange formats optimize for a shared contract.
 
 ---
 
 ## Mental model
 
-Main memory may be viewed as a linear array of **bytes** (integer values from 0 through 255), each identified by an address 0, 1, 2, …. Program variables and objects are **contiguous or linked groups of those bytes**, interpreted under a rule (“these four bytes constitute a 32-bit integer,” “these eight bytes constitute an address of further bytes,” and so on).
+Think of main memory as a linear array of **bytes** (integer values from 0 through 255). Each byte has an address: 0, 1, 2, and so on. Program variables and objects are **contiguous or linked groups of those bytes**, interpreted under a rule such as “these four bytes constitute a 32-bit integer” or “these eight bytes constitute an address of further bytes.”
 
 ```text
   In-memory (one process)              On the wire (agreed contract)
@@ -31,7 +33,7 @@ Main memory may be viewed as a linear array of **bytes** (integer values from 0 
               rebuild local objects or views
 ```
 
-A dump of process-local memory includes padding, pointer addresses, and host-specific byte order. Another machine cannot treat that sequence as the same values unless the parties **define a contract** (a serialization format).
+A dump of process-local memory includes padding, pointer addresses, and host-specific byte order. Another machine cannot treat that sequence as the same values unless both sides **define a contract**—in other words, a serialization format.
 
 ---
 
@@ -39,22 +41,22 @@ A dump of process-local memory includes padding, pointer addresses, and host-spe
 
 ### Representations of common values as bytes
 
-Detailed processor microarchitecture is unnecessary here. The essential questions are: **how many bytes does this value occupy**, and **does the variable store the value itself or a reference to bytes stored elsewhere?**
+You do not need detailed processor microarchitecture for this course. The essential questions are simpler: **how many bytes does this value occupy**, and **does the variable store the value itself or a reference to bytes stored elsewhere?**
 
-| Kind of value (typical modern desktop or server) | Width | Contents at the variable’s address |
+| Kind of value (typical modern desktop or server) | Width | What sits at the variable’s address |
 |--------------------------------------------------|-------|-------------------------------------|
 | Small integer (8-bit unsigned) | 1 byte | The integer itself (0–255) |
-| 32-bit integer (e.g. C `int32_t`) | 4 bytes | The integer, split across four bytes (order determined by endianness) |
-| 64-bit integer | 8 bytes | As above, eight bytes |
+| 32-bit integer (for example C `int32_t`) | 4 bytes | The integer, split across four bytes; the order depends on endianness |
+| 64-bit integer | 8 bytes | The same idea as above, using eight bytes |
 | 32-bit binary floating-point (`float`) | 4 bytes | An IEEE 754 bit pattern—not the decimal characters of a printed number |
-| 64-bit binary floating-point (`double`) | 8 bytes | As above, eight bytes |
+| 64-bit binary floating-point (`double`) | 8 bytes | The same idea as above, using eight bytes |
 | Fixed array of three bytes | 3 bytes (padding may follow inside a structure) | Those three bytes in order |
 | Text string in C (`char *`) | Pointer width (often 8 bytes on 64-bit processes) | An **address** of character data elsewhere—not the characters themselves |
-| Text string in Python, Java, C#, or JavaScript | A **reference** to a heap object | Length, character data, and type metadata live in that object, not as a single trivial blob at the variable |
+| Text string in Python, Java, C#, or JavaScript | A **reference** to a heap object | Length, character data, and type metadata live in that object, not as one simple blob at the variable |
 
-**Integer example (before endianness).** The integer 305 419 896 is commonly written in hexadecimal as `0x12345678`. As a 32-bit integer it occupies **four** bytes. Which address receives `0x12` versus `0x78` is a matter of **endianness** (below). The pedagogical point: **the value is not stored as the decimal characters** `3` `0` `5` … unless a text format such as JSON is used deliberately.
+**Integer example (before endianness).** The integer 305 419 896 is commonly written in hexadecimal as `0x12345678`. As a 32-bit integer it occupies **four** bytes. Which address receives `0x12` versus `0x78` is a matter of **endianness**, discussed below. The teaching point is simple: **the value is not stored as the decimal characters** `3` `0` `5` … unless you deliberately use a text format such as JSON.
 
-**Floating-point example.** The value `1.5` as a 32-bit binary float is a specific 32-bit pattern defined by IEEE 754—not the three characters `1`, `.`, and `5`. Text is appropriate for human display; processors perform arithmetic on the binary pattern.
+**Floating-point example.** The value `1.5` as a 32-bit binary float is a specific 32-bit pattern defined by IEEE 754—not the three characters `1`, `.`, and `5`. Text is appropriate for human display. Processors perform arithmetic on the binary pattern.
 
 **String example (why copying the variable fails as interchange):**
 
@@ -65,33 +67,33 @@ Detailed processor microarchitecture is unnecessary here. The essential question
   └──────────────────────────┘                 (or a richer string object)
 ```
 
-Copying only those eight bytes copies an **address that is meaningless in another process**. A serialization format must transmit the **character data** (with length or terminator rules), not the pointer.
+If you copy only those eight bytes, you copy an **address that is meaningless in another process**. A serialization format must transmit the **character data** (with length or terminator rules), not the pointer.
 
 ### Field order and padding
 
-A **structure** or **record** comprises several fields placed at successive addresses. Two facts matter for binary dumps:
+A **structure** or **record** is several fields placed at successive addresses. Two facts matter for binary dumps:
 
-1. **Order** — which field occupies the lower addresses (often declaration order in C-like languages, though not a universal law).  
+1. **Order** — which field occupies the lower addresses. In C-like languages this is often declaration order, though that is not a universal law.
 2. **Padding** — unused bytes inserted so that the *next* field begins at an address the processor can load efficiently (for example, a multiple of four or eight).
 
 #### Why padding exists
 
-Many processors load a four-byte integer most efficiently when its starting address is a **multiple of four** (and an eight-byte quantity when the address is a multiple of eight). Compilers **align** fields to such boundaries by inserting unused **padding** bytes. Those bytes do not appear in source code; they still appear in memory and in an uninterpreted memory dump.
+Many processors load a four-byte integer most efficiently when its starting address is a **multiple of four**, and an eight-byte quantity when the address is a multiple of eight. Compilers **align** fields to such boundaries by inserting unused **padding** bytes. Those bytes do not appear in your source code. They still appear in memory, and they still appear in an uninterpreted memory dump.
 
-Simplified rules used by many C compilers on common desktop and server platforms (exact rules depend on the compiler, operating system, and CPU):
+Here are simplified rules used by many C compilers on common desktop and server platforms. Exact rules depend on the compiler, operating system, and CPU:
 
-- a one-byte field may begin at any address;  
-- a four-byte field begins at an address divisible by four;  
+- a one-byte field may begin at any address;
+- a four-byte field begins at an address divisible by four;
 - an eight-byte field or pointer on a typical 64-bit platform begins at an address divisible by eight.
 
-The instructional conclusion is that **unused gaps appear** between fields.
+The instructional conclusion is that **unused gaps appear** between fields, even when you never wrote them.
 
 #### Identical fields, different layouts
 
 Consider three logical fields:
 
-- `flag` — one byte (for example 0 or 1);  
-- `id` — four-byte integer;  
+- `flag` — one byte (for example 0 or 1);
+- `id` — four-byte integer;
 - `score` — eight-byte integer (or a pointer-sized field).
 
 **Layout 1 — order `flag`, `id`, `score` (typical 64-bit C-like padding):**
@@ -116,15 +118,15 @@ Consider three logical fields:
   total size often still 16 bytes, but field positions differ
 ```
 
-Even when both layouts occupy 16 bytes, a reader that assumes Layout 1 and receives Layout 2 misinterprets `id` and `score`. If sizes differ across compilers or packing attributes (for example `#pragma pack`), offsets diverge further.
+Even when both layouts occupy 16 bytes, a reader that assumes Layout 1 and receives Layout 2 misinterprets `id` and `score`. If sizes differ across compilers or packing attributes (for example `#pragma pack`), the offsets diverge even further.
 
-**Conclusion:** agreement that both parties “have flag, id, and score” is **insufficient** for an uninterpreted binary dump. The parties need agreed **order, sizes, and padding**—or a format that encodes fields without host padding.
+**Conclusion:** agreeing that both parties “have flag, id, and score” is **not enough** for an uninterpreted binary dump. The parties need agreed **order, sizes, and padding**—or a format that encodes fields without host padding.
 
 #### Uninterpreted memory dump
 
-For Layout 1 with `flag = 1`, `id = 42`, `score = 7` on a **little-endian** host (least significant byte at the **lowest** address—the usual rule on x86 and many ARM systems). Hexadecimal byte values use two digits per byte (for example `2a` means decimal 42).
+Consider Layout 1 with `flag = 1`, `id = 42`, and `score = 7` on a **little-endian** host. Little-endian means the least significant byte sits at the **lowest** address; that is the usual rule on x86 and many ARM systems. Hexadecimal byte values use two digits per byte (for example `2a` means decimal 42).
 
-Byte-by-byte map (each row is one address; field borders cannot drift):
+Here is a byte-by-byte map. Each row is one address, and the field borders cannot drift:
 
 | Offset | Byte (hex) | Belongs to | Role in the value |
 |-------:|:----------:|------------|-------------------|
@@ -145,7 +147,7 @@ Byte-by-byte map (each row is one address; field borders cannot drift):
 | 14 | `00` | **score** | |
 | 15 | `00` | **score** | most significant byte → together **score = 7** |
 
-Compact one-line view. Each column is exactly three characters (`NN` plus a space), so the `field` markers line up under the same offsets as `byte`:
+Here is a compact one-line view. Each column is exactly three characters (`NN` plus a space), so the `field` markers line up under the same offsets as `byte`:
 
 ```text
 offset  00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 
@@ -153,7 +155,7 @@ byte    01 00 00 00 2a 00 00 00 07 00 00 00 00 00 00 00
 field   F  p  p  p  I  I  I  I  S  S  S  S  S  S  S  S  
 ```
 
-Legend: **F** = `flag` (value **1** at offset 00 only) · **p** = padding · **I** = `id` little-endian (**42** from `2a 00 00 00` at 04–07) · **S** = `score` little-endian (**7** from `07` then seven `00` at 08–15). Trailing zeros on multi-byte fields are high-order bits of a small number; they do **not** mean the value is zero.
+Legend: **F** is `flag` (value **1** at offset 00 only). **p** is padding. **I** is `id` in little-endian form (**42** from `2a 00 00 00` at offsets 04–07). **S** is `score` in little-endian form (**7** from `07` followed by seven `00` bytes at offsets 08–15). Trailing zeros on multi-byte fields are high-order bits of a small number; they do **not** mean the whole value is zero.
 
 **Same layout with `id = 43`** (still `flag = 1`, `score = 7`): only the byte under the first **I** changes (`2a` → `2b`, because 43₁₀ = `2b`₁₆).
 
@@ -163,16 +165,16 @@ byte    01 00 00 00 2b 00 00 00 07 00 00 00 00 00 00 00
 field   F  p  p  p  I  I  I  I  S  S  S  S  S  S  S  S  
 ```
 
-| Decimal | Hex | Little-endian 4-byte pattern (`id`) |
+| Decimal | Hex | Little-endian 4-byte pattern for `id` |
 |--------:|-----|--------------------------------------|
 | 42 | `2a` | `2a 00 00 00` |
 | 43 | `2b` | `2b 00 00 00` |
-| 256 | `100` | `00 01 00 00` (second byte becomes non-zero) |
+| 256 | `100` | `00 01 00 00` (the second byte becomes non-zero) |
 | 7 as 64-bit `score` | `7` | `07 00 00 00 00 00 00 00` |
 
-On a **big-endian** host the multi-byte fields would reverse byte order within each field (for example `id = 42` as `00 00 00 2a`). That is why uninterpreted dumps are not portable across endianness. Endianness is developed further in the next section.
+On a **big-endian** host the multi-byte fields would reverse byte order within each field (for example `id = 42` would appear as `00 00 00 2a`). That is why uninterpreted dumps are not portable across endianness. The next section develops endianness more carefully.
 
-A portable format might transmit only domain data under an explicit rule—for example “one-byte flag, then four-byte little-endian `id`, then eight-byte little-endian `score`,” **without** the three padding zeros—or employ JSON, MessagePack, or Protocol Buffers so that field identity does not depend on host offsets.
+A portable format might transmit only domain data under an explicit rule—for example “one-byte flag, then four-byte little-endian `id`, then eight-byte little-endian `score`,” **without** the three padding zeros. Or it might use JSON, MessagePack, or Protocol Buffers so that field identity does not depend on host offsets.
 
 #### Same record in two languages
 
@@ -186,14 +188,14 @@ struct Player { char flag; int32_t id; int64_t score; };
 player = {"flag": 1, "id": 42, "score": 7}
 ```
 
-The Python dictionary comprises references and hash-table machinery in the interpreter heap. There is **no** single 16-byte image equivalent to the C structure. “Binary dump of my object” is meaningful, if at all, **only inside one language and one compiler/runtime on one platform**—and often not even then for managed objects.
+The Python dictionary is built from references and hash-table machinery in the interpreter heap. There is **no** single 16-byte image equivalent to the C structure. “Binary dump of my object” is meaningful, if at all, **only inside one language and one compiler/runtime on one platform**—and often not even then for managed objects.
 
 ### Endianness
 
 A multi-byte integer is stored as **several bytes in a defined order**. Two common conventions are:
 
-- **Big-endian (BE):** most significant byte at the lowest address (analogous to writing the decimal numeral 1234 from left to right).  
-- **Little-endian (LE):** least significant byte at the lowest address—common on x86/x86-64 and many ARM hosts.
+- **Big-endian (BE):** the most significant byte sits at the lowest address. This is similar to writing the decimal numeral 1234 from left to right.
+- **Little-endian (LE):** the least significant byte sits at the lowest address. This is common on x86/x86-64 and many ARM hosts.
 
 **Example:** 32-bit value `0x12345678` (decimal 305 419 896):
 
@@ -204,22 +206,22 @@ A multi-byte integer is stored as **several bytes in a defined order**. Two comm
   Little-endian:  78  56  34  12
 ```
 
-If a little-endian writer emits those four bytes and a big-endian reader loads them as a native integer **without conversion**, the reader obtains a different numeric value. Network protocols historically adopted a **network byte order** (classical Internet Protocol stacks: big-endian). Every serialization format must **document** endianness—or avoid host integers as the interchange unit (for example decimal text in JSON). See also the [historical perspective](../101/historical_perspective.md).
+If a little-endian writer emits those four bytes and a big-endian reader loads them as a native integer **without conversion**, the reader obtains a different numeric value. Network protocols historically adopted a **network byte order**; classical Internet Protocol stacks used big-endian. Every serialization format must **document** endianness—or avoid host integers as the interchange unit (for example by using decimal text in JSON). See also the [historical perspective](../101/historical_perspective.md).
 
-Binary floating-point values are subject to the same byte-order considerations when stored in memory.
+Binary floating-point values face the same byte-order considerations when stored in memory.
 
 ### Alignment and zero-copy formats
 
-Formats designed for **in-place reads** (FlatBuffers-class designs—see [Zero-copy](zero-copy.md)) place fields so that a host can load integers from buffer offsets with limited extra work (typically assuming a documented endianness). That arrangement is not the absence of a format; it is a **layout specification** that resembles a convenient memory image while still forbidding raw host pointers into another process’s heap.
+Formats designed for **in-place reads** (FlatBuffers-class designs—see [Zero-copy](zero-copy.md)) place fields so that a host can load integers from buffer offsets with limited extra work, typically assuming a documented endianness. That arrangement is not the absence of a format. It is a **layout specification** that resembles a convenient memory image while still forbidding raw host pointers into another process’s heap.
 
 ### Managed objects and graphs
 
-In C, a small structure may store integers **inline** (the bytes of `id` sit inside the structure itself). In managed languages (Python, Java, C#, JavaScript, and similar environments), a “record” or “object” is often a **graph**: the variable holds a **reference** (an address-like handle into a heap managed by the runtime), and fields may be further references to strings, lists, or nested objects. Those addresses are meaningful only inside **this process** and **this runtime**; they must not be treated as portable data.
+In C, a small structure may store integers **inline**: the bytes of `id` sit inside the structure itself. In managed languages (Python, Java, C#, JavaScript, and similar environments), a “record” or “object” is often a **graph**. The variable holds a **reference**—an address-like handle into a heap managed by the runtime—and fields may be further references to strings, lists, or nested objects. Those addresses are meaningful only inside **this process** and **this runtime**. They must not be treated as portable data.
 
 Serializing such a structure “as memory” would require:
 
-1. following every reference to the objects it points to;  
-2. defining behaviour for **shared** objects (one object reachable by two paths) and **cycles** (A refers to B and B refers to A);  
+1. following every reference to the objects it points to;
+2. defining behaviour for **shared** objects (one object reachable by two paths) and **cycles** (A refers to B and B refers to A);
 3. recording **type** information so that the receiver can reconstruct objects of the correct kinds.
 
 #### Nested object with a string field
@@ -242,7 +244,7 @@ Illustrative layout in the heap (addresses are fictional):
                                                          length / type metadata …
 ```
 
-What a naïve “dump of `player`” would capture depends on the language, but it is **not** the twelve bytes of a packed C `struct { int32_t id; char name[4]; }`. More often one would obtain only the **reference** to the map (a machine word), or a runtime-specific object header—neither of which another process can interpret as “id 42 and name Ada.”
+What a naïve “dump of `player`” would capture depends on the language, but it is **not** the twelve bytes of a packed C `struct { int32_t id; char name[4]; }`. More often you would obtain only the **reference** to the map (a machine word), or a runtime-specific object header. Neither of those can be interpreted by another process as “id 42 and name Ada.”
 
 A portable encoding must emit the **logical content**, for example:
 
@@ -266,14 +268,14 @@ task_b = {"title": label}   # same string object, not a second copy
   task_b ──► { title ──┘ }
 ```
 
-In memory there is **one** string object and **two** references to it. A graph-aware native serializer may record that sharing (write the string once, then two back-references). A simple tree encoding (typical JSON) writes the characters twice:
+In memory there is **one** string object and **two** references to it. A graph-aware native serializer may record that sharing: write the string once, then two back-references. A simple tree encoding (typical JSON) writes the characters twice:
 
 ```json
 {"title": "urgent"}
 {"title": "urgent"}
 ```
 
-Both approaches can be correct for a given product; they are **different contracts**. An uninterpreted memory dump does not choose either contract—it only freezes process-local addresses that are useless elsewhere.
+Both approaches can be correct for a given product; they are simply **different contracts**. An uninterpreted memory dump does not choose either contract. It only freezes process-local addresses that are useless elsewhere.
 
 #### Cycle
 
@@ -300,64 +302,64 @@ struct Player {
 };
 ```
 
-Here `id` and the four `name` bytes can sit **inside** one contiguous block (plus padding rules from earlier sections). Even so, as soon as `name` becomes a `char *` pointer to a heap buffer, the C picture becomes a small graph as well: the structure holds an address, and the characters live elsewhere.
+Here `id` and the four `name` bytes can sit **inside** one contiguous block, plus the padding rules from earlier sections. Even so, as soon as `name` becomes a `char *` pointer to a heap buffer, the C picture becomes a small graph as well: the structure holds an address, and the characters live elsewhere.
 
 | Approach | What is stored for a string field | Portable as a raw dump? |
 |----------|-----------------------------------|-------------------------|
-| Inline fixed array in C | Character bytes inside the structure | Only with agreed size, order, and encoding |
+| Inline fixed array in C | Character bytes inside the structure | Only if size, order, and character encoding are agreed |
 | Managed object / `char *` | Reference (address or handle) to data elsewhere | **No** — addresses are process-local |
 | JSON / MessagePack / schema codec | Length or delimiters plus character bytes (or field numbers plus values) | **Yes**, under that format’s rules |
-| Language-native graph serializer (`pickle`, Java serialization, …) | Runtime type tags, handles, and payload for **that** VM | Only to the **same** language/runtime family; unsafe on untrusted input |
+| Language-native graph serializer (`pickle`, Java serialization, and similar) | Runtime type tags, handles, and payload for **that** virtual machine | Only within the **same** language/runtime family; unsafe on untrusted input |
 
-Language-native serializers perform graph walking for **one** runtime. Portable formats ordinarily flatten data to **trees or tables of values** (numbers, character data for strings, nested records) under explicit rules—never “here is a heap address from this virtual machine.”
+Language-native serializers walk graphs for **one** runtime. Portable formats ordinarily flatten data to **trees or tables of values**—numbers, character data for strings, nested records—under explicit rules. They never mean “here is a heap address from this virtual machine.”
 
 ---
 
 ## Costs and constraints
 
-| Axis | What changes | What usually does not |
-|------|----------------|------------------------|
-| Processor time | Byte swaps or copies when host endianness differs from the wire; scanning padding versus dense packing | The need for *some* layout rule |
-| Memory / allocations | Dense packed buffers versus pointer-rich graphs | A costless solution that ignores portability |
-| Size / bandwidth | Padding wastes bytes; pointers become identifiers or nested payloads | Free portability of raw `sizeof` dumps |
-| Operability | Hexadecimal dumps of packed formats require a decoder | Informal dumps that appear simple in a single-host debugger |
+| Axis | What changes with layout and format choices | What usually stays true |
+|------|---------------------------------------------|-------------------------|
+| Processor time | Byte swaps or copies when host endianness differs from the wire; scanning padding versus dense packing | You still need *some* layout rule |
+| Memory / allocations | Dense packed buffers versus pointer-rich graphs | There is no free solution that ignores portability |
+| Size / bandwidth | Padding wastes bytes; pointers become identifiers or nested payloads | Raw `sizeof` dumps are not free portability |
+| Operability | Hexadecimal dumps of packed formats need a decoder to understand | Informal dumps can look simple in a single-host debugger |
 | Security / trust | Accepting raw native images from untrusted parties is hazardous | — |
 
 ---
 
 ## Illustrative scenario
 
-A game client on a little-endian laptop writes player state with an uninterpreted copy of a packed C structure and uploads it to a backend. The backend may use a different compiler or CPU convention for field layout, or a managed language that stores fields in an entirely different way for garbage collection. Inventory counts become incorrect; the defect appears to be application logic until the byte sequences are compared with an endian-aware viewer.
+A game client on a little-endian laptop writes player state with an uninterpreted copy of a packed C structure and uploads it to a backend. The backend may use a different compiler or CPU convention for field layout, or a managed language that stores fields in an entirely different way for garbage collection (GC = automatic reclamation of unused memory). Inventory counts become incorrect. The defect looks like application logic until someone compares the byte sequences with an endian-aware viewer.
 
-A durable remedy is not an informal document describing structure packing. It is an explicit format (even a simple length-prefixed little-endian layout, or a schema-driven codec) shared by both ends.
+A durable remedy is not an informal document describing structure packing. It is an explicit format shared by both ends—even a simple length-prefixed little-endian layout, or a schema-driven codec.
 
 ---
 
 ## In this suite
 
-The harness measures **codecs**, not raw structure dumps: each registered serializer implements a defined encode and decode path over the same logical fixtures. That choice is deliberate—portable interchange is the subject of multi-language comparison.
+The harness measures **codecs**, not raw structure dumps. Each registered serializer implements a defined encode and decode path over the same logical fixtures. That choice is deliberate: portable interchange is the subject of multi-language comparison.
 
-**Results** therefore reflect the cost of *those* contracts (JSON text, MessagePack tags, Protocol Buffers field encodings, and so on), not an uninterpreted memory-copy baseline. For family groupings, see [Serialization categories](../../analysis/serialization_categories.md).
+**Results** therefore reflect the cost of *those* contracts—JSON text, MessagePack tags, Protocol Buffers field encodings, and so on—not an uninterpreted memory-copy baseline. For family groupings, see [Serialization categories](../../analysis/serialization_categories.md).
 
 ---
 
 ## Common errors of practice
 
-- Treating `sizeof` together with an uninterpreted binary write as a multi-language interface.  
-- Forgetting that **padding and field order** are decisions of the compiler and platform, not merely part of a mental model of the domain object.  
-- Assuming that the prevalence of little-endian hosts makes endianness irrelevant—**embedded systems, network equipment, and file formats** still require a written rule.  
-- Confusing **host layout** with **zero-copy wire layout**; the latter is designed, versioned, and free of host pointers.  
+- Treating `sizeof` together with an uninterpreted binary write as if that combination were a multi-language interface.
+- Forgetting that **padding and field order** are decisions of the compiler and platform, not merely part of how you picture the domain object in your head.
+- Assuming that because little-endian hosts are common, endianness no longer matters. **Embedded systems, network equipment, and file formats** still need a written rule.
+- Confusing **host layout** with **zero-copy wire layout**. The latter is designed, versioned, and free of host pointers into another process’s heap.
 - Transmitting language-native serializations of object graphs across a trust boundary (see security notes in the [engineering perspective](../101/engineer_perspective.md)).
 
 ---
 
 ## Key takeaways
 
-- In-memory layout optimises for one processor and runtime; the wire optimises for a shared contract.  
-- Padding, field order, pointer representation, and endianness all invalidate uninterpreted dumps as interchange.  
-- Portable formats replace host assumptions with explicit sizes, order, and byte order (or self-describing tags).  
-- Zero-copy formats still define a layout; they make that layout readable in place.  
-- Multi-language systems require an agreed encoding, not merely a shared C header.  
-- Measure real codecs on representative payloads; do not treat a local memory-copy microbenchmark as an interchange strategy.
+- In-memory layout optimizes for one processor and runtime; the wire optimizes for a shared contract.
+- Padding, field order, pointer representation, and endianness all prevent uninterpreted dumps from working as interchange.
+- Portable formats replace host assumptions with explicit sizes, order, and byte order—or with self-describing tags.
+- Zero-copy formats still define a layout; they make that layout readable in place instead of rebuilding a full object graph.
+- Multi-language systems need an agreed encoding, not merely a shared C header file.
+- Measure real codecs on representative payloads. A local memory-copy microbenchmark is not an interchange strategy.
 
 ---

--- a/docs/theory/201/schema-evolution.md
+++ b/docs/theory/201/schema-evolution.md
@@ -6,15 +6,19 @@
 
 ## Problem
 
-Services and data pipelines are seldom deployed as a single atomic unit. For a period of time one invariably observes **older readers with newer writers**, **newer readers with older writers**, or both. A field rename regarded as “local to one team,” reuse of a Protocol Buffers field number, or removal of a JSON property without a defined default can break a consumer that was overlooked—or corrupt analytical results for an extended period before the defect is noticed.
+Services and data pipelines are seldom deployed as a single atomic unit. For a while you almost always have **older readers with newer writers**, **newer readers with older writers**, or both. A field rename that one team treats as “local,” reuse of a Protocol Buffers field number, or removal of a JSON property without a defined default can break a consumer that was overlooked—or corrupt analytical results for a long time before anyone notices.
 
-Evolution is not a library feature that can be enabled with a single configuration flag. It is a **compatibility policy** together with encoding rules that make that policy feasible.
+Evolution is not a library feature you enable with one configuration flag. It is a **compatibility policy** together with encoding rules that make that policy feasible.
 
 ---
 
 ## Short answer
 
-Safe evolution means defining what **writers may add, remove, or change** while **readers at a different version** still obtain a sufficiently correct view of the data. In practice one prefers **additive** optional fields with explicit defaults; one never repurposes identifiers (Protocol Buffers field numbers; Avro names under a stated compatibility mode; API property names without versioning); one documents nullability and defaults as product semantics; and one enforces policy in continuous integration or a schema registry when more than one team shares the contract. “Forward” and “backward” compatibility are **directional**—the required direction must be known before fields are deleted.
+Safe evolution means defining what **writers may add, remove, or change** while **readers at a different version** still obtain a sufficiently correct view of the data.
+
+In practice you prefer **additive** optional fields with explicit defaults. You never repurpose identifiers—Protocol Buffers field numbers, Avro names under a stated compatibility mode, or API property names without versioning. You document nullability and defaults as product semantics. When more than one team shares the contract, you enforce policy in continuous integration or a schema registry.
+
+“Forward” and “backward” compatibility are **directional**. You need to know which direction matters before you delete fields.
 
 ---
 
@@ -33,7 +37,7 @@ Safe evolution means defining what **writers may add, remove, or change** while 
     · in-place type change of an existing field
 ```
 
-If deployment cannot guarantee “all readers first” or “all writers first,” both directions must hold for a supported interval (**full** compatibility in the terminology of many schema registries).
+If deployment cannot guarantee “all readers first” or “all writers first,” both directions must hold for a supported interval. Many schema registries call that **full** compatibility.
 
 ---
 
@@ -43,11 +47,11 @@ If deployment cannot guarantee “all readers first” or “all writers first,�
 
 | Term (common usage) | Meaning |
 |---------------------|---------|
-| **Backward-compatible** change | **New software can read old data** (fields absent from old data receive defaults). |
-| **Forward-compatible** change | **Old software can read new data** (unknown fields are skipped or ignored). |
+| **Backward-compatible** change | **New software can read old data**. Fields absent from old data receive defaults. |
+| **Forward-compatible** change | **Old software can read new data**. Unknown fields are skipped or ignored. |
 | **Full** compatibility | Both properties hold for a defined support window. |
 
-Exact registry definitions vary; project documentation should be authoritative. The engineering idea is stable: **which side advances first** constrains admissible changes.
+Exact registry definitions vary; project documentation should be authoritative. The engineering idea is stable: **which side advances first** constrains which changes are allowed.
 
 ### Beginner example: adding a field
 
@@ -65,13 +69,13 @@ Version 2 adds `currency_code` (string), default `"USD"` when absent.
 | Writer v2 → Reader v1 | Reader v1 must **ignore** `currency_code` if unknown, and still process `order_id` and `total_cents`. |
 | Writer v1 → Reader v2 | Reader v2 must treat missing `currency_code` as **`"USD"`** (or another documented default), not as an error—unless the product deliberately requires a hard cut-over. |
 
-If version 2 instead **renames** `total_cents` to `amount_cents` without a dual-field period, older readers stop seeing the amount (key absent) and newer readers miss older writers’ key. The failure mode is often silent.
+If version 2 instead **renames** `total_cents` to `amount_cents` without a dual-field period, older readers stop seeing the amount (the old key is absent) and newer readers miss the key that older writers still send. The failure mode is often silent.
 
 ### Protocol Buffers–style evolution (field numbers)
 
-- New fields receive **new numbers**; they are introduced as optional (exact presence rules depend on language edition and toolchain).  
-- A field number must **never** be reused for a new meaning; deleted numbers and names should be marked `reserved`.  
-- Renaming a field in the `.proto` source without changing its number is a source-level rename; the binary wire form may remain compatible while JSON mappings and human-facing APIs may not.  
+- New fields receive **new numbers**. They are introduced as optional; exact presence rules depend on language edition and toolchain.
+- A field number must **never** be reused for a new meaning. Deleted numbers and names should be marked `reserved`.
+- Renaming a field in the `.proto` source without changing its number is a source-level rename. The binary wire form may remain compatible while JSON mappings and human-facing APIs may not.
 - Changing a field’s type in place is ordinarily a breaking change.
 
 **Illustration — unsafe reuse:**
@@ -81,7 +85,7 @@ If version 2 instead **renames** `total_cents` to `amount_cents` without a dual-
   v2:  field 3 = total (string decimal)   ← same number, new type/meaning
 ```
 
-Readers compiled for v1 interpret string-shaped bytes (or a different wire type) incorrectly; mixed fleets produce inconsistent accounts.
+Readers compiled for v1 interpret string-shaped bytes (or a different wire type) incorrectly. Mixed fleets produce inconsistent accounts.
 
 **Illustration — safer migration:**
 
@@ -94,14 +98,16 @@ Readers compiled for v1 interpret string-shaped bytes (or a different wire type)
 
 ### Avro-style evolution (writer and reader schemas)
 
-Protocol Buffers evolution is organised around **field numbers that stay on the wire forever**. Avro (and similar systems) organise evolution around **two schemas at read time**:
+Protocol Buffers evolution is organized around **field numbers that stay on the wire forever**. Avro (and similar systems) organize evolution around **two schemas at read time**:
 
 | Schema | Role |
 |--------|------|
 | **Writer schema** | Describes how the **bytes were encoded** when the record was produced (field names, types, order). |
 | **Reader schema** | Describes how the **application wants to see** the record now (possibly a newer or older version of the model). |
 
-The Avro runtime performs **schema resolution**: it matches fields between writer and reader (primarily by **name**, with optional aliases) and applies documented rules for missing fields, extra fields, and limited type promotions. The important beginner idea is: **the payload need not carry field names on every record** (in the binary encoding they are implied by the writer schema), yet the reader still needs a precise account of how the writer laid the values out—or a **schema id** that retrieves that account from a registry.
+The Avro runtime performs **schema resolution**: it matches fields between writer and reader (primarily by **name**, with optional aliases) and applies documented rules for missing fields, extra fields, and limited type promotions.
+
+The important beginner idea is this: **the payload need not carry field names on every record** (in the binary encoding they are implied by the writer schema), yet the reader still needs a precise account of how the writer laid the values out—or a **schema id** that retrieves that account from a registry.
 
 #### Minimal example: adding a field with a default
 
@@ -128,9 +134,9 @@ A record written with **v1** contains only two long values in the Avro binary la
 
 | Field | How the value is obtained |
 |-------|---------------------------|
-| `order_id` | decoded from the writer’s bytes |
-| `total_cents` | decoded from the writer’s bytes |
-| `currency_code` | **not on the wire** → filled from the **default** in the reader schema (`"USD"`) |
+| `order_id` | Decoded from the writer’s bytes |
+| `total_cents` | Decoded from the writer’s bytes |
+| `currency_code` | **Not on the wire** → filled from the **default** in the reader schema (`"USD"`) |
 
 That is **backward-compatible** evolution in the “new software reads old data” sense: the new reader understands old bytes because the new field has a default.
 
@@ -140,8 +146,8 @@ That is **backward-compatible** evolution in the “new software reads old data�
 
 | Field on the wire (v2 writer) | Old reader (v1) behaviour under resolution |
 |-------------------------------|--------------------------------------------|
-| `order_id`, `total_cents` | decoded as usual |
-| `currency_code` | **no matching field** in the reader schema → value is **skipped / discarded** for that application |
+| `order_id`, `total_cents` | Decoded as usual |
+| `currency_code` | **No matching field** in the reader schema → value is **skipped / discarded** for that application |
 
 The old application never sees `currency_code`, but it continues to process the fields it knows. That supports **forward-compatible** change (old software reading new data) when the project’s compatibility rules allow the writer to add fields.
 
@@ -166,8 +172,8 @@ A reader cannot know whether the second long is `total_cents` or something else.
 | Pattern | What travels with the bytes |
 |---------|-----------------------------|
 | **Object container file** (classic Avro files) | Writer schema (or enough metadata) in the file header; many records share it |
-| **Schema registry** (common on event buses) | Small **schema id** (or fingerprint) per record or per batch; the full writer schema is fetched from the registry |
-| **Out-of-band agreement** | Both sides pinned to the same schema version by deployment process alone (fragile at scale) |
+| **Schema registry** (common on event buses) | A small **schema id** (or fingerprint) per record or batch; the full writer schema is fetched from the registry |
+| **Out-of-band agreement** | Both sides are pinned to the same schema version by deployment process alone (fragile at scale) |
 
 **Illustrative registry flow:**
 
@@ -187,31 +193,31 @@ The consumer’s **reader schema** may be v3 (extra fields with defaults, rename
 
 #### Rename via alias (sketch)
 
-Writer still uses the old field name; reader prefers a new name:
+The writer still uses the old field name; the reader prefers a new name:
 
 ```text
   Writer schema:   long total_cents;
   Reader schema:   long amount_cents;   with alias "total_cents"
 ```
 
-Resolution maps the writer’s `total_cents` bytes onto the reader’s `amount_cents` field. Without an alias or a dual-field period, a pure rename is a **break** (same problem as JSON key renames).
+Resolution maps the writer’s `total_cents` bytes onto the reader’s `amount_cents` field. Without an alias or a dual-field period, a pure rename is a **break**—the same problem as JSON key renames.
 
 #### Contrast with Protocol Buffers (same logical change)
 
 | Concern | Protocol Buffers (typical) | Avro (typical) |
 |---------|----------------------------|----------------|
-| Field identity on the wire | **Numbers** (`total_cents = 3`) | **Names** in the schema; binary layout follows the writer schema |
-| What the reader must know | Compiled message types / descriptors (numbers stable) | **Writer schema** (or id) **and** reader schema |
-| New field | New number; old readers skip unknown numbers | New name + default for old data; old readers skip unknown names under resolution |
-| Operational centre of gravity | `.proto` ownership and reserved numbers | Schema registry, compatibility modes (BACKWARD / FORWARD / FULL, product-specific) |
+| Field identity on the wire | **Numbers** (for example `total_cents = 3`) | **Names** in the schema; binary layout follows the writer schema |
+| What the reader must know | Compiled message types / descriptors (numbers stay stable) | **Writer schema** (or id) **and** reader schema |
+| New field | New number; old readers skip unknown numbers | New name plus a default for old data; old readers skip unknown names under resolution |
+| Operational center of gravity | `.proto` ownership and reserved numbers | Schema registry and compatibility modes (BACKWARD / FORWARD / FULL, product-specific) |
 
-Neither model removes the need for a **compatibility policy**; they implement that policy with different mechanisms. For analytical pipelines and lake-oriented formats, see also the [data science perspective](../101/data_science_perspective.md).
+Neither model removes the need for a **compatibility policy**. They implement that policy with different mechanisms. For analytical pipelines and lake-oriented formats, see also the [data science perspective](../101/data_science_perspective.md).
 
 ### JSON and schemaless binary formats
 
-- **Additive** properties are the usual safe change; consumers that require forward compatibility should ignore unknown keys.  
-- **Renames** fail silently (old key absent; new key ignored by older clients).  
-- **Type changes** of an existing key (for example, string to object) are breaking.  
+- **Additive** properties are the usual safe change. Consumers that need forward compatibility should ignore unknown keys.
+- **Renames** fail silently: the old key is absent, and the new key is ignored by older clients.
+- **Type changes** of an existing key (for example string to object) are breaking.
 - Without automated validation, “compatibility” is only as strong as the weakest client.
 
 **Minimal JSON examples:**
@@ -231,10 +237,10 @@ Neither model removes the need for a **compatibility policy**; they implement th
 
 Wire formats cannot invent product meaning. Designers must decide explicitly:
 
-- missing field versus explicit null versus a numeric zero default;  
+- whether a missing field, an explicit null, and a numeric zero default mean different things;
 - whether the value `0` is allowed to mean “unset” (usually a poor design).
 
-Code generators and serializers differ; tests should cover fixtures for **old payload × new reader** and **new payload × old reader**.
+Code generators and serializers differ. Tests should cover fixtures for **old payload × new reader** and **new payload × old reader**.
 
 ---
 
@@ -242,9 +248,9 @@ Code generators and serializers differ; tests should cover fixtures for **old pa
 
 | Axis | Consequence of weak evolution discipline | Benefit of disciplined practice |
 |------|------------------------------------------|----------------------------------|
-| Evolution risk | Service failures; corrupted stores; undeliverable messages | Rolling deployments without synchronized flag days |
+| Evolution risk | Service failures, corrupted stores, undeliverable messages | Rolling deployments without synchronized flag days |
 | Operability | Emergency reconstruction of schema history | Versioned schemas and clear ownership |
-| Size / bandwidth | Optional fields retained indefinitely accumulate | Planned deprecation windows |
+| Size / bandwidth | Optional fields kept forever slowly accumulate | Planned deprecation windows |
 | Tooling | Informal documents that drift from reality | Registry, breaking-change checks, contract tests |
 | Security / trust | Misinterpretation after silent type changes | Explicit validation of untrusted shapes |
 
@@ -252,37 +258,39 @@ Code generators and serializers differ; tests should cover fixtures for **old pa
 
 ## Illustrative scenario
 
-A billing field `amount_cents` (integer) is “replaced” by `amount` (decimal string) by reusing the same JSON key or the same Protocol Buffers field number. Part of the deployment still expects integers; part expects strings; some components write both. Reconciliation fails for a subset of accounts. A sound approach introduces a **new field** (or a versioned API), dual-writes and dual-reads during a migration window, then retires the old field with `reserved` markers or formal API deprecation—not an in-place type substitution.
+A billing field `amount_cents` (integer) is “replaced” by `amount` (decimal string) by reusing the same JSON key or the same Protocol Buffers field number. Part of the deployment still expects integers; part expects strings; some components write both. Reconciliation fails for a subset of accounts.
+
+A sound approach introduces a **new field** (or a versioned API), dual-writes and dual-reads during a migration window, then retires the old field with `reserved` markers or formal API deprecation—not an in-place type substitution.
 
 ---
 
 ## In this suite
 
-Benchmark fixtures assume a **stable logical model** so that libraries remain comparable; the suite is not a schema-registry simulator. Use Serialization 201 and the perspective documents for evolutionary *judgment*; use **Results** for encode and decode cost of a chosen codec once the contract is fixed.
+Benchmark fixtures assume a **stable logical model** so that libraries remain comparable. The suite is not a schema-registry simulator. Use Serialization 201 and the perspective documents for evolutionary *judgment*; use **Results** for encode and decode cost of a chosen codec once the contract is fixed.
 
-When evaluating schema-driven libraries on language overview pages, production use still requires an organization’s own compatibility process—the harness does not replace it.
+When you evaluate schema-driven libraries on language overview pages, production use still requires your organization’s own compatibility process. The harness does not replace it.
 
 ---
 
 ## Common errors of practice
 
-- Reusing Protocol Buffers field numbers or Avro names under incompatible modes.  
-- Deploying writers that emit a newly required field before all readers understand it.  
-- Renaming JSON properties without versioning or a dual-field period.  
-- Treating “optional in the interface description” as “optional in the product” without defaults.  
-- Omitting consumer tests against **reference payloads** from older versions.  
-- Deleting fields on the same day writers stop emitting them (no drain interval).
+- Reusing Protocol Buffers field numbers or Avro names under incompatible modes.
+- Deploying writers that emit a newly required field before all readers understand it.
+- Renaming JSON properties without versioning or a dual-field period.
+- Treating “optional in the interface description” as “optional in the product” without defaults.
+- Omitting consumer tests against **reference payloads** from older versions.
+- Deleting fields on the same day writers stop emitting them, with no drain interval.
 
 ---
 
 ## Key takeaways
 
-- Evolution is a **policy together with encoding rules** under rolling deployment and long-lived data.  
-- Determine whether older readers, older writers, or both must be supported during migration.  
-- Prefer additive optional fields with explicit defaults; never repurpose identifiers.  
-- Flexibility of JSON does not remove the need for a compatibility strategy.  
-- Registry and continuous-integration enforcement scale more reliably than informal coordination alone.  
-- Dual-read and dual-write migration windows are preferable to simultaneous type changes.  
+- Evolution is a **policy together with encoding rules** under rolling deployment and long-lived data.
+- Decide whether older readers, older writers, or both must be supported during migration.
+- Prefer additive optional fields with explicit defaults, and never repurpose identifiers.
+- Flexibility of JSON does not remove the need for a compatibility strategy.
+- Registry and continuous-integration enforcement scale more reliably than informal coordination alone.
+- Dual-read and dual-write migration windows are preferable to simultaneous type changes.
 - Test old×new and new×old payloads, not only matched-version paths.
 
 ---

--- a/docs/theory/201/self-describing-vs-schema-dependent.md
+++ b/docs/theory/201/self-describing-vs-schema-dependent.md
@@ -6,7 +6,7 @@
 
 ## Problem
 
-Two systems exchange the “same” logical record: an identifier, a name, and a monetary balance. Encoded as JSON, a practitioner can often open a log line and infer meaning from field names. Encoded as a compact binary sequence without accompanying documentation, the same practitioner sees only opaque bytes until a schema file, interface description, or other authoritative specification is consulted.
+Two systems exchange the “same” logical record: an identifier, a name, and a monetary balance. Encoded as JSON, you can often open a log line and infer meaning from the field names. Encoded as a compact binary sequence without documentation nearby, the same person sees only opaque bytes until a schema file, interface description, or other authoritative specification is consulted.
 
 The design question is not merely “are there types?” It is **where the meaning of each field is recorded** when the message is in transit or at rest.
 
@@ -14,7 +14,11 @@ The design question is not merely “are there types?” It is **where the meani
 
 ## Short answer
 
-**Self-describing** formats (to varying degrees) embed enough structure in the payload that a generic tool can recover a tree of values: field names and/or type tags travel with the data (JSON; MessagePack; CBOR; many “binary JSON” encodings). **Schema-dependent** formats omit most of that metadata from each message: readers require a **shared schema or interface description language (IDL)** (classic Protocol Buffers binary encoding; raw Avro data bytes; many compact remote-procedure-call encodings) to know, for example, that field number `3` denotes `balance` and how that field is encoded. Self-describing formats typically trade larger size and additional parsing work for inspectability and flexibility. Schema-dependent formats trade an explicit, maintained contract and supporting tooling for density, code generation, and clearer evolution rules—when that contract is actually maintained.
+**Self-describing** formats (to varying degrees) embed enough structure in the payload that a generic tool can recover a tree of values. Field names and/or type tags travel with the data. JSON, MessagePack, CBOR, and many “binary JSON” encodings sit in this family.
+
+**Schema-dependent** formats omit most of that metadata from each message. Readers need a **shared schema or interface description language (IDL)**—a formal description of messages and field types shared by producers and consumers. Classic Protocol Buffers binary encoding, raw Avro data bytes, and many compact remote-procedure-call encodings work this way. For example, you need the schema to know that field number `3` means `balance` and how that field is encoded.
+
+Self-describing formats typically trade larger size and extra parsing work for inspectability and flexibility. Schema-dependent formats trade an explicit, maintained contract and supporting tooling for density, code generation, and clearer evolution rules—when that contract is actually maintained.
 
 ---
 
@@ -36,7 +40,7 @@ The design question is not merely “are there types?” It is **where the meani
                                          └──────────────────────────┘
 ```
 
-“Self-describing” is a spectrum. JSON prioritizes human inspection. MessagePack remains machine-oriented yet still carries tags (and often keys). Operational deployments that ship descriptor sets alongside Protocol Buffers are hybrid arrangements; they are not the minimal on-the-wire encoding.
+“Self-describing” is a spectrum, not a single switch. JSON prioritizes human inspection. MessagePack remains machine-oriented yet still carries tags and often keys. Operational deployments that ship descriptor sets alongside Protocol Buffers are hybrid arrangements; they are not the minimal on-the-wire encoding.
 
 ---
 
@@ -46,8 +50,8 @@ The design question is not merely “are there types?” It is **where the meani
 
 Any decoder must recover:
 
-1. **Extent** — where each field begins and ends (delimiters, length prefixes, or fixed layout).  
-2. **Type** — whether the value is an integer, string, nested record, and so on (or a schema that fixes the type).  
+1. **Extent** — where each field begins and ends (delimiters, length prefixes, or fixed layout).
+2. **Type** — whether the value is an integer, string, nested record, and so on (or a schema that fixes the type).
 3. **Identity** — which logical field is present (name, numeric identifier, or positional index).
 
 Self-describing formats answer (2) and (3) **inside the byte stream**. Schema-dependent formats answer them primarily from an **out-of-band contract** agreed at build or deployment time (sometimes versioned through a registry).
@@ -67,7 +71,7 @@ Logical record:
 {"user_id":42,"name":"Ada"}
 ```
 
-A general-purpose parser can construct a map without any project-specific schema file. The characters `user_id` and `name` appear in **every** message, which aids debugging and costs space when millions of messages are stored or transmitted.
+A general-purpose parser can construct a map without any project-specific schema file. The characters `user_id` and `name` appear in **every** message. That helps debugging, and it costs space when millions of messages are stored or transmitted.
 
 **Schema-dependent sketch (Protocol Buffers style, conceptual):**
 
@@ -78,23 +82,23 @@ Suppose the shared schema states:
   field number 2: name, length-delimited UTF-8 string
 ```
 
-The on-the-wire form carries **field numbers and values**, not the Unicode names `user_id` and `name`. A reader lacking the schema cannot reliably map number `1` to the product concept “user identifier.” Density improves because names are not repeated; **correct interpretation depends on sharing the same schema version**.
+The on-the-wire form carries **field numbers and values**, not the Unicode names `user_id` and `name`. A reader that lacks the schema cannot reliably map number `1` to the product concept “user identifier.” Density improves because names are not repeated. **Correct interpretation depends on sharing the same schema version.**
 
 ### Why dense binary encodings “require” a schema
 
-Protocol Buffers’ compact binary encoding is small largely **because field names are absent from the stream**—field numbers and wire types remain. Without the mapping from numbers to names and types, only limited generic inspection is possible. That property is not peculiar to one product: it is the general pattern of **schema-dependent density**. The schema is part of the product contract; the bytes are an encoding of values under that contract.
+Protocol Buffers’ compact binary encoding is small largely **because field names are absent from the stream**—field numbers and wire types remain. Without the mapping from numbers to names and types, only limited generic inspection is possible. That property is not peculiar to one product; it is the general pattern of **schema-dependent density**. The schema is part of the product contract. The bytes are an encoding of values under that contract.
 
 ### “Schemaless” on the wire is not “no contract in the organization”
 
-JSON and MessagePack do not eliminate the need for agreements among producers and consumers. They relocate validation, documentation, and compatibility policy into specifications such as OpenAPI or JSON Schema, shared source types, tests, and operational practice. The wire representation remains flexible; the organization still requires an authoritative definition of allowed shapes.
+JSON and MessagePack do not eliminate the need for agreements among producers and consumers. They relocate validation, documentation, and compatibility policy into specifications such as OpenAPI or JSON Schema, shared source types, tests, and operational practice. The wire representation remains flexible. The organization still needs an authoritative definition of allowed shapes.
 
 ### Hybrid arrangements
 
 | Arrangement | Where the contract lives | What the payload emphasizes |
 |-------------|--------------------------|-----------------------------|
-| Avro data file with embedded writer schema | File header and/or registry | Compact values; schema available nearby |
-| Events with a schema-registry identifier | Registry entry referenced by id | Small per-record overhead; schema fetched by id |
-| JSON validated against JSON Schema | External schema document | Self-describing payload plus correctness checks |
+| Avro data file with embedded writer schema | File header and/or registry | Compact values, with the schema available nearby |
+| Events with a schema-registry identifier | Registry entry referenced by id | Small per-record overhead; the full schema is fetched by id |
+| JSON validated against JSON Schema | External schema document | Self-describing payload plus separate correctness checks |
 | Protocol Buffers JSON mapping | Schema plus JSON field names | Human-oriented debugging at larger size |
 
 ---
@@ -103,12 +107,12 @@ JSON and MessagePack do not eliminate the need for agreements among producers an
 
 | Axis | Self-describing (typical) | Schema-dependent (typical) |
 |------|---------------------------|----------------------------|
-| Size / bandwidth | Names and tags repeated; larger | Often smaller for the same logical record |
+| Size / bandwidth | Names and tags are repeated, so payloads are larger | Often smaller for the same logical record |
 | Processor time | Parse tags and names; flexible decoders | Less metadata; code generation can be efficient |
-| Evolution | Easy to add keys; easy to disagree silently | Explicit rules (field numbers, compatibility modes)—if enforced |
-| Operability | Logs and support benefit from inspectable payloads | Decoders and schema versions required for observability |
-| Tooling | Widely available generic parsers | IDL, code generation, continuous-integration discipline |
-| Security / trust | Untrusted input must still be validated | Presence of a schema does not by itself imply safety |
+| Evolution | Easy to add keys; also easy to disagree silently | Explicit rules (field numbers, compatibility modes)—if you enforce them |
+| Operability | Logs and support benefit from inspectable payloads | You need decoders and schema versions for observability |
+| Tooling | Widely available generic parsers | IDL, code generation, and continuous-integration discipline |
+| Security / trust | Untrusted input must still be validated | Presence of a schema does not by itself make input safe |
 
 ---
 
@@ -116,7 +120,7 @@ JSON and MessagePack do not eliminate the need for agreements among producers an
 
 **Public HTTP API.** JSON is retained so browsers, gateways, and external partners can inspect errors without a code generator.
 
-**Internal event bus among owned services.** A schema-dependent binary codec with a registry reduces payload size; continuous integration enforces compatibility. Both designs can be appropriate; they locate field identity differently because **audiences and change-control processes** differ.
+**Internal event bus among owned services.** A schema-dependent binary codec with a registry reduces payload size; continuous integration enforces compatibility. Both designs can be appropriate. They locate field identity differently because **audiences and change-control processes** differ.
 
 ---
 
@@ -137,21 +141,21 @@ See [Serialization categories](../../analysis/serialization_categories.md) and l
 
 ## Common errors of reasoning
 
-- Describing JSON as “schemaless” as if the product had no contract.  
-- Expecting Protocol Buffers–like size from MessagePack while transmitting full key strings in every message.  
-- Deploying schema-dependent bytes without a versioned account of which party holds which schema.  
-- Treating human readability as a substitute for validation at trust boundaries.  
-- Assuming that the existence of a schema makes deserialization safe against adversarial input (resource limits and verifiers remain necessary).
+- Describing JSON as “schemaless” as if the product had no contract at all.
+- Expecting Protocol Buffers–like size from MessagePack while still transmitting full key strings in every message.
+- Deploying schema-dependent bytes without a versioned account of which party holds which schema.
+- Treating human readability as a substitute for validation at trust boundaries.
+- Assuming that the existence of a schema makes deserialization safe against adversarial input. Resource limits and verifiers remain necessary.
 
 ---
 
 ## Key takeaways
 
-- The central design choice is **where field identity and types live**: in the payload or in a shared contract.  
-- Self-describing formats favour flexibility and inspectability; they typically cost size and some parsing work.  
-- Schema-dependent formats favour density and code generation; they require tooling and contract discipline.  
-- “Protocol Buffers requires a schema” is an instance of the general lesson of **dense binary encoding without names on the wire**.  
-- Flexible wire formats still require organizational contracts (documentation, validators, tests).  
+- The central design choice is **where field identity and types live**: in the payload or in a shared contract.
+- Self-describing formats favour flexibility and inspectability; they typically cost size and some parsing work.
+- Schema-dependent formats favour density and code generation; they require tooling and contract discipline.
+- “Protocol Buffers requires a schema” is one instance of the general lesson of **dense binary encoding without names on the wire**.
+- Flexible wire formats still require organizational contracts—documentation, validators, and tests.
 - Choose the locus of truth according to who must read the bytes and how change is managed.
 
 ---

--- a/docs/theory/201/zero-copy.md
+++ b/docs/theory/201/zero-copy.md
@@ -2,15 +2,17 @@
 
 ## Problem
 
-In the classical serialization model, a byte sequence arrives, a parser **constructs a new object graph** in the language runtime, application code reads properties from those objects, and memory is later reclaimed (manually or by garbage collection). The model is straightforward to reason about and becomes expensive when messages are large, numerous, or only partly examined—because the implementation pays to materialize fields that are never read.
+In the classical serialization model, a byte sequence arrives, a parser **constructs a new object graph** in the language runtime, application code reads properties from those objects, and memory is later reclaimed—manually or by garbage collection (GC = automatic reclamation of unused memory). That model is straightforward to reason about. It becomes expensive when messages are large, numerous, or only partly examined, because the implementation pays to materialize fields that are never read.
 
-Some formats are described as **zero-copy**, or are said **not to deserialize**. Such phrasing is easily misread as “costless and invariably safer.” The underlying mechanism is precise: for a chosen endianness and alignment policy, **the on-the-wire layout is arranged so that fields can be read in place**, using offsets into the receive buffer, rather than by allocating a parallel tree of language objects.
+Some formats are described as **zero-copy**, or are said **not to deserialize**. Such phrasing is easily misread as “costless and invariably safer.” The underlying mechanism is more precise: for a chosen endianness (byte order) and alignment policy, **the on-the-wire layout is arranged so that fields can be read in place**, using offsets into the receive buffer, rather than by allocating a parallel tree of language objects.
 
 ---
 
 ## Short answer
 
-In a **zero-copy** design (FlatBuffers, Cap’n Proto, and related systems), encoding produces a binary image whose fields are accessible through **generated accessors or equivalent offset arithmetic** applied directly to the receive buffer. There is no separate step that parses the entire message into ordinary language objects on the ordinary read path—hence “does not deserialize” in the *classical* sense of full materialization. Encoding still requires work to **construct** that layout; **validation** of untrusted buffers remains necessary (omitting it is a serious risk); partial mutation is often awkward; and operational tooling differs from text-oriented formats. Zero-copy is a layout and application-programming-interface philosophy, not a costless substitute for a schema or a trust model.
+In a **zero-copy** design (FlatBuffers, Cap’n Proto, and related systems), encoding produces a binary image whose fields are accessible through **generated accessors or equivalent offset arithmetic** applied directly to the receive buffer. There is no separate step that parses the entire message into ordinary language objects on the ordinary read path. That is what people mean by “does not deserialize” in the *classical* sense of full materialization.
+
+Encoding still requires work to **construct** that layout. **Validation** of untrusted buffers remains necessary—omitting it is a serious risk. Partial mutation is often awkward, and operational tooling differs from text-oriented formats. Zero-copy is a layout and application-programming-interface philosophy, not a costless substitute for a schema or a trust model.
 
 ---
 
@@ -39,8 +41,8 @@ In a **zero-copy** design (FlatBuffers, Cap’n Proto, and related systems), enc
 
 Recall from [memory layout](memory-layout.md) that a process-local structure may contain padding and host pointers. A zero-copy **message format** instead defines a **portable layout**:
 
-- multi-byte integers appear at agreed alignments and byte orders;  
-- variable-length data (strings, vectors) are reached through **offsets** stored in the buffer;  
+- multi-byte integers appear at agreed alignments and byte orders;
+- variable-length data (strings, vectors) are reached through **offsets** stored in the buffer;
 - optional fields may be indicated by a table of field offsets (often called a vtable in FlatBuffers documentation).
 
 **Beginner sketch — reading one integer field.**
@@ -62,12 +64,12 @@ No host pointer from the **writer’s** address space appears in the file. Offse
 
 | Stage | What happens |
 |-------|----------------|
-| Design | An IDL/schema declares tables and fields; tools generate readers and builders. |
+| Design | An IDL (interface description language) / schema declares tables and fields; tools generate readers and builders. |
 | Encode | A builder API appends data (often depth-first) and patches offsets so the final buffer is self-consistent. |
 | Verify | A verifier checks that offsets and lengths lie within the buffer (essential for untrusted input). |
 | Read | Accessors traverse offsets; unread fields need not become heap objects. |
 
-Thus “FlatBuffers does not deserialize” means “does not classically materialize the whole message as objects,” not “does no work and needs no schema.”
+So “FlatBuffers does not deserialize” means “does not classically materialize the whole message as objects.” It does **not** mean “does no work and needs no schema.”
 
 ### The encode path is not free
 
@@ -79,14 +81,14 @@ Avoiding object materialization must not mean avoiding **bounds and structural c
 
 ### Mutation and operability
 
-In-place updates are constrained (sufficient space must already exist; changing lengths is difficult). Many deployments treat buffers as **immutable messages** and rebuild when state changes. Debugging requires format-aware tools; hexadecimal dumps are less informative than structured text logs.
+In-place updates are constrained: sufficient space must already exist, and changing lengths is difficult. Many deployments treat buffers as **immutable messages** and rebuild when state changes. Debugging requires format-aware tools; hexadecimal dumps are less informative than structured text logs.
 
 ### Related but distinct ideas
 
 | Idea | Relation to message zero-copy |
 |------|-------------------------------|
-| Memory-mapped columnar formats (Arrow, Parquet access paths) | Zero-copy *columns* for analytical workloads—different problem domain ([data science perspective](../101/data_science_perspective.md)) |
-| `span` / buffer views on ordinary codecs | Reduce copies without a full zero-copy message format |
+| Memory-mapped columnar formats (Arrow, Parquet access paths) | Zero-copy *columns* for analytical workloads—a different problem domain ([data science perspective](../101/data_science_perspective.md)) |
+| `span` / buffer views on ordinary codecs | Reduce copies without adopting a full zero-copy message format |
 | Protocol Buffers with arenas or pooling | Fast materialization or reduced allocation—not the same layout model |
 
 ---
@@ -100,14 +102,16 @@ In-place updates are constrained (sufficient space must already exist; changing 
 | Memory / allocations | Fewer objects on the read path | Buffer lifetime must outlive views |
 | Size / bandwidth | Competitive; alignment may introduce padding | Not a substitute for compression ([Compression vs format](compression-is-not-a-format.md)) |
 | Evolution | Schema or IDL still required | Compatibility discipline remains |
-| Security | Omitting verification can appear “fast” and is unsafe | Always verify untrusted buffers |
+| Security | Omitting verification can look “fast” and is unsafe | Always verify untrusted buffers |
 | Operability | Specialized inspectors | Weaker ad hoc log readability |
 
 ---
 
 ## Illustrative scenario
 
-A mobile client downloads a large catalogue message. The user interface requires only a few fields per screen. Classical decoding may allocate thousands of objects at load time. A FlatBuffers-style buffer is retained (or memory-mapped) once, verified once, and read on demand. The same pattern appears in some remote-procedure-call or inter-process paths for large, immutable configuration snapshots. The approach fits poorly for small, frequently mutated documents when builder complexity exceeds any gain, and it fits poorly when a team will not adopt schema tooling.
+A mobile client downloads a large catalogue message. The user interface needs only a few fields per screen. Classical decoding may allocate thousands of objects at load time. A FlatBuffers-style buffer is retained (or memory-mapped) once, verified once, and read on demand. The same pattern appears in some remote-procedure-call or inter-process paths for large, immutable configuration snapshots.
+
+The approach fits poorly for small, frequently mutated documents when builder complexity exceeds any gain. It also fits poorly when a team will not adopt schema tooling.
 
 ---
 
@@ -119,22 +123,22 @@ Where FlatBuffers or similar codecs are **registered** for a language, treat the
 
 ## Common errors of reasoning
 
-- Interpreting “no deserialization” as “no processor work and no schema.”  
-- Using zero-copy buffers received from a network **without verification**.  
-- Retaining views into a buffer that has been freed, recycled, or overwritten.  
-- Selecting zero-copy for small, highly mutable messages because a benchmark used large static ones.  
+- Interpreting “no deserialization” as “no processor work and no schema.”
+- Using zero-copy buffers received from a network **without verification**.
+- Retaining views into a buffer that has been freed, recycled, or overwritten.
+- Selecting zero-copy for small, highly mutable messages because a benchmark used large static ones.
 - Comparing an unverified zero-copy path with a fully validating classical parser on speed alone.
 
 ---
 
 ## Key takeaways
 
-- Zero-copy means **in-place field access** from a designed layout, not “no interpretation of bytes.”  
-- “Does not deserialize” targets the classical **full object-graph materialization** step.  
-- Construction and **verification** still cost time; security requires the latter for untrusted data.  
-- Best fit: large or sparsely read, mostly immutable messages, with acceptance of schema tooling.  
-- Poor fit: tiny mutable documents; environments that require text inspectability above all else.  
-- Columnar and buffer-view techniques are related but not identical.  
+- Zero-copy means **in-place field access** from a designed layout, not “no interpretation of bytes.”
+- “Does not deserialize” targets the classical **full object-graph materialization** step.
+- Construction and **verification** still cost time; security requires the latter for untrusted data.
+- Best fit: large or sparsely read, mostly immutable messages, with acceptance of schema tooling.
+- Poor fit: tiny mutable documents, or environments that require text inspectability above all else.
+- Columnar and buffer-view techniques are related but not identical.
 - Interpret suite measurements in light of validation settings and access patterns.
 
 ---

--- a/docs/theory/301/caching-and-queues.md
+++ b/docs/theory/301/caching-and-queues.md
@@ -6,45 +6,47 @@ Redis, SQS, Kafka, and in-process caches all store **bytes**. Developers paste t
 
 ## Short answer
 
-For **shared** caches and queues, use **portable** formats with an explicit schema or documented JSON contract ([trust boundaries](trust-boundaries.md), [polyglot estates](polyglot-estates.md)). Reserve language-native codecs for **single-binary, trusted, non-shared** state if the threat model allows. Separate **event log** design ([schema registries](schema-registries.md)) from **ephemeral cache** values, but do not lower the portability bar just because TTL is short. Size limits and poison-message handling matter as much as codec speed.
+For **shared** caches and queues, use **portable** formats with an explicit schema or a documented JSON contract ([trust boundaries](trust-boundaries.md), [polyglot estates](polyglot-estates.md)). Reserve language-native codecs for **single-binary, trusted, non-shared** state if the threat model allows.
+
+Separate **event log** design ([schema registries](schema-registries.md)) from **ephemeral cache** values, but do not lower the portability bar just because time-to-live (TTL) is short. Size limits and poison-message handling matter as much as codec speed.
 
 ## Constraints that matter
 
 | Store | Prefer | Avoid |
 |-------|--------|-------|
-| Cross-service Redis | JSON / MessagePack / Protobuf with schema | pickle / Java ser |
-| Single-service memory cache | Native or struct OK if not shared | Accidentally exposing native via admin API |
-| Durable bus | Schema culture + registry | Undocumented dual formats |
-| Task queues | Portable job payloads; version field | Opaque blobs without reader |
+| Cross-service Redis | JSON, MessagePack, or Protobuf with a schema | pickle or Java serialization |
+| Single-service memory cache | Native encoding or plain structs are OK if not shared | Accidentally exposing native values via an admin API |
+| Durable bus | Schema culture plus a registry | Undocumented dual formats |
+| Task queues | Portable job payloads with a version field | Opaque blobs with no documented reader |
 
 ## Decision frame
 
 ```text
-  Can another process/language/version read this key?
+  Can another process, language, or version read this key?
     yes → portable + versioned contract
-    no  → native optional under documented trust
+    no  → native is optional under documented trust
 ```
 
 | Concern | Practice |
 |---------|----------|
-| Poison messages | Dead-letter; do not infinite-retry bad payloads |
-| Schema change | Version field or subject; dual-read |
-| Large values | Pointer to object store + small metadata message |
-| PII in queues | Retention and redaction ([payload surfaces](payload-surfaces.md)) |
+| Poison messages | Send them to a dead-letter queue; do not infinite-retry bad payloads |
+| Schema change | Use a version field or subject; dual-read during transition |
+| Large values | Store a pointer to object storage plus a small metadata message |
+| PII in queues | Apply retention and redaction ([payload surfaces](payload-surfaces.md)) |
 
 ## Failure modes
 
 | Mistake | Outcome |
 |---------|---------|
-| pickle in Redis “only we write” | Second service appears; or RCE |
-| No max size | Memory blowups |
-| Dual formats without version | Random consumers fail |
-| Cache as system of record | Lost evolution story |
-| Compressing without framing version | Deploy skew |
+| pickle in Redis “only we write” | A second service appears later, or remote code execution becomes possible |
+| No maximum size | Memory blowups |
+| Dual formats without a version | Random consumers fail |
+| Cache used as system of record | The evolution story is lost |
+| Compressing without a framing version | Deploy skew between writers and readers |
 
 ## Real-world sketch
 
-Session cache stores MessagePack with a `v` field and a documented schema. Auth service (Go) and API (Python) share fixtures in CI. A proposal to switch to Python pickle for speed dies in review: a future Node edge worker cannot participate, and security rejects native deserialize from Redis.
+A session cache stores MessagePack with a `v` version field and a documented schema. The auth service (Go) and the API (Python) share fixtures in continuous integration. A proposal to switch to Python pickle for speed dies in review: a future Node edge worker could not participate, and security rejects native deserialize from Redis.
 
 ## In this suite
 
@@ -54,55 +56,57 @@ Session cache stores MessagePack with a `v` field and a documented schema. Auth 
 | Native entries | Cost of portability—not a green light for shared stores |
 | [Using this suite](using-this-suite.md) | Local comparisons only |
 
-
 ## Experiments
 
-**Question:** Are shared **cache/queue** payloads portable, versioned, and safe for every consumer that can read them?
+**Question:** Are shared **cache and queue** payloads portable, versioned, and safe for every consumer that can read them?
 
 ### Setup
-1. List cache keys/topics and all reader services/languages.  
-2. Current encoding (often native or ad hoc JSON).  
-3. TTL, poison-message handling, and DLQ behavior.
+
+1. List cache keys or topics and all reader services and languages.
+2. Note the current encoding (often native or ad hoc JSON).
+3. Record TTL, poison-message handling, and dead-letter queue behavior.
 
 ### Procedure
-1. Apply trust-boundary test: multi-service or multi-language readers ⇒ portable required.  
-2. Encode a golden fixture; consume from each reader; check logical equality.  
-3. Deploy a compatible schema change; confirm old readers still work.  
-4. Inject poison payload; confirm quarantine, not crash loops.  
-5. Suite: size/speed among allowed portable codecs for payload budget.
+
+1. Apply the trust-boundary test: multi-service or multi-language readers require a portable format.
+2. Encode a golden fixture; consume it from each reader; check logical equality.
+3. Deploy a compatible schema change; confirm old readers still work.
+4. Inject a poison payload; confirm quarantine rather than crash loops.
+5. Use the suite for size and speed among allowed portable codecs against the payload budget.
 
 ### Decision rule
-- Any cross-service reader + native encoding ⇒ migrate to portable.  
-- No poison handling ⇒ fix ops before chasing ser benchmarks.
+
+- Any cross-service reader plus native encoding means migrate to portable.
+- No poison handling means fix operations before chasing serialize benchmarks.
 
 ## Metrics
 
 | Metric / signal | Role |
 |-----------------|------|
-| **Reader language/service count** | **Primary** portability driver |
+| **Reader language and service count** | **Primary** portability driver |
 | Interop matrix pass rate | Correctness |
-| Poison/DLQ rate | Operational safety |
-| Payload size p95 vs broker/cache limits | Capacity |
+| Poison and DLQ rate | Operational safety |
+| Payload size at p95 versus broker or cache limits | Capacity |
 | Schema evolution success | Longevity |
-| Suite size / deser time | Cost among portable options |
+| Suite size and deserialize time | Cost among portable options |
 
-**Conclusion style:** “Redis blob is Protobuf portable; native cache encoding removed.”
+**Conclusion style:** “The Redis blob is portable Protobuf; native cache encoding has been removed.”
 
 ## What this suite cannot tell you
 
-- Redis eviction and hot-key design.  
-- Exactly-once queue semantics.  
-- Correct TTL for *your* sessions.
+- Redis eviction policy and hot-key design.
+- Exactly-once queue semantics.
+- The correct TTL for *your* sessions.
 
 ## Common mistakes
 
-- “TTL is 60s so schema doesn’t matter.”  
-- Storing entire user graphs per key.  
+- “TTL is 60 seconds, so schema doesn’t matter.”
+- Storing entire user graphs per key.
 - Logging cache values that contain tokens.
 
 ## Key takeaways
 
-- Shared stores are **interchange boundaries**.  
-- Portable + versioned beats native speed on multi-service caches.  
-- Queues need poison handling and contracts, not only throughput.  
-- Suite picks libraries after the store’s trust model is fixed.
+- Shared stores are **interchange boundaries**.
+- Portable and versioned formats beat native speed on multi-service caches.
+- Queues need poison handling and contracts, not only throughput.
+- The suite picks libraries after the store’s trust model is fixed.

--- a/docs/theory/301/case-analytics-lake.md
+++ b/docs/theory/301/case-analytics-lake.md
@@ -1,24 +1,24 @@
 # Case study: analytics lake on object storage
 
-> Nightly and ad-hoc analytics must scan large histories efficiently—what belongs in the lake versus on the service bus?
+> Nightly and ad-hoc analytics must scan large histories efficiently. What belongs in the lake versus on the service bus?
 
-## Context & goals
+## Context and goals
 
-**Setting:** Product analytics and finance report on years of commerce data in object storage. Query engines (Spark/DuckDB-class) scan few columns over huge tables. Real-time services already emit events on a bus.
+**Setting:** Product analytics and finance report on years of commerce data in object storage. Query engines in the Spark or DuckDB class scan a few columns over huge tables. Real-time services already emit events on a bus.
 
-**Goals:** Cheap scans, reliable schema evolution for tables, clear separation from operational RPC.
+**Goals:** Cheap scans, reliable schema evolution for tables, and a clear separation from operational RPC.
 
-## Non-goals / hard constraints
+## Non-goals and hard constraints
 
-- Not low-latency checkout RPC ([internal RPC case](case-internal-rpc.md)).  
-- Not browser-facing REST ([public REST case](case-public-rest-api.md)).  
-- Must not force analysts to parse opaque service-only native blobs.
+- This is not low-latency checkout RPC ([internal RPC case](case-internal-rpc.md)).
+- This is not browser-facing REST ([public REST case](case-public-rest-api.md)).
+- Analysts must not be forced to parse opaque service-only native blobs.
 
 ## Options on the table
 
 | Option | Sketch |
 |--------|--------|
-| **A. Columnar lake (Parquet/ORC) + catalog** | Compact jobs from events/DB into partitions |
+| **A. Columnar lake (Parquet/ORC) plus catalog** | Compact jobs turn events or database extracts into partitions |
 | **B. Store Protobuf/JSON event files as the lake** | Land raw bus dumps forever |
 | **C. One RPC codec for serve and lake** | “Everything is Protobuf files” |
 
@@ -27,41 +27,42 @@
 | Axis | A. Columnar lake | B. Raw event dump | C. RPC codec as lake |
 |------|------------------|-------------------|----------------------|
 | Scan efficiency | High | Poor | Poor |
-| Evolution | Table + file schema | Event culture only | Wrong tool |
-| Ops | Compaction pipelines | Simple land, hard query | Simple land, hard query |
+| Evolution | Table and file schema | Event culture only | Wrong tool |
+| Operations | Compaction pipelines | Simple to land, hard to query | Simple to land, hard to query |
 | Fit | Analytics | Temporary landing only | Anti-pattern |
 
 ## Recommendation (under these constraints)
 
-**Prefer A:** keep operational events as row messages on the bus ([event backbone](case-event-stream.md)); **compact** into columnar partitions with a catalog. Use B only as a **landing zone** with TTL, not as the system of record for analytics. **Reject C** ([row vs columnar](row-vs-columnar.md)).
-
-
+**Prefer A:** keep operational events as row messages on the bus ([event backbone](case-event-stream.md)); **compact** them into columnar partitions with a catalog. Use B only as a **landing zone** with time-to-live, not as the system of record for analytics. **Reject C** ([row vs columnar](row-vs-columnar.md)).
 
 ## Experiments
 
-**Question:** Lake path—columnar analytical format vs storing row event dumps—for the stated query mix?
+**Question:** For the lake path and the stated query mix, how does a columnar analytical format compare with storing row event dumps?
 
 ### Setup
-1. Representative analytical queries and data volume.  
-2. Candidate: Parquet/ORC/Arrow vs raw JSON/Avro row dumps.  
-3. Cluster or local prototype with same dataset.
+
+1. Representative analytical queries and data volume.
+2. Candidates: Parquet, ORC, or Arrow versus raw JSON or Avro row dumps.
+3. A cluster or local prototype with the same dataset.
 
 ### Procedure
-1. Load same data into row dumps and columnar tables.  
-2. Run query set; record wall time and bytes read.  
-3. Measure storage footprint.  
-4. Confirm ingest path still uses appropriate **row** codec if needed.  
+
+1. Load the same data into row dumps and columnar tables.
+2. Run the query set; record wall time and bytes read.
+3. Measure storage footprint.
+4. Confirm the ingest path still uses an appropriate **row** codec if needed.
 5. Reject “use RPC Protobuf files as the lake.”
 
 ### Decision rule
-- Scan queries dominate ⇒ columnar.  
-- Only point lookup of whole events ⇒ row store may suffice (rare for “lake”).
+
+- When scan queries dominate, choose columnar.
+- When only point lookup of whole events is needed, a row store may suffice (rare for a true “lake”).
 
 ## Metrics
 
 | Metric / signal | Role |
 |-----------------|------|
-| **Query wall time / bytes scanned** | **Primary** |
+| **Query wall time and bytes scanned** | **Primary** |
 | Storage bytes | Cost |
 | Ingest throughput | Pipeline fit |
 | Suite row-codec metrics | Ingest hop only |
@@ -69,11 +70,11 @@
 
 ## What would change the answer
 
-- Tiny data that fits in OLTP replicas → warehouse optional.  
-- Streaming SQL directly on bus with acceptable cost → still plan compaction for history.
+- Tiny data that fits in OLTP replicas can make a warehouse optional.
+- Streaming SQL directly on the bus with acceptable cost still needs a plan for compacting history.
 
 ## Key takeaways
 
-- Lakes want **columnar**; buses want **row events**.  
-- Compaction bridges them deliberately.  
+- Lakes want **columnar** storage; buses want **row events**.
+- Compaction bridges them deliberately.
 - This suite does not replace lake engine benchmarks.

--- a/docs/theory/301/case-event-stream.md
+++ b/docs/theory/301/case-event-stream.md
@@ -1,31 +1,31 @@
 # Case study: event backbone
 
-> A multi-producer, multi-consumer event log must evolve for years—what serialization and control plane fit?
+> A multi-producer, multi-consumer event log must evolve for years. What serialization and control plane fit?
 
-## Context & goals
+## Context and goals
 
-**Setting:** Commerce platform. Producers in Java/Go (conceptually: any of the suite languages), consumers for search index, analytics, fraud, and third-party webhooks (webhooks leave the backbone via a bridge). Events are business facts (`OrderPlaced`, `PaymentCaptured`) retained for months. Independent deploy cadence per service.
+**Setting:** Commerce platform. Producers run in Java and Go (conceptually: any of the suite languages). Consumers include search index, analytics, fraud, and third-party webhooks (webhooks leave the backbone via a bridge). Events are business facts such as `OrderPlaced` and `PaymentCaptured`, retained for months. Each service deploys on its own cadence.
 
 **Goals:**
 
-- Rolling upgrades without stop-the-world schema freezes.  
-- Independent producer/consumer versions.  
-- Clear compatibility policy.  
+- Rolling upgrades without stop-the-world schema freezes.
+- Independent producer and consumer versions.
+- A clear compatibility policy.
 - Analytics can export to a lake without using the event codec as the lake format ([row vs columnar](row-vs-columnar.md)).
 
-## Non-goals / hard constraints
+## Non-goals and hard constraints
 
-- Not per-request public REST ([public REST case](case-public-rest-api.md)).  
-- Not single-binary native dumps ([trust boundaries](trust-boundaries.md)).  
+- This is not per-request public REST ([public REST case](case-public-rest-api.md)).
+- This is not single-binary native dumps ([trust boundaries](trust-boundaries.md)).
 - Consumers must not all deploy in lockstep with producers.
 
 ## Options on the table
 
 | Option | Sketch |
 |--------|--------|
-| **A. Avro + schema registry** | Resolution culture; compatibility modes on subjects |
-| **B. Protobuf + registry/process** | Field-number culture; file/registry of descriptors; CI breaks |
-| **C. JSON events + conventions** | JSON bodies; org schema docs; optional JSON Schema |
+| **A. Avro plus schema registry** | Resolution culture; compatibility modes on subjects |
+| **B. Protobuf plus registry or process** | Field-number culture; file or registry of descriptors; continuous-integration breaks |
+| **C. JSON events plus conventions** | JSON bodies; organization schema docs; optional JSON Schema |
 | **D. Mixed per team** | Each producer picks its own encoding |
 
 ## Trade-off matrix
@@ -33,20 +33,20 @@
 | Axis | A. Avro + registry | B. Protobuf + process | C. JSON events | D. Mixed |
 |------|--------------------|-----------------------|----------------|----------|
 | Independent versioning | Strong (resolution) | Strong if process holds | Weak unless strict | Chaos |
-| Compatibility gates | First-class modes | Breaking-change CI + policy | Manual / schema store | None |
-| Multi-language | Good in data ecosystems | Excellent codegen story | Excellent | Accidental |
-| Debug | Tooling | Tooling | Easy | Varies |
-| Ops cost | Registry HA + subjects | IDL ownership | Low tooling, high drift risk | Highest long-term |
-| Lake story | Row events → compact to columnar | Same | Same | Painful |
+| Compatibility gates | First-class modes | Breaking-change CI plus policy | Manual process or schema store | None |
+| Multi-language | Good in data ecosystems | Excellent code-generation story | Excellent | Accidental |
+| Debug | Tooling required | Tooling required | Easy | Varies |
+| Operations cost | Registry high availability plus subjects | IDL ownership | Low tooling, high drift risk | Highest long-term |
+| Lake story | Row events compact to columnar | Same | Same | Painful |
 
 ## Recommendation (under these constraints)
 
 **Prefer A or B with an explicit culture**—do not half-adopt both ([two schema cultures](two-schema-cultures.md)):
 
-- Choose **A (Avro-class + registry)** when the org already centers on registry-enforced compatibility and data-platform tooling.  
-- Choose **B (Protobuf-class)** when IDL monorepo + codegen already dominate and event schemas can live beside RPC protos with the same discipline.
+- Choose **A (Avro-class plus registry)** when the organization already centers on registry-enforced compatibility and data-platform tooling.
+- Choose **B (Protobuf-class)** when an IDL monorepo and code generation already dominate and event schemas can live beside RPC protos with the same discipline.
 
-**Use C** only for low-stakes or early-stage streams with a **written** schema process and size budget acceptance—plan a migration path before high fan-out.
+**Use C** only for low-stakes or early-stage streams with a **written** schema process and acceptance of JSON size costs. Plan a migration path before high fan-out.
 
 **Reject D** immediately; it fails [polyglot estates](polyglot-estates.md).
 
@@ -54,48 +54,49 @@ Bridge **webhooks** to JSON at the edge; do not force external parties to speak 
 
 Compact to **columnar** lake formats in batch; do not treat the event codec as the analytics store.
 
-
-
 ## Experiments
 
-**Question:** Event backbone under rolling deploy—which **schema culture + registry mode + codec** keeps consumers live?
+**Question:** Under rolling deploy, which **schema culture, registry mode, and codec** keep consumers live on the event backbone?
 
 ### Setup
-1. Multi-service producers/consumers; registry available.  
-2. Rolling deploy plan; sample additive and breaking schema events.  
-3. Broker lag/DLQ metrics.
+
+1. Multi-service producers and consumers; a registry is available.
+2. A rolling deploy plan; sample additive and breaking schema events.
+3. Broker lag and dead-letter queue metrics.
 
 ### Procedure
-1. Choose culture ([two schema cultures](two-schema-cultures.md)) and compatibility mode.  
-2. Dry-run schema register accept/reject.  
-3. Canary producer with additive field; watch consumer errors/lag.  
-4. Attempt break; confirm reject or controlled dual-run ([versioning](versioning-in-the-wild.md)).  
-5. Suite size/speed only for capacity of chosen stack.
+
+1. Choose culture ([two schema cultures](two-schema-cultures.md)) and compatibility mode.
+2. Dry-run schema registration accept and reject cases.
+3. Canary a producer with an additive field; watch consumer errors and lag.
+4. Attempt a break; confirm reject or a controlled dual-run ([versioning](versioning-in-the-wild.md)).
+5. Use suite size and speed only for capacity planning of the chosen stack.
 
 ### Decision rule
-- Prefer enforceable registry mode + culture that matches deploy order.  
-- Speed cannot override failed compatibility experiment.
+
+- Prefer an enforceable registry mode and a culture that matches deploy order.
+- Speed cannot override a failed compatibility experiment.
 
 ## Metrics
 
 | Metric / signal | Role |
 |-----------------|------|
-| Compatibility pass/fail | **Primary** |
-| Consumer lag / error rate on canary | Production safety |
-| DLQ rate | Poison/schema skew |
-| Dual-run duration vs kill criteria | Migration health |
-| Suite size / ser time | Capacity planning |
+| Compatibility pass or fail | **Primary** |
+| Consumer lag and error rate on canary | Production safety |
+| Dead-letter queue rate | Poison messages and schema skew |
+| Dual-run duration versus kill criteria | Migration health |
+| Suite size and serialize time | Capacity planning |
 | Matrix interop if polyglot | Estate fit |
 
 ## What would change the answer
 
-- Single producer team, lockstep deploys → simpler process; registry may be overkill but portable format still required.  
-- Pure analytics firehose with no service consumers → prefer lake-oriented design earlier.  
-- Extreme debug pressure and low volume → JSON events with strict schema may suffice temporarily.
+- A single producer team with lockstep deploys can use a simpler process; a registry may be overkill, but a portable format is still required.
+- A pure analytics firehose with no service consumers prefers lake-oriented design earlier.
+- Extreme debug pressure and low volume may allow JSON events with a strict schema temporarily.
 
 ## Key takeaways
 
-- Event backbones need a **schema culture + enforcement**, not only a codec brand.  
-- Avro-class and Protobuf-class both work; **mixing cultures without tooling** does not.  
-- Suite timings choose implementations; **compatibility policy** chooses the system.  
+- Event backbones need a **schema culture plus enforcement**, not only a codec brand.
+- Avro-class and Protobuf-class both work; **mixing cultures without tooling** does not.
+- Suite timings choose implementations; **compatibility policy** chooses the system.
 - Keep lake columnar conversion as a **deliberate pipeline**, not the consumer’s problem alone.

--- a/docs/theory/301/case-faster-postmortem.md
+++ b/docs/theory/301/case-faster-postmortem.md
@@ -1,87 +1,88 @@
 # Case study: “we need it faster” postmortem
 
-> Latency regressions trigger a codec swap—what should have been checked before the rewrite?
+> Latency regressions trigger a codec swap. What should have been checked before the rewrite?
 
-## Context & goals
+## Context and goals
 
 **Setting:** After a traffic ramp, p99 of a Go service climbs. A popular post claims “switch to X binary format for 10×.” An engineer opens suite Results, picks the top name on a mixed chart, and plans a week-long rewrite.
 
 **Goals of this postmortem:** Separate **wrong benchmark**, **wrong paradigm**, and **wrong payload** so the next fix is targeted.
 
-## Non-goals / hard constraints
+## Non-goals and hard constraints
 
-- Not a greenfield architecture.  
-- Cannot ignore customer SLOs while rewriting.
+- This is not a greenfield architecture.
+- Customer service-level objectives cannot be ignored while rewriting.
 
 ## Options on the table (retrospective)
 
 | Hypothesis | Investigation |
 |------------|---------------|
-| **H1. Wrong library in same family** | Compare JSON (or current family) libs only ([implementation variance](implementation-variance.md)) |
-| **H2. Wrong paradigm for the hop** | Revisit public vs internal, trust, evolution ([capstones](case-public-rest-api.md)) |
-| **H3. Payload shape / allocs** | Profile; deep graphs vs dense structs ([latency tails](latency-tails-and-gc.md), 201 encode cost) |
-| **H4. Not serialization** | DB, lock, downstream RTT, GC from other code |
-| **H5. Compression / network** | Size vs RTT ([compression as system choice](compression-as-system-choice.md)) |
+| **H1. Wrong library in the same family** | Compare JSON (or current-family) libraries only ([implementation variance](implementation-variance.md)) |
+| **H2. Wrong paradigm for the hop** | Revisit public versus internal, trust, and evolution ([capstones](case-public-rest-api.md)) |
+| **H3. Payload shape and allocations** | Profile; deep graphs versus dense structs ([latency tails](latency-tails-and-gc.md), 201 encode cost) |
+| **H4. Not serialization** | Database, lock, downstream round-trip time, GC from other code |
+| **H5. Compression and network** | Size versus round-trip time ([compression as system choice](compression-as-system-choice.md)) |
 
 ## Trade-off matrix (response cost)
 
 | Action | Speed of learning | Risk |
 |--------|-------------------|------|
-| Profile + fair Results slice | Fast | Low |
-| Swap library same family | Medium | Low–medium |
-| Change wire format | Slow | High (clients) |
+| Profile plus a fair Results slice | Fast | Low |
+| Swap library within the same family | Medium | Low to medium |
+| Change the wire format | Slow | High (clients) |
 | Rewrite business logic | Slow | High |
 
 ## Recommendation (under these constraints)
 
-**Before any format rewrite:** (1) confirm serialization is on the critical path via profiling; (2) re-read Results with [using this suite](using-this-suite.md) discipline—same language, paradigm, fixture, mode, metric; (3) try best-in-family library and payload fixes; (4) only then consider paradigm change with an explicit contract migration.
+**Before any format rewrite:** (1) confirm serialization is on the critical path via profiling; (2) re-read Results with [using this suite](using-this-suite.md) discipline—same language, paradigm, fixture, mode, and metric; (3) try the best-in-family library and payload fixes; (4) only then consider a paradigm change with an explicit contract migration.
 
-In the composite postmortem, the root cause was **unbounded JSON allocations on a deep graph** plus a **slow library**, not “JSON is impossible.” Switching libraries and flattening the DTO restored SLO without a cross-stack Protobuf migration.
-
-
+In the composite postmortem, the root cause was **unbounded JSON allocations on a deep graph** plus a **slow library**, not “JSON is impossible.” Switching libraries and flattening the data-transfer object restored the service-level objective without a cross-stack Protobuf migration.
 
 ## Experiments
 
-**Question:** What actually caused the latency regression—wrong library, wrong paradigm, wrong payload/allocs, or not serialization?
+**Question:** What actually caused the latency regression—wrong library, wrong paradigm, wrong payload or allocations, or something that is not serialization?
 
 ### Setup
-1. Production profile or reproduction under load.  
-2. Current codec family and library pin.  
+
+1. Production profile or a reproduction under load.
+2. Current codec family and library pin.
 3. Fair suite access for same-language slices.
 
 ### Procedure
-1. Profile: confirm ser/deser on critical path (H4).  
-2. Fair Results within **same family** (H1) ([using this suite](using-this-suite.md)).  
-3. Inspect payload shape and allocs (H3) ([latency tails](latency-tails-and-gc.md)).  
-4. Only if family cannot meet SLO, revisit paradigm (H2).  
-5. Check compression/network (H5) before rewrite.  
-6. Write postmortem with evidence for the winning hypothesis.
+
+1. Profile: confirm serialize/deserialize is on the critical path (H4).
+2. Fair Results within the **same family** (H1) ([using this suite](using-this-suite.md)).
+3. Inspect payload shape and allocations (H3) ([latency tails](latency-tails-and-gc.md)).
+4. Only if the family cannot meet the service-level objective, revisit paradigm (H2).
+5. Check compression and network (H5) before rewrite.
+6. Write the postmortem with evidence for the winning hypothesis.
 
 ### Decision rule
-- Act on the first hypothesis that both explains p99 and is cheap to validate.  
-- Format rewrite last, not first.
+
+- Act on the first hypothesis that both explains p99 and is cheap to validate.
+- Format rewrite is last, not first.
 
 ## Metrics
 
 | Metric / signal | Role |
 |-----------------|------|
-| **p99 before/after** | **Primary** success |
-| Profile % time in ser/deser | Attribution |
-| Alloc rate / GC pauses | H3 evidence |
-| Suite same-family deser median | H1 evidence |
-| Size / RTT / compress CPU | H5 evidence |
+| **p99 before and after** | **Primary** success |
+| Profile percent time in serialize/deserialize | Attribution |
+| Allocation rate and GC pauses | H3 evidence |
+| Suite same-family deserialize median | H1 evidence |
+| Size, round-trip time, and compress CPU | H5 evidence |
 | Error rate during change | Safety |
 
-**Conclusion style:** Root cause tagged H1–H5 with metrics; fix matched tag.
+**Conclusion style:** Root cause tagged H1–H5 with metrics; the fix matches the tag.
 
 ## What would change the answer
 
-- Profiling shows >50% time in encode of a stable internal hop → paradigm change may be justified (see [internal RPC](case-internal-rpc.md)).  
-- Public API with integrators → cannot silently go binary ([public REST](case-public-rest-api.md)).
+- Profiling shows more than 50% time in encode of a stable internal hop → a paradigm change may be justified (see [internal RPC](case-internal-rpc.md)).
+- A public API with integrators cannot silently go binary ([public REST](case-public-rest-api.md)).
 
 ## Key takeaways
 
-- “Need it faster” is a **diagnosis** problem first.  
-- Wrong chart → wrong rewrite.  
-- Prefer same-family library and shape fixes before multi-week format migrations.  
-- Suite is evidence only inside a disciplined question.
+- “Need it faster” is a **diagnosis** problem first.
+- A wrong chart produces a wrong rewrite.
+- Prefer same-family library and shape fixes before multi-week format migrations.
+- The suite is evidence only inside a disciplined question.

--- a/docs/theory/301/case-internal-rpc.md
+++ b/docs/theory/301/case-internal-rpc.md
@@ -1,95 +1,96 @@
 # Case study: internal high-QPS RPC
 
-> Internal services exchange dense records at high QPS on a private network—how should payloads be encoded?
+> Internal services exchange dense records at high QPS (queries or requests per second) on a private network. How should payloads be encoded?
 
-## Context & goals
+## Context and goals
 
-**Setting:** Payment authorization path. Services in Go and Rust (with a Python batch sibling not on the hot path). Private network, mTLS service identity. Messages are compact structured records (ids, amounts, status enums)—not arbitrary documents. Target: low p99 latency and stable multi-year evolution.
+**Setting:** Payment authorization path. Services run in Go and Rust (with a Python batch sibling that is not on the hot path). The network is private with mutual TLS service identity. Messages are compact structured records (identifiers, amounts, status enums)—not arbitrary documents. The target is low p99 latency and stable multi-year evolution.
 
 **Goals:**
 
-- High throughput encode/decode on the hot path.  
-- Shared contract across Go and Rust.  
-- Safe rolling deploys (additive evolution).  
+- High throughput encode and decode on the hot path.
+- A shared contract across Go and Rust.
+- Safe rolling deploys through additive evolution.
 - No browser clients on this hop.
 
-## Non-goals / hard constraints
+## Non-goals and hard constraints
 
-- Not public third-party HTTP ([public REST case](case-public-rest-api.md)).  
-- Not cross-org untrusted input (still validate size/depth).  
-- Language-native codecs disallowed across services ([trust boundaries](trust-boundaries.md)).  
-- Python appears only offline—must not dictate hot-path format, but must not be impossible to speak later.
+- This is not public third-party HTTP ([public REST case](case-public-rest-api.md)).
+- This is not cross-organization untrusted input (you still validate size and depth).
+- Language-native codecs are disallowed across services ([trust boundaries](trust-boundaries.md)).
+- Python appears only offline—it must not dictate the hot-path format, but speaking the format later must remain possible.
 
 ## Options on the table
 
 | Option | Sketch |
 |--------|--------|
-| **A. Schema-driven IDL (Protobuf-class)** | Shared `.proto`; codegen; field-number culture |
-| **B. Schemaless binary (MessagePack/CBOR-class)** | Flexible maps; org-owned validation |
-| **C. JSON internal** | Same as public style, private network |
-| **D. Language-native per service** | Fastest local graph dump | 
+| **A. Schema-driven IDL (Protobuf-class)** | Shared `.proto`; code generation; field-number culture |
+| **B. Schemaless binary (MessagePack/CBOR-class)** | Flexible maps; organization-owned validation |
+| **C. JSON internal** | Same style as public APIs, but on a private network |
+| **D. Language-native per service** | Fastest local graph dump |
 
 ## Trade-off matrix
 
 | Axis | A. IDL binary | B. Schemaless binary | C. JSON | D. Native |
 |------|---------------|----------------------|---------|-----------|
-| Density / CPU potential | High | Medium–high | Lower | Often high, **unsafe here** |
-| Multi-language | Excellent with codegen | Good if libs mature | Excellent | Fail polyglot |
-| Evolution | Field-number process | Ad hoc unless disciplined | Ad hoc unless schema layer | Brittle |
+| Density and CPU potential | High | Medium to high | Lower | Often high, **unsafe here** |
+| Multi-language | Excellent with code generation | Good if libraries are mature | Excellent | Fails polyglot requirements |
+| Evolution | Field-number process | Ad hoc unless disciplined | Ad hoc unless a schema layer exists | Brittle |
 | Debug | Tooling needed | Tooling needed | Easy | Opaque |
-| Fit for enums/stable records | Strong | Weaker unless careful | OK with care | N/A |
+| Fit for enums and stable records | Strong | Weaker unless careful | OK with care | Not applicable |
 
 ## Recommendation (under these constraints)
 
-**Prefer A (Protobuf-class IDL binary)** for the hot hop: stable record shape, two compiled languages, evolution via field numbers and CI breaking-change checks ([two schema cultures](two-schema-cultures.md)). Select **implementations per language** with suite Results in the schema-driven family ([implementation variance](implementation-variance.md)).
+**Prefer A (Protobuf-class IDL binary)** for the hot hop: stable record shape, two compiled languages, and evolution via field numbers and continuous-integration breaking-change checks ([two schema cultures](two-schema-cultures.md)). Select **implementations per language** with suite Results in the schema-driven family ([implementation variance](implementation-variance.md)).
 
-**Keep B** as alternative if the team refuses IDL tooling *and* will fund validation + compatibility tests equivalent to a registry/IDL process—rare on high-QPS money paths.
+**Keep B** as an alternative if the team refuses IDL tooling *and* will fund validation and compatibility tests equivalent to a registry or IDL process. That combination is rare on high-QPS money paths.
 
-**Keep C** only if SLOs are met with JSON after best libraries and the org values uniform JSON everywhere more than density—validate with measurement, not taste.
+**Keep C** only if service-level objectives are met with JSON after the best libraries, and the organization values uniform JSON everywhere more than density. Validate that claim with measurement, not taste.
 
 **Reject D** at the service boundary.
 
-
-
 ## Experiments
 
-**Question:** Internal high-QPS RPC—schema-driven binary vs schemaless binary vs JSON—under the stated QPS and evolution constraints?
+**Question:** For internal high-QPS RPC, how do schema-driven binary, schemaless binary, and JSON compare under the stated QPS and evolution constraints?
 
 ### Setup
-1. Fix language(s), QPS, p99 budget, payload fixture.  
-2. Families: JSON, MessagePack/CBOR-class, Protobuf/Avro-class.  
-3. Suite Results + load generator.
+
+1. Fix language or languages, QPS, p99 budget, and payload fixture.
+2. Consider families: JSON, MessagePack/CBOR-class, Protobuf/Avro-class.
+3. Use suite Results plus a load generator.
 
 ### Procedure
-1. Fair suite slice per family ([using this suite](using-this-suite.md)).  
-2. Load-test shortlisted impls at target QPS; record p99 and CPU.  
-3. Score evolution needs (field adds, multi-service).  
-4. Apply trust (internal mesh vs expose).  
-5. Recommend with evidence table.
+
+1. Take a fair suite slice per family ([using this suite](using-this-suite.md)).
+2. Load-test shortlisted implementations at target QPS; record p99 and CPU.
+3. Score evolution needs (field adds, multi-service rollout).
+4. Apply trust constraints (internal mesh versus any plan to expose the hop).
+5. Recommend with an evidence table.
 
 ### Decision rule
-- Miss p99 at QPS ⇒ denser/faster family or impl.  
-- Strong evolution + multi-service ⇒ prefer schema-driven despite small speed gap.
+
+- If you miss p99 at target QPS, move to a denser or faster family or implementation.
+- If evolution needs are strong and multiple services share the hop, prefer schema-driven despite a small speed gap.
 
 ## Metrics
 
 | Metric / signal | Role |
 |-----------------|------|
-| **p99 RPC latency @ target QPS** | **Primary** |
-| CPU % on ser/deser | Capacity |
-| Suite median ser/deser + size | Shortlist |
-| Schema evolution pain (qualitative + incident count) | Long-term cost |
+| **p99 RPC latency at target QPS** | **Primary** |
+| CPU percent on serialize and deserialize | Capacity |
+| Suite median serialize/deserialize and size | Shortlist |
+| Schema evolution pain (qualitative plus incident count) | Long-term cost |
 | `mean_fidelity` | Correctness |
 | Cross-family leaderboard | Do not use raw |
 
 ## What would change the answer
 
-- Document-shaped, highly variable payloads → schemaless binary or JSON with validation may fit better.  
-- Many dynamic consumers without codegen → resolution culture / events ([event case](case-event-stream.md)).  
-- Need browser on same hop → not this case; add a gateway with JSON.
+- Document-shaped, highly variable payloads may fit schemaless binary or JSON with validation better.
+- Many dynamic consumers without code generation lean toward resolution culture and events ([event case](case-event-stream.md)).
+- A browser on the same hop is not this case; add a gateway with JSON.
 
 ## Key takeaways
 
-- Internal high-QPS **stable records** lean **schema-driven IDL**, not native codecs.  
-- Suite picks **libraries per language** after the family is fixed.  
+- Internal high-QPS **stable records** lean toward **schema-driven IDL**, not native codecs.
+- The suite picks **libraries per language** after the family is fixed.
 - Evolution process is part of the recommendation—not an afterthought.

--- a/docs/theory/301/case-polyglot-boundary.md
+++ b/docs/theory/301/case-polyglot-boundary.md
@@ -1,82 +1,83 @@
 # Case study: cross-language service boundary
 
-> Three languages must share one internal contract—how do you stop local optima from fragmenting the estate?
+> Three languages must share one internal contract. How do you stop local optima from fragmenting the estate?
 
-## Context & goals
+## Context and goals
 
-**Setting:** Edge gateway (TypeScript), core API (Go), ML feature service (Python). Private network. Need shared request/response for feature fetch at moderate QPS. Human debug of failures required for on-call.
+**Setting:** An edge gateway in TypeScript, a core API in Go, and a machine-learning feature service in Python. The network is private. The team needs a shared request and response for feature fetch at moderate QPS. On-call engineers must be able to debug failures in human-readable ways when needed.
 
-**Goals:** One portable contract, independent deploys, acceptable latency, no native codecs.
+**Goals:** One portable contract, independent deploys, acceptable latency, and no native codecs.
 
-## Non-goals / hard constraints
+## Non-goals and hard constraints
 
-- Not public third-party API (JSON may still be used at outer edge).  
-- Not analytics lake.  
-- Python cannot dictate native pickle to Go/TS.
+- This is not a public third-party API (JSON may still be used at the outer edge).
+- This is not an analytics lake.
+- Python cannot dictate native pickle to Go or TypeScript.
 
 ## Options on the table
 
 | Option | Sketch |
 |--------|--------|
-| **A. Protobuf IDL + codegen** | Shared protos; per-language libs from Results |
-| **B. JSON + JSON Schema** | Uniform text; validate each side |
-| **C. MessagePack ad hoc** | Compact; org-owned schemas |
-| **D. Each language picks favorite** | Local Results winners |
+| **A. Protobuf IDL plus code generation** | Shared protos; per-language libraries chosen from Results |
+| **B. JSON plus JSON Schema** | Uniform text; validate on each side |
+| **C. MessagePack ad hoc** | Compact; organization-owned schemas |
+| **D. Each language picks its favorite** | Local Results winners only |
 
 ## Trade-off matrix
 
 | Axis | A. Protobuf | B. JSON | C. MessagePack | D. Mixed |
 |------|-------------|---------|----------------|----------|
 | Polyglot maturity | Strong | Strong | Good if disciplined | Fail |
-| Debug | Tooling | Easy | Medium | Chaos |
-| Density | High | Lower | Medium–high | — |
-| Evolution | Field numbers + CI | Process heavy | Process heavy | None |
+| Debug | Tooling required | Easy | Medium | Chaos |
+| Density | High | Lower | Medium to high | Not meaningful |
+| Evolution | Field numbers plus CI | Process-heavy | Process-heavy | None |
 | Risk | IDL ownership | Verbosity | Schema drift | Integration hell |
 
 ## Recommendation (under these constraints)
 
-**Prefer A** if the org will own a proto monorepo and CI breaking checks ([two schema cultures](two-schema-cultures.md), [polyglot estates](polyglot-estates.md)). **Prefer B** if debug/simplicity outweigh density and QPS allows—still enforce schema ([public API contracts](public-api-contracts.md) pattern internally). **C** only with explicit schema docs and conformance tests. **Reject D**.
+**Prefer A** if the organization will own a proto monorepo and continuous-integration breaking checks ([two schema cultures](two-schema-cultures.md), [polyglot estates](polyglot-estates.md)). **Prefer B** if debug and simplicity outweigh density and QPS allows—still enforce a schema ([public API contracts](public-api-contracts.md) pattern used internally). **C** is acceptable only with explicit schema docs and conformance tests. **Reject D**.
 
 Pick **implementations per language** via suite Results within the chosen family ([implementation variance](implementation-variance.md)).
 
-
-
 ## Experiments
 
-**Question:** One contract across three languages—does the **interop matrix** pass before we optimize?
+**Question:** With one contract across three languages, does the **interop matrix** pass before we optimize performance?
 
 ### Setup
-1. Three languages from the case; shared schema.  
-2. Golden logical fixtures.  
-3. CI job skeleton for encode/decode matrix.
+
+1. The three languages from the case and a shared schema.
+2. Golden logical fixtures.
+3. A continuous-integration job skeleton for the encode/decode matrix.
 
 ### Procedure
-1. Freeze schema; implement matrix ([polyglot estates](polyglot-estates.md), [401 fidelity](../401/protobuf-cross-language-fidelity.md)).  
-2. Fix failures (defaults, field names, packing).  
-3. Then per-language library pins via suite Results.  
-4. Document version pins and CI gate.
+
+1. Freeze the schema; implement the matrix ([polyglot estates](polyglot-estates.md), [401 fidelity](../401/protobuf-cross-language-fidelity.md)).
+2. Fix failures (defaults, field names, packing).
+3. Then pin per-language libraries via suite Results.
+4. Document version pins and the CI gate.
 
 ### Decision rule
-- Matrix green required before performance work.  
-- No global “fastest language” ranking as the boundary decision.
+
+- A green matrix is required before performance work.
+- Do not use a global “fastest language” ranking as the boundary decision.
 
 ## Metrics
 
 | Metric / signal | Role |
 |-----------------|------|
 | Matrix pass rate | **Primary** |
-| Logical equality failures by pair | Debug signal |
-| Per-lang `mean_fidelity` | Local health |
-| Per-lang p99 / suite medians | Capacity after interop |
+| Logical equality failures by language pair | Debug signal |
+| Per-language `mean_fidelity` | Local health |
+| Per-language p99 and suite medians | Capacity after interop |
 | Version pin drift | Drift risk |
 
 ## What would change the answer
 
-- Browser on the same hop → JSON edge + binary internal via gateway.  
-- Extreme QPS → lean harder to A + load tests ([latency tails](latency-tails-and-gc.md)).
+- A browser on the same hop suggests JSON at the edge and binary internally via a gateway.
+- Extreme QPS leans harder toward A plus load tests ([latency tails](latency-tails-and-gc.md)).
 
 ## Key takeaways
 
-- One boundary → one portable contract → N implementations.  
-- Suite optimizes **library pins**, not politics of mixed formats.  
+- One boundary means one portable contract and N implementations.
+- The suite optimizes **library pins**, not the politics of mixed formats.
 - Conformance tests are part of the recommendation.

--- a/docs/theory/301/case-public-rest-api.md
+++ b/docs/theory/301/case-public-rest-api.md
@@ -1,95 +1,96 @@
 # Case study: public REST API
 
-> A multi-client HTTP API must stay inspectable and stable while latency and payload size start to hurt—what serialization approach fits?
+> A multi-client HTTP API must stay inspectable and stable while latency and payload size start to hurt. What serialization approach fits?
 
-## Context & goals
+## Context and goals
 
-**Setting:** A B2B product exposes a versioned REST API over HTTPS. Clients include browser SPAs, mobile apps, and third-party integrators. Payloads are mostly business documents (orders, accounts)—not multi-megabyte bulk extracts. On-call engineers debug production using logs and `curl`.
+**Setting:** A business-to-business product exposes a versioned REST API over HTTPS. Clients include browser single-page applications, mobile apps, and third-party integrators. Payloads are mostly business documents (orders, accounts)—not multi-megabyte bulk extracts. On-call engineers debug production using logs and `curl`.
 
 **Goals:**
 
-- Human-readable request/response bodies at the edge.  
-- Stable contract for external integrators (years).  
-- Acceptable p95 latency under expected load.  
+- Human-readable request and response bodies at the edge.
+- A stable contract for external integrators over years.
+- Acceptable p95 latency under expected load.
 - Validation of untrusted input.
 
-## Non-goals / hard constraints
+## Non-goals and hard constraints
 
-- Not a private mesh-only RPC (see [internal RPC case](case-internal-rpc.md)).  
-- Not an analytics lake ([row vs columnar](row-vs-columnar.md)).  
-- Cannot require all clients to run `protoc`.  
-- Language-native codecs forbidden on this boundary ([trust boundaries](trust-boundaries.md)).
+- This is not a private mesh-only RPC (see [internal RPC case](case-internal-rpc.md)).
+- This is not an analytics lake ([row vs columnar](row-vs-columnar.md)).
+- You cannot require all clients to run `protoc`.
+- Language-native codecs are forbidden on this boundary ([trust boundaries](trust-boundaries.md)).
 
 ## Options on the table
 
 | Option | Sketch |
 |--------|--------|
-| **A. JSON only + schema** | JSON bodies; OpenAPI/JSON Schema; pick strong JSON libs per language |
-| **B. Dual stack** | JSON default; optional Protobuf (or similar) on same resources via content negotiation |
-| **C. Binary-only public API** | Schema-driven or MessagePack as the only public encoding |
+| **A. JSON only plus schema** | JSON bodies; OpenAPI or JSON Schema; pick strong JSON libraries per language |
+| **B. Dual stack** | JSON as the default; optional Protobuf (or similar) on the same resources via content negotiation |
+| **C. Binary-only public API** | Schema-driven binary or MessagePack as the only public encoding |
 
 ## Trade-off matrix
 
 | Axis | A. JSON + schema | B. Dual stack | C. Binary-only public |
 |------|------------------|---------------|------------------------|
-| Integrator friction | Lowest | Medium (two modes) | Highest |
-| Debug / support | Excellent | Good if JSON remains default | Weak without tools |
-| Evolution | Process + schema docs | Two surfaces to version | IDL discipline |
-| Performance headroom | Implementation-limited | Binary path for heavy clients | Best potential size/CPU |
-| Ops complexity | Low | Medium (transcoding, tests) | Medium–high |
+| Integrator friction | Lowest | Medium (two modes to support) | Highest |
+| Debug and support | Excellent | Good if JSON remains the default | Weak without specialized tools |
+| Evolution | Process plus schema docs | Two surfaces to version | IDL discipline |
+| Performance headroom | Limited by the JSON implementation | Binary path available for heavy clients | Best potential size and CPU |
+| Operations complexity | Low | Medium (transcoding and tests) | Medium to high |
 | Trust | Portable; still validate | Same | Portable; still validate |
 
 ## Recommendation (under these constraints)
 
-**Prefer A (JSON + hard contract)** as the default public surface. Invest in: OpenAPI/JSON Schema (or equivalent), server-side validation, and **per-language JSON library** selection using suite Results ([implementation variance](implementation-variance.md)).
+**Prefer A (JSON plus a hard contract)** as the default public surface. Invest in OpenAPI or JSON Schema (or an equivalent), server-side validation, and **per-language JSON library** selection using suite Results ([implementation variance](implementation-variance.md)).
 
-**Consider B** only when measured evidence shows JSON cannot meet SLOs **after** library and payload-shape work, *and* a non-trivial client set will adopt binary. Own content-type negotiation and conformance tests for both encodings.
+**Consider B** only when measured evidence shows JSON cannot meet service-level objectives **after** library and payload-shape work, *and* a non-trivial client set will adopt binary. Own content-type negotiation and conformance tests for both encodings.
 
-**Reject C** for this public multi-integrator setting unless the product is explicitly a binary protocol API (not classic REST for third parties).
-
-
+**Reject C** for this public multi-integrator setting unless the product is explicitly a binary protocol API rather than classic REST for third parties.
 
 ## Experiments
 
-**Question:** For this public REST API, do we ship **JSON + hard contract** only, or a **dual** binary/JSON contract?
+**Question:** For this public REST API, do we ship **JSON plus a hard contract** only, or a **dual** binary and JSON contract?
 
 ### Setup
-1. Constraints from the case (public clients, versioning, team skills).  
-2. Draft OpenAPI/JSON Schema for the resource.  
-3. Optional second content-type candidate (e.g. Protobuf) only if clients demand it.
+
+1. Restate the constraints from the case (public clients, versioning, team skills).
+2. Draft OpenAPI or JSON Schema for the resource.
+3. Optionally name a second content-type candidate (for example Protobuf) only if clients demand it.
 
 ### Procedure
-1. Contract-test JSON samples against schema (old + additive).  
-2. Load-test JSON library options on the server language ([implementation variance](implementation-variance.md)).  
-3. If dual contract proposed: interop matrix for the binary type + versioning plan.  
-4. Compare ops cost of one vs two contracts against non-goals.  
+
+1. Contract-test JSON samples against the schema (old clients and additive changes).
+2. Load-test JSON library options on the server language ([implementation variance](implementation-variance.md)).
+3. If a dual contract is proposed: build an interop matrix for the binary type and a versioning plan.
+4. Compare operations cost of one versus two contracts against the non-goals.
 5. Recommend under the case constraints.
 
 ### Decision rule
-- Default: single JSON contract with schema if public multi-language clients dominate.  
-- Dual only with explicit client need and versioning budget.
+
+- Default to a single JSON contract with schema when public multi-language clients dominate.
+- Offer dual encoding only with explicit client need and versioning budget.
 
 ## Metrics
 
 | Metric / signal | Role |
 |-----------------|------|
-| Schema/contract CI pass rate | **Primary** ship gate |
+| Schema and contract CI pass rate | **Primary** ship gate |
 | Public client break rate on additive changes | Evolution safety |
-| Server p99 on JSON encode/decode | Performance SLO |
-| Suite JSON metrics (language of server) | Library shortlist |
-| Dual-contract engineering cost | Go/no-go for second type |
+| Server p99 on JSON encode and decode | Performance service-level objective |
+| Suite JSON metrics (language of the server) | Library shortlist |
+| Dual-contract engineering cost | Go or no-go for a second type |
 | Payload leak checks on errors | Security |
 
-**Conclusion style:** Match the case **Recommendation**; metrics must support it.
+**Conclusion style:** Match the case **Recommendation**; the metrics must support it.
 
 ## What would change the answer
 
-- First-party-only clients under your control → B or internal binary becomes easier.  
-- Huge bulk download endpoints → separate export format (columnar/files), not the CRUD API default.  
-- Regulatory need for non-JSON → document exception; still avoid native codecs.
+- First-party-only clients under your control make B or internal binary easier.
+- Huge bulk download endpoints want a separate export format (columnar files), not the CRUD API default.
+- A regulatory need for non-JSON is a documented exception; still avoid native codecs.
 
 ## Key takeaways
 
-- Public REST defaults to **JSON + explicit contract**, not the fastest binary on a chart.  
-- Suite helps choose **JSON libraries**, not whether to abandon HTTP JSON wholesale.  
-- Dual stack is earned by measurement and client willingness—not fashion.
+- Public REST defaults to **JSON plus an explicit contract**, not the fastest binary on a chart.
+- The suite helps choose **JSON libraries**, not whether to abandon HTTP JSON wholesale.
+- A dual stack is earned by measurement and client willingness—not fashion.

--- a/docs/theory/301/compression-as-system-choice.md
+++ b/docs/theory/301/compression-as-system-choice.md
@@ -2,109 +2,114 @@
 
 ## Problem
 
-Bandwidth tickets trigger “enable compression” as a global default. Small RPCs get slower; already-compressed media is double-compressed; teams stop improving message design because “gzip will fix size.” 201 explains the mechanism ([compression vs format](../201/compression-is-not-a-format.md)); 301 places compression in **budgets and tiers**.
+Bandwidth tickets often trigger “enable compression” as a global default. Small RPCs get slower; already-compressed media is double-compressed; teams stop improving message design because “gzip will fix size.” Serialization 201 explains the mechanism ([compression vs format](../201/compression-is-not-a-format.md)). Serialization 301 places compression in **budgets and tiers**.
 
 ## Short answer
 
-Choose a **format for meaning** first; add **compression as a transport or storage tier** when payloads are large enough that CPU trades for bandwidth positively under measurement. Prefer dense schema-aware encodings when structure allows; use general-purpose compression for verbose text or cold storage. Do not treat suite encode times as including your link-level gzip unless the experiment says so.
+Choose a **format for meaning** first. Add **compression as a transport or storage tier** when payloads are large enough that trading CPU for bandwidth is a net win under measurement. Prefer dense schema-aware encodings when structure allows; use general-purpose compression for verbose text or cold storage. Do not treat suite encode times as including your link-level gzip unless the experiment says so.
 
 ## Constraints that matter
 
 | Budget | Question |
 |--------|----------|
-| **CPU** | Encode + compress + decrypt on path? |
-| **Bandwidth / storage** | Dominates cost model? |
-| **Latency** | Small messages: compression can hurt |
-| **Content** | Already compressed media? |
-| **Layering** | TLS, HTTP content-encoding, app-level |
+| **CPU** | Does the path encode, compress, and decrypt on every request? |
+| **Bandwidth and storage** | Do they dominate the cost model? |
+| **Latency** | For small messages, compression can hurt |
+| **Content** | Is the payload already compressed media? |
+| **Layering** | Where do TLS, HTTP content-encoding, and application-level compression sit relative to each other? |
 
 ## Decision frame
 
 ```text
-  Message tiny + local network? → often skip general compression
-  Verbose JSON over WAN / cold store? → compress after measuring
-  Need field access / evolution? → format first; compress opaque bytes after
+  Message tiny and network local?
+        → often skip general-purpose compression
+  Verbose JSON over a WAN or cold store?
+        → compress after measuring
+  Need field access and evolution?
+        → choose format first; compress opaque bytes after
 ```
 
 | Scenario | Lean |
 |----------|------|
-| Public HTTP large JSON | content-encoding + good JSON lib |
-| High-QPS internal RPC 200 B | Usually no app gzip |
+| Public HTTP with large JSON | HTTP content-encoding plus a good JSON library |
+| High-QPS internal RPC around 200 bytes | Usually no application-level gzip |
 | Lake files | Format-aware columnar compression |
-| Encrypted tunnel + gzip | Order and CPU stacking matter |
+| Encrypted tunnel plus gzip | Order of layers and stacked CPU cost matter |
 
 ## Failure modes
 
 | Mistake | Outcome |
 |---------|---------|
 | Compress everything | CPU-bound services |
-| Skip format design | Permanent verbose tax |
+| Skip format design | Permanent tax from verbose encodings |
 | Double compress | Wasted work |
-| Compare compressed size to suite Size column naively | Category error |
-| Forget mobile CPU cost | Battery / heat regressions |
+| Compare compressed size to the suite Size column naively | Category error |
+| Forget mobile CPU cost | Battery and heat regressions |
 
 ## Real-world sketch
 
-An API enables gzip globally. p50 improves for 100KB responses; p99 for 1KB control RPCs worsens. Ops keeps gzip for large GETs via content negotiation and disables it on chatty RPCs. Separately, internal events move from JSON to Protobuf, cutting size before compression—and compression becomes optional on the mesh.
+An API enables gzip globally. Median latency improves for 100KB responses; p99 for 1KB control RPCs worsens. Operations keeps gzip for large GET responses via content negotiation and disables it on chatty RPCs. Separately, internal events move from JSON to Protobuf, cutting size before compression—and compression becomes optional on the mesh.
 
 ## In this suite
 
 | Resource | Role |
 |----------|------|
-| Size / time **Results** | Uncompressed codec behavior (typical) |
-| 201 compression article | Mechanism |
+| Size and time **Results** | Uncompressed codec behavior (typical) |
+| 201 compression article | Mechanism explanation |
 | [Using this suite](using-this-suite.md) | What is and is not measured |
-
 
 ## Experiments
 
-**Question:** Where should **compression** sit (app codec vs transport vs storage), and does it beat a denser binary format for *this* link?
+**Question:** Where should **compression** sit (application codec versus transport versus storage), and does it beat a denser binary format for *this* link?
 
 ### Setup
-1. Measure uncompressed payload sizes and link RTT/bandwidth.  
-2. Candidates: gzip/zstd levels; alternative binary format without compress; compress-after-serialize.  
-3. CPU headroom on producer/consumer.
+
+1. Measure uncompressed payload sizes and link round-trip time and bandwidth.
+2. List candidates: gzip/zstd levels; an alternative binary format without compression; compress-after-serialize.
+3. Estimate CPU headroom on producer and consumer.
 
 ### Procedure
-1. Baseline: suite `median_size_bytes` + ser/deser time without compress.  
-2. Apply candidate compression on the wire; measure **end-to-end** latency and CPU.  
-3. Compare to denser format **without** compress on same hop.  
-4. Check double-compression waste (e.g. already-compressed fields).  
-5. Pick placement (client, reverse proxy, broker, app).
+
+1. Baseline: suite `median_size_bytes` plus serialize/deserialize time without compression.
+2. Apply candidate compression on the wire; measure **end-to-end** latency and CPU.
+3. Compare to a denser format **without** compression on the same hop.
+4. Check for double-compression waste (for example already-compressed fields).
+5. Pick placement (client, reverse proxy, broker, or application).
 
 ### Decision rule
-- Choose the option minimizing **SLO latency or $/bandwidth** under CPU cap—not the smallest microbenchmark size alone.  
+
+- Choose the option that minimizes **service-level latency or cost per bandwidth** under the CPU cap—not the smallest microbenchmark size alone.
 - Compression is not a substitute for a wrong paradigm ([row vs columnar](row-vs-columnar.md)).
 
 ## Metrics
 
 | Metric / signal | Role |
 |-----------------|------|
-| **End-to-end latency with compress** | **Primary** when user-facing |
-| Compressed size / compression ratio | Bandwidth economics |
-| CPU % ser+compress / deser+decompress | Capacity limit |
+| **End-to-end latency with compression** | **Primary** when user-facing |
+| Compressed size and compression ratio | Bandwidth economics |
+| CPU percent for serialize+compress and deserialize+decompress | Capacity limit |
 | Suite `median_size_bytes` (raw codec) | Pre-compress baseline |
-| Suite ser/deser times | Codec CPU before compress |
+| Suite serialize/deserialize times | Codec CPU before compression |
 | Planned `size_gzip6` / `size_zstd3` (if present) | Suite compression proxies |
 | Error rate under CPU saturation | Stability |
 
-**Conclusion style:** “zstd on broker beats switching format for this topic size; app-level gzip off.”
+**Conclusion style:** “zstd on the broker beats switching format for this topic size; application-level gzip stays off.”
 
 ## What this suite cannot tell you
 
-- Optimal zstd level for *your* corpus.  
-- CDN behavior.  
+- The optimal zstd level for *your* corpus.
+- CDN behavior.
 - Interaction with specific TLS offload hardware.
 
 ## Common mistakes
 
-- “Binary so we don’t need gzip” without size data.  
-- “Gzip so format doesn’t matter.”  
-- Benchmarking compress off then enabling it only in prod.
+- Claiming “we use binary so we don’t need gzip” without size data.
+- Claiming “we use gzip so format doesn’t matter.”
+- Benchmarking with compression off, then enabling it only in production.
 
 ## Key takeaways
 
-- Compression is a **tier**, not a format.  
-- Measure CPU vs bandwidth; defaults are not universal.  
-- Improve encoding when structure allows; compress the remainder.  
+- Compression is a **tier**, not a format.
+- Measure CPU versus bandwidth; defaults are not universal.
+- Improve encoding when structure allows; compress the remainder.
 - Suite Size is not automatically post-gzip Size.

--- a/docs/theory/301/implementation-variance.md
+++ b/docs/theory/301/implementation-variance.md
@@ -8,52 +8,52 @@ Architecture discussions often stop at the format name: “we use JSON,” “we
 
 After the **paradigm family** is fixed ([categories](../../analysis/serialization_categories.md)), choose a **concrete library** (and version) per language using same-fixture, same-mode Results—and read Overview caveats. Format brand sets interoperability *possibility*; implementation sets cost and engineering quality on that runtime. Do not assume one language’s winning JSON library has a twin with identical behavior elsewhere ([polyglot estates](polyglot-estates.md)).
 
-Assumes [using this suite](using-this-suite.md) and 201 [encode/decode cost](../201/encode-decode-cost.md).
+This page assumes [using this suite](using-this-suite.md) and 201 [encode/decode cost](../201/encode-decode-cost.md).
 
 ## Constraints that matter
 
 | Source of variance | Example effect |
 |--------------------|----------------|
-| **Parser strategy** | DOM-style tree vs streaming/SIMD-oriented JSON |
-| **Codegen vs reflection** | Schema-driven stacks: generated structs vs runtime field discovery |
-| **Allocations** | Zero-copy views vs new string per field |
-| **Feature surface** | Full JSON numbers vs limited int ranges; schema subsets |
-| **Safety defaults** | Strict vs loose duplicate keys; depth limits |
-| **Maintenance** | Abandoned crate vs actively fuzzed library |
+| **Parser strategy** | DOM-style tree versus streaming or SIMD-oriented JSON |
+| **Code generation versus reflection** | Schema-driven stacks: generated structs versus runtime field discovery |
+| **Allocations** | Zero-copy views versus a new string per field |
+| **Feature surface** | Full JSON numbers versus limited integer ranges; schema subsets |
+| **Safety defaults** | Strict versus loose handling of duplicate keys; depth limits |
+| **Maintenance** | Abandoned crate versus an actively fuzzed library |
 | **Version** | Major upgrades change both speed and edge-case behavior |
 
 ## Decision frame
 
 ```text
-  1. Fix boundary contract + family (301 policy articles)
+  1. Fix boundary contract and family (other 301 policy articles)
   2. For each language on that boundary:
        open Overview → candidates in that family
-       open Results → same TestDataName + mode
-       apply fidelity / stream caveats
-       pick library + pin version
+       open Results → same TestDataName and mode
+       apply fidelity and stream caveats
+       pick library and pin the version
   3. Add conformance tests for shared fixtures across languages
 ```
 
 | Question | Wrong tool | Right tool |
 |----------|------------|------------|
-| JSON vs Protobuf for public API? | Mixed Results chart | Product constraints + families |
-| Which JSON lib in Python? | “JSON is slow” slogan | Python Results, JSON-family rows |
-| Is our Go JSON fast enough? | Rust Results | Go Results + your SLO |
-| Why is size different within MessagePack? | Format myth | Key strategy, lib options, fixture shape |
+| JSON versus Protobuf for a public API? | Mixed Results chart | Product constraints and paradigm families |
+| Which JSON library in Python? | “JSON is slow” slogan | Python Results, JSON-family rows |
+| Is our Go JSON fast enough? | Rust Results | Go Results plus your service-level objective |
+| Why is size different within MessagePack? | Format myth | Key strategy, library options, fixture shape |
 
 ## Failure modes
 
 | Mistake | Consequence |
 |---------|-------------|
-| **Brand-only ADRs** | Unpredictable p99 and surprising edge cases |
+| **Brand-only architecture decision records** | Unpredictable p99 and surprising edge cases |
 | **Copying pins across languages** | APIs diverge; bugs differ |
-| **Ignoring fidelity notes** | “Winning” lib does not round-trip your graph |
+| **Ignoring fidelity notes** | The “winning” library does not round-trip your graph |
 | **Chasing micro-wins weekly** | Churn without product gain |
 | **One global ranking table** | Cross-paradigm and cross-language confusion |
 
 ## Real-world sketch
 
-An ADR says “use JSON for the public API.” Three services pick three Python JSON libraries from habit. Latency and Unicode edge cases differ; only one path appears in CI benchmarks. Unifying on a single Overview-listed library, pinned in lockfiles, and tracked on Python Results for the public fixture reduces variance. A later move to schema-driven **internal** RPC is a separate family decision—not a reason to renumber the public JSON debate.
+An architecture decision record says “use JSON for the public API.” Three services pick three Python JSON libraries from habit. Latency and Unicode edge cases differ; only one path appears in continuous-integration benchmarks. Unifying on a single Overview-listed library, pinned in lockfiles, and tracked on Python Results for the public fixture reduces variance. A later move to schema-driven **internal** RPC is a separate family decision—not a reason to reopen the public JSON debate.
 
 ## In this suite
 
@@ -62,65 +62,67 @@ An ADR says “use JSON for the public API.” Three services pick three Python 
 | Language **Overview** | Registered `SerializerName` values and categories |
 | Language **Results** | Within-language, within-fixture comparisons |
 | [Categories](../../analysis/serialization_categories.md) | Family membership |
-| [Metrics](../../analysis/METRICS.md) / [methodology](../../analysis/ANALYSIS_METHODOLOGY.md) | What means and CIs mean |
+| [Metrics](../../analysis/METRICS.md) / [methodology](../../analysis/ANALYSIS_METHODOLOGY.md) | What means and confidence intervals mean |
 | [Using this suite](using-this-suite.md) | Anti-leaderboard checklist |
 
 When multiple JSON (or multiple schema-driven) entries exist, **that spread is the lesson**: implementation variance is first-class.
 
-
 ## Experiments
 
-**Question:** Within a **fixed family** (e.g. JSON text or schema-driven Protobuf), which **library + version** should we pin on this language?
+**Question:** Within a **fixed family** (for example JSON text or schema-driven Protobuf), which **library and version** should we pin on this language?
 
 ### Setup
-1. Freeze boundary contract and paradigm family (other 301 articles).  
-2. One language, production-like `TestDataName`, same string/stream mode.  
-3. Candidate list from Overview (same family only).
+
+1. Freeze the boundary contract and paradigm family (other 301 articles).
+2. Choose one language, a production-like `TestDataName`, and the same string or stream mode.
+3. Build a candidate list from Overview (same family only).
 
 ### Procedure
-1. Run or read suite Results for all candidates on that slice.  
-2. Filter `mean_fidelity` failures and Overview caveats (stream, unsupported fixtures).  
-3. Rank by the SLO metric (often deser or total median; sometimes size).  
-4. Spot-check version pins and maintenance posture.  
-5. Optional: short load test if p99 matters ([latency tails](latency-tails-and-gc.md)).  
-6. Pin winner in lockfile/manifest.
+
+1. Run or read suite Results for all candidates on that slice.
+2. Filter out `mean_fidelity` failures and Overview caveats (stream mode, unsupported fixtures).
+3. Rank by the service-level metric (often deserialize or total median; sometimes size).
+4. Spot-check version pins and maintenance posture.
+5. Optionally run a short load test if p99 matters ([latency tails](latency-tails-and-gc.md)).
+6. Pin the winner in the lockfile or manifest.
 
 ### Decision rule
-- Winner = best SLO metric among **faithful** same-family candidates.  
-- Never pick by format name alone; never import another language’s winning library name without re-running this experiment.
+
+- The winner is the best service-level metric among **faithful** same-family candidates.
+- Never pick by format name alone. Never import another language’s winning library name without re-running this experiment.
 
 ## Metrics
 
 | Metric / signal | Role |
 |-----------------|------|
-| `total_median_ns` / `deser_median_ns` / `ser_median_ns` | **Primary** speed compare within family |
+| `total_median_ns` / `deser_median_ns` / `ser_median_ns` | **Primary** speed comparison within the family |
 | `avg_ops_per_sec` | Throughput-oriented display of the same idea |
 | `median_size_bytes` | When density matters inside the family |
 | `mean_fidelity` | **Hard filter** |
-| `mean_memory_peak_bytes` | Tie-break when allocs matter |
+| `mean_memory_peak_bytes` | Tie-break when allocations matter |
 | `serializer_version` | What you pin |
-| Effect sizes vs fastest (Cliff’s δ, if multi-way) | “Is the gap real?” |
-| Overview caveats / error CSV | Disqualify unsafe paths |
+| Effect sizes versus fastest (Cliff’s δ, if multi-way) | “Is the gap real?” |
+| Overview caveats and error CSV | Disqualify unsafe paths |
 
-**Conclusion style:** “Pin `orjson@x` for Python JSON **message** fixture, bytes mode—lowest deser median, fidelity 1.0.”
+**Conclusion style:** “Pin `orjson@x` for the Python JSON **message** fixture in bytes mode—lowest deserialize median, fidelity 1.0.”
 
 ## What this suite cannot tell you
 
-- Security audit status of a dependency.  
-- License or supply-chain policy.  
-- Behavior under **your** custom validators and middleware.  
-- Whether a 5% encode win matters against network RTT.
+- Security audit status of a dependency.
+- License or supply-chain policy.
+- Behavior under **your** custom validators and middleware.
+- Whether a 5% encode win matters against network round-trip time.
 
 ## Common mistakes
 
-- Averaging ranks across families “for fairness.”  
-- Treating the fastest lib as default for **untrusted** input without reading safety docs.  
+- Averaging ranks across families “for fairness.”
+- Treating the fastest library as the default for **untrusted** input without reading safety docs.
 - Upgrading major versions without re-checking Results and fidelity.
 
 ## Key takeaways
 
-- Format family ≠ single performance number.  
-- Pick **library + version** per language after family is fixed.  
-- Suite Results exist to expose **implementation variance** honestly.  
-- Polyglot contracts share **format/IDL**, not necessarily identical library behavior.  
+- A format family is not a single performance number.
+- Pick **library and version** per language after the family is fixed.
+- Suite Results exist to expose **implementation variance** honestly.
+- Polyglot contracts share **format or IDL**, not necessarily identical library behavior.
 - Pin and re-measure; brands do not ship bytes—implementations do.

--- a/docs/theory/301/index.md
+++ b/docs/theory/301/index.md
@@ -1,104 +1,106 @@
 # Serialization 301: Production Data Serialization
 
-> Production serialization—trust, contracts, workloads, and honest measurement—for people who already know how formats work.
+> This course is about production serialization: trust, contracts, workloads, and honest measurement. It is written for people who already know how formats work and now need to choose what to ship.
 
 ## Who this is for
 
-Experienced students and developers who must **ship a choice** under conflicting constraints (trust, evolution, multi-language estates, performance claims). This is the **core** advanced course after [Serialization 201](../201/index.md).
+Serialization 301 is for experienced students and developers who must **ship a choice** under conflicting constraints. Those constraints usually include trust and security, schema evolution, multi-language estates, and performance claims that do not all point the same way. This is the **core** advanced course after [Serialization 201](../201/index.md).
 
-If you need to **implement** a codec (wire encoding, runtime paths, a subset lab), that is [Serialization 401](../401/index.md) (implementer elective)—not this course.
+If your goal is to **implement** a codec—wire encoding, runtime paths, or a subset lab—that work belongs in [Serialization 401](../401/index.md) (the implementer elective), not here.
 
 ## Prerequisites
 
 | Type | Requirement |
 |------|-------------|
-| **Hard** | [Serialization 101](../101/index.md) — trade-off axes and at least one lens |
-| **Hard** | [Serialization 201](../201/index.md) — especially schema identity, evolution, dynamic vs IDL, encode cost, zero-copy, compression vs format *(or equivalent experience)* |
+| **Hard** | [Serialization 101](../101/index.md) — trade-off axes and at least one of the three lenses |
+| **Hard** | [Serialization 201](../201/index.md) — especially schema identity, evolution, dynamic versus IDL (interface definition language) binary formats, encode cost, zero-copy, and compression versus format *(or equivalent experience)* |
 
-This course does **not** re-teach 201 mechanisms. Open the 201 article when you need a model; return here for multi-constraint judgment.
+This course does **not** re-teach 201 mechanisms. When you need a mechanism model, open the matching 201 article. Then return here for multi-constraint judgment: what to ship when several good answers conflict.
 
 ## Learning outcomes
 
 By the end of this course you should be able to:
 
-1. **Analyze** trust boundaries and state when portable vs language-native formats are acceptable.
-2. **Distinguish** operational schema cultures (e.g. Avro-style resolution vs Protobuf field-number discipline) without re-deriving wire rules.
-3. **Evaluate** workload fit (row vs columnar at system scale; polyglot contracts; RPC vs messaging shape).
-4. **Critique** benchmark claims using this suite’s paradigm-and-language rules.
-5. **Recommend** a family or approach under stated constraints and **justify** it with categories and **Results**.
-6. **Identify** what this harness cannot answer.
+1. **Analyze** trust boundaries and state when portable formats are required and when language-native formats might still be acceptable.
+2. **Distinguish** operational schema cultures (for example Avro-style writer/reader resolution versus Protobuf field-number discipline) without re-deriving wire rules from scratch.
+3. **Evaluate** workload fit: row versus columnar storage at system scale, polyglot contracts across languages, and the different shapes of RPC (remote procedure call) versus messaging payloads.
+4. **Critique** benchmark claims using this suite’s rules about paradigm families and single-language comparisons.
+5. **Recommend** a format family or approach under stated constraints and **justify** it with serialization categories and language **Results**.
+6. **Identify** what this benchmark harness cannot answer, so you do not over-claim.
 
 ## How this course fits the program
 
 | Course | Role |
 |--------|------|
-| [101](../101/index.md) | Foundations — what serialization is; axes and lenses |
-| [201](../201/index.md) | Mechanisms — how formats work |
-| **301 (this course)** | Production judgment — what to ship under constraints |
-| [401](../401/index.md) | Implementer elective — wire + language paths + lab |
+| [101](../101/index.md) | Foundations — what serialization is; trade-off axes and lenses |
+| [201](../201/index.md) | Mechanisms — how formats work under the hood |
+| **301 (this course)** | Production judgment — what to ship under real constraints |
+| [401](../401/index.md) | Implementer elective — wire formats, language paths, and a hands-on lab |
 
-Default path: **101 → 201 → 301**. Suite lab: [Benchmarks](../../analysis/index.md) and language **Results**.
+The default path through the program is **101, then 201, then 301**. For measured evidence on this project’s harness, use the [Benchmarks](../../analysis/index.md) pages and each language’s **Results**.
 
 ## Suggested paths
 
-**Services track:** [trust boundaries](trust-boundaries.md) → [untrusted input](untrusted-input.md) → [using this suite](using-this-suite.md) → [two schema cultures](two-schema-cultures.md) / [public API contracts](public-api-contracts.md) → [rpc and messaging](rpc-and-messaging.md) → [implementation variance](implementation-variance.md) → cases [public REST](case-public-rest-api.md), [internal RPC](case-internal-rpc.md), [polyglot boundary](case-polyglot-boundary.md).
+You do not need to read every article in order. Pick a track that matches the problem you are solving.
 
-**Data / events track:** [using this suite](using-this-suite.md) → [row vs columnar](row-vs-columnar.md) → [two schema cultures](two-schema-cultures.md) → [schema registries](schema-registries.md) → [versioning](versioning-in-the-wild.md) → cases [event backbone](case-event-stream.md), [analytics lake](case-analytics-lake.md).
+**Services track.** Start with [trust boundaries](trust-boundaries.md) and [untrusted input](untrusted-input.md). Then read [using this suite](using-this-suite.md) so you do not misread numbers. Continue with [two schema cultures](two-schema-cultures.md) and [public API contracts](public-api-contracts.md), then [rpc and messaging](rpc-and-messaging.md) and [implementation variance](implementation-variance.md). Finish with the service case studies: [public REST](case-public-rest-api.md), [internal RPC](case-internal-rpc.md), and [polyglot boundary](case-polyglot-boundary.md).
 
-**Performance deep path:** [using this suite](using-this-suite.md) → [implementation variance](implementation-variance.md) → [latency tails and GC](latency-tails-and-gc.md) → [compression as system choice](compression-as-system-choice.md) → [zero-copy in production](zero-copy-in-production.md) → [faster postmortem](case-faster-postmortem.md).
+**Data and events track.** Start with [using this suite](using-this-suite.md) and [row vs columnar](row-vs-columnar.md). Then study [two schema cultures](two-schema-cultures.md), [schema registries](schema-registries.md), and [versioning](versioning-in-the-wild.md). Finish with [event backbone](case-event-stream.md) and [analytics lake](case-analytics-lake.md).
+
+**Performance deep path.** Start with [using this suite](using-this-suite.md) and [implementation variance](implementation-variance.md). Then read [latency tails and GC](latency-tails-and-gc.md) (garbage collection), [compression as system choice](compression-as-system-choice.md), and [zero-copy in production](zero-copy-in-production.md). Close with the [faster postmortem](case-faster-postmortem.md) case study.
 
 ## Modules
 
-### Trust & boundaries
+### Trust and boundaries
 
 | Article | You should be able to… |
 |---------|------------------------|
-| [Trust boundaries: portable vs native](trust-boundaries.md) | Say when native formats are unacceptable as interchange |
+| [Trust boundaries: portable vs native](trust-boundaries.md) | Explain when language-native formats are unacceptable as interchange |
 | [Untrusted input and parser risk](untrusted-input.md) | Name failure modes and controls for hostile payloads |
-| [Secrets, PII, and payload surfaces](payload-surfaces.md) | Spot leak surfaces in logs, traces, and secondary stores |
+| [Secrets, PII, and payload surfaces](payload-surfaces.md) | Spot leak surfaces in logs, traces, and secondary stores (PII means personally identifiable information) |
 
 ### Contracts that survive years
 
 | Article | You should be able to… |
 |---------|------------------------|
-| [Two schema cultures: Avro vs Protobuf](two-schema-cultures.md) | Contrast resolution culture vs field-number discipline |
-| [Schema registries and compatibility modes](schema-registries.md) | Choose and enforce BACKWARD / FORWARD / FULL-class policy |
-| [Public API contracts](public-api-contracts.md) | Require a hard contract when the wire is JSON |
-| [Versioning strategies in the wild](versioning-in-the-wild.md) | Plan dual-write, content-type, and kill criteria |
+| [Two schema cultures: Avro vs Protobuf](two-schema-cultures.md) | Contrast resolution culture with field-number discipline |
+| [Schema registries and compatibility modes](schema-registries.md) | Choose and enforce BACKWARD, FORWARD, or FULL-class compatibility policy |
+| [Public API contracts](public-api-contracts.md) | Require a hard contract even when the wire format is JSON |
+| [Versioning strategies in the wild](versioning-in-the-wild.md) | Plan dual-write periods, content-type versioning, and kill criteria for old paths |
 
 ### Workload architecture
 
 | Article | You should be able to… |
 |---------|------------------------|
-| [Row vs columnar at system scale](row-vs-columnar.md) | Keep RPC codecs out of lake design (and the reverse) |
-| [Polyglot estates](polyglot-estates.md) | Defend one product contract across runtimes |
-| [RPC and messaging payload design](rpc-and-messaging.md) | Shape messages for sync vs fan-out |
-| [Zero-copy in production](zero-copy-in-production.md) | Adopt zero-copy only when ops fit |
-| [Caching and queues](caching-and-queues.md) | Keep shared stores portable and versioned |
+| [Row vs columnar at system scale](row-vs-columnar.md) | Keep RPC message codecs out of lake design (and keep lake formats off the hot RPC path) |
+| [Polyglot estates](polyglot-estates.md) | Defend one product contract across several language runtimes |
+| [RPC and messaging payload design](rpc-and-messaging.md) | Shape messages differently for synchronous calls versus fan-out events |
+| [Zero-copy in production](zero-copy-in-production.md) | Adopt zero-copy layouts only when operations and tooling fit |
+| [Caching and queues](caching-and-queues.md) | Keep shared caches and queues portable and versioned |
 
 ### Performance as engineering
 
 | Article | You should be able to… |
 |---------|------------------------|
-| [Using this suite without fooling yourself](using-this-suite.md) | Read Results within paradigm and language |
+| [Using this suite without fooling yourself](using-this-suite.md) | Read Results within one paradigm family and one language |
 | [Implementation variance within a family](implementation-variance.md) | Choose libraries without ranking formats globally |
-| [Latency tails, allocations, and GC](latency-tails-and-gc.md) | Judge p99 and allocation pressure |
-| [Compression as a system choice](compression-as-system-choice.md) | Place gzip/zstd without replacing format design |
+| [Latency tails, allocations, and GC](latency-tails-and-gc.md) | Judge p99 (99th-percentile latency) and allocation pressure |
+| [Compression as a system choice](compression-as-system-choice.md) | Place gzip or zstd in the stack without treating compression as a format |
 
 ### Capstones
 
 | Case study | Focus |
 |------------|--------|
-| [Public REST API](case-public-rest-api.md) | JSON + validation vs dual contracts |
-| [Internal high-QPS RPC](case-internal-rpc.md) | Schema-driven vs schemaless binary |
-| [Event backbone](case-event-stream.md) | Avro/Protobuf + evolution under rolling deploy |
-| [Analytics lake](case-analytics-lake.md) | Columnar lake vs row event dumps |
-| [Cross-language service boundary](case-polyglot-boundary.md) | One contract, three languages |
-| [“We need it faster” postmortem](case-faster-postmortem.md) | Wrong bench vs wrong paradigm vs wrong payload |
+| [Public REST API](case-public-rest-api.md) | JSON plus validation versus dual contracts |
+| [Internal high-QPS RPC](case-internal-rpc.md) | Schema-driven binary versus schemaless binary (QPS means queries or requests per second) |
+| [Event backbone](case-event-stream.md) | Avro or Protobuf plus evolution under rolling deploys |
+| [Analytics lake](case-analytics-lake.md) | Columnar lake storage versus dumping row events forever |
+| [Cross-language service boundary](case-polyglot-boundary.md) | One contract shared by three languages |
+| [“We need it faster” postmortem](case-faster-postmortem.md) | Wrong benchmark versus wrong paradigm versus wrong payload |
 
 ## Lab notebooks (Python / Colab)
 
-Experiment notebooks implement selected article **Experiments** (decision labs, not full harness clones):
+Experiment notebooks implement selected article **Experiments**. They are decision labs, not full clones of the suite harness:
 
 | Notebook | Article |
 |----------|---------|
@@ -107,27 +109,27 @@ Experiment notebooks implement selected article **Experiments** (decision labs, 
 | [Two schema cultures](../notebooks/301/two_schema_cultures.ipynb) | [Two schema cultures](two-schema-cultures.md) |
 | [Row vs columnar](../notebooks/301/row_vs_columnar.ipynb) | [Row vs columnar](row-vs-columnar.md) |
 
-Notes: [notebooks README](../notebooks/README.md).
+Install and run notes live in the [notebooks README](../notebooks/README.md).
 
 ## Honesty rules
 
-Same program rules as 101 / 201:
+The same program rules apply as in 101 and 201:
 
-1. No universal winners — always under stated constraints.  
-2. Implementation beats brand name.  
-3. Payload shape matters.  
-4. Compare within paradigm and within one language before cross-cutting claims.  
-5. Security and trust are first-class.  
-6. Prose numbers are illustrative; **Results** own suite truth for this harness.
+1. There are no universal winners. Every recommendation is under stated constraints.
+2. Implementation quality beats brand name. Two libraries can share a format label and differ sharply.
+3. Payload shape matters. Dense records and deep graphs are different jobs.
+4. Compare within one paradigm family and within one language before making cross-cutting claims.
+5. Security and trust are first-class concerns, not afterthoughts.
+6. Numbers in prose are illustrative. Language **Results** own the suite truth for this harness.
 
-**301-specific:** every article includes **Experiments** (setup, procedure, decision rule for the page’s problem) and **Metrics** (primary signals for that experiment’s conclusion), plus **what this suite cannot tell you**. Prefer failure modes and decision tables over mechanism encyclopedias.
+**301-specific guidance:** every article includes **Experiments** (setup, procedure, and a decision rule for that page’s problem), **Metrics** (the primary signals for that experiment’s conclusion), and a section on **what this suite cannot tell you**. Prefer failure modes and decision tables over encyclopedias of wire formats.
 
 ## Assessment (self-check)
 
-Treat the capstone case studies as the course exam: under fixed constraints, recommend an approach, name the evidence you would collect on this suite, and state what you would still need to measure outside the harness.
+Treat the capstone case studies as the course exam. Under fixed constraints, recommend an approach, name the evidence you would collect on this suite, and state what you would still need to measure outside the harness.
 
 ## Where to go next
 
-- Finish or skim [Serialization 201](../201/index.md) if mechanisms are rusty.  
-- [Serialization categories](../../analysis/serialization_categories.md) and language **Results** for suite evidence.  
-- [Serialization 401](../401/index.md) if you build or deeply integrate codecs.
+- Finish or skim [Serialization 201](../201/index.md) if the mechanisms feel rusty.
+- Use [Serialization categories](../../analysis/serialization_categories.md) and language **Results** for suite evidence.
+- Move to [Serialization 401](../401/index.md) if you build or deeply integrate codecs.

--- a/docs/theory/301/latency-tails-and-gc.md
+++ b/docs/theory/301/latency-tails-and-gc.md
@@ -2,7 +2,7 @@
 
 ## Problem
 
-Mean serialize time looks fine while p99 collapses under load. Managed runtimes pay for **allocation rate** with garbage-collection pauses; native heaps pay with allocator contention and cache misses. Codecs that “win” microbenchmarks by allocating per field can lose the service-level objective. Charts that show only means hide the failure mode.
+Mean serialize time looks fine while p99 (the 99th-percentile latency) collapses under load. Managed runtimes pay for **allocation rate** with garbage-collection (GC) pauses; native heaps pay with allocator contention and cache misses. Codecs that “win” microbenchmarks by allocating per field can lose the service-level objective. Charts that show only means hide the failure mode.
 
 ## Short answer
 
@@ -12,37 +12,37 @@ Treat **allocation and copy behavior** as first-class when choosing among implem
 
 | Factor | Effect on tails |
 |--------|-----------------|
-| Allocations per message | GC or allocator work |
-| Payload shape | Deep graphs → many objects |
-| Concurrency | Parallel allocate → pause clustering |
+| Allocations per message | GC work or allocator work |
+| Payload shape | Deep graphs create many objects |
+| Concurrency | Parallel allocate can cluster pauses |
 | Buffer reuse | Lowers steady-state pressure |
-| Native vs managed | Different pause mechanics, same “don’t thrash the allocator” lesson |
+| Native versus managed | Different pause mechanics, same lesson: do not thrash the allocator |
 
 ## Decision frame
 
 ```text
-  SLO is p99/p999 under load?
-    → inspect allocs / pooling / streaming options
+  Is the SLO p99 or p999 under load?
+    → inspect allocations, pooling, and streaming options
     → load-test; do not stop at mean Results
-  Mean-only batch job nightly?
-    → means may suffice; still watch memory ceiling
+  Is this a mean-only nightly batch job?
+    → means may suffice; still watch the memory ceiling
 ```
 
 | Signal | Action |
 |--------|--------|
-| High alloc/op in profiler | Try alternate lib or object reuse |
-| GC pause correlates with traffic | Reduce chattiness of decode |
-| Size fine, latency bad | CPU/alloc path—not network |
+| High allocations per operation in the profiler | Try an alternate library or object reuse |
+| GC pause correlates with traffic | Reduce how chatty decode is |
+| Size looks fine, latency looks bad | Suspect the CPU or allocation path, not the network |
 
 ## Failure modes
 
 | Mistake | Outcome |
 |---------|---------|
-| Optimizing mean only | p99 pages at peak |
-| Ignoring shape | Microbench on tiny structs misleads |
-| Cross-language GC comparison | Invalid |
-| Disabling GC in bench | Fantasy numbers |
-| Pooling without clear ownership | Use-after-free / data races |
+| Optimizing mean only | p99 pages at peak traffic |
+| Ignoring payload shape | Microbenchmarks on tiny structs mislead |
+| Cross-language GC comparison | Invalid basis for format choice |
+| Disabling GC in the bench | Fantasy numbers |
+| Pooling without clear ownership | Use-after-free and data races |
 
 ## Real-world sketch
 
@@ -52,34 +52,36 @@ Two JSON libraries show similar mean decode on Python Results. Production p99 di
 
 | Resource | Role |
 |----------|------|
-| **Results** means / ops | Orientation within language |
-| Methodology | Warmup, outliers—read before quoting |
-| Optional memory metrics | If present for a language, use cautiously |
+| **Results** means and ops | Orientation within one language |
+| Methodology | Warmup and outliers—read before quoting |
+| Optional memory metrics | If present for a language, use them cautiously |
 | [Using this suite](using-this-suite.md) | Fair slice checklist |
 
 Many published tables emphasize central tendency; **you** still owe a concurrent validation.
-
 
 ## Experiments
 
 **Question:** Under production-shaped load, is encode/decode **allocation pressure** (not mean time alone) driving p99 risk for candidate libraries in the same family?
 
 ### Setup
-1. Fix **one language**, **one paradigm family**, and **one fixture** close to production shape (e.g. deep graph vs dense `Telemetry`)—see [using this suite](using-this-suite.md).  
-2. Shortlist 2–3 implementations from language **Results** (same family); note versions.  
-3. Confirm the harness reports or you can attach: wall times, optional `MemoryPeakBytes` / tracemalloc (Python), and a **process profiler** (alloc rate, GC pauses) outside pure means.  
+
+1. Fix **one language**, **one paradigm family**, and **one fixture** close to production shape (for example a deep graph versus dense `Telemetry`)—see [using this suite](using-this-suite.md).
+2. Shortlist two or three implementations from language **Results** (same family); note versions.
+3. Confirm the harness reports, or that you can attach: wall times, optional `MemoryPeakBytes` or tracemalloc (Python), and a **process profiler** for allocation rate and GC pauses outside pure means.
 4. Configure a load path that reuses your service concurrency model (workers, pool sizes)—not only single-threaded suite loops.
 
 ### Procedure
-1. Run suite slice for candidates → record mean/median ser, deser, total; size; fidelity.  
-2. If available, record `mean_memory_peak_bytes` / peak alloc columns.  
-3. Load-test or profile each candidate on the same fixture at target concurrency; capture **p99/p999** latency and GC/alloc stats from the runtime.  
-4. Optionally disable “fantasy” modes (e.g. GC off) only as a diagnostic—not as the decision number.  
-5. Apply the decision rule below; pin library + version.
+
+1. Run the suite slice for candidates and record mean/median serialize, deserialize, and total time; size; and fidelity.
+2. If available, record `mean_memory_peak_bytes` or peak allocation columns.
+3. Load-test or profile each candidate on the same fixture at target concurrency; capture **p99/p999** latency and GC/allocation stats from the runtime.
+4. Optionally disable “fantasy” modes (for example GC off) only as a diagnostic—not as the decision number.
+5. Apply the decision rule below; pin library and version.
 
 ### Decision rule
-- Prefer the candidate that meets **p99 SLO** with acceptable alloc/GC, even if mean is slightly worse.  
-- Reject candidates that win mean Results but show high alloc/op or GC pause clustering under load.  
+
+- Prefer the candidate that meets the **p99 service-level objective** with acceptable allocation and GC behavior, even if mean is slightly worse.
+- Reject candidates that win mean Results but show high allocations per operation or GC pause clustering under load.
 - Do **not** compare GC metrics across languages to choose a format brand.
 
 ## Metrics
@@ -88,35 +90,36 @@ Primary signals for this page’s decision (see also [Metrics catalog](../../ana
 
 | Metric / signal | Where | Role |
 |-----------------|-------|------|
-| **p99 / p999 latency** (ser, deser, or end-to-end) | Load test / APM | **Primary**—tails are the SLO |
+| **p99 / p999 latency** (serialize, deserialize, or end-to-end) | Load test or APM | **Primary**—tails are the service-level objective |
 | `total_median_ns` / `ser_median_ns` / `deser_median_ns` | Suite analysis | Orientation within language; not sufficient alone |
 | `total_mean_ns`, `avg_ops_per_sec` | Suite | Central tendency; easy to over-trust |
-| `total_p95_ns` / `total_p99_ns` (if computed) | Suite / full metrics profile | Bridge from harness to tails when available |
+| `total_p95_ns` / `total_p99_ns` (if computed) | Suite or full metrics profile | Bridge from harness to tails when available |
 | `total_std_ns` / CV / MAD | Suite | Dispersion hint; not production p99 |
-| `mean_memory_peak_bytes` / `MemoryPeakBytes` | Suite (optional) | Alloc pressure proxy when present |
+| `mean_memory_peak_bytes` / `MemoryPeakBytes` | Suite (optional) | Allocation-pressure proxy when present |
 | **Allocations per op / alloc rate** | Profiler | Explains GC pressure |
 | **GC pause time / frequency** | Runtime metrics | Direct tail mechanism on managed runtimes |
-| `median_size_bytes` | Suite | Separates “big payload” from “alloc-heavy codec” |
-| `mean_fidelity` | Suite | Reject broken codecs before performance debate |
+| `median_size_bytes` | Suite | Separates “big payload” from “allocation-heavy codec” |
+| `mean_fidelity` | Suite | Reject broken codecs before the performance debate |
 
-**Conclusion style:** “Choose library L because p99 and alloc rate under load meet SLO; mean Results only shortlisted L.”  
+**Conclusion style:** “Choose library L because p99 and allocation rate under load meet the service-level objective; mean Results only shortlisted L.”
+
 **Not decision metrics here:** cross-language Results ranks; format brand alone.
 
 ## What this suite cannot tell you
 
-- p99 under *your* framework and GC flags.  
-- Interaction with other allocators on the host.  
+- p99 under *your* framework and GC flags.
+- Interaction with other allocators on the host.
 - Whether pooling is safe in *your* concurrency model.
 
 ## Common mistakes
 
-- “Binary always lower GC” without measuring.  
-- Comparing C# and Python pause behavior for format choice.  
-- Shipping the fastest mean lib that allocates unbounded on hostile input ([untrusted input](untrusted-input.md)).
+- Claiming “binary always means lower GC” without measuring.
+- Comparing C# and Python pause behavior to choose a format brand.
+- Shipping the fastest mean library that allocates unbounded on hostile input ([untrusted input](untrusted-input.md)).
 
 ## Key takeaways
 
-- Tails track **allocations and shape**, not slogans.  
-- Means are necessary, not sufficient, for latency SLOs.  
-- Pick implementations with runtime behavior in mind.  
+- Tails track **allocations and shape**, not slogans.
+- Means are necessary, not sufficient, for latency service-level objectives.
+- Pick implementations with runtime behavior in mind.
 - Confirm under load outside the harness.

--- a/docs/theory/301/payload-surfaces.md
+++ b/docs/theory/301/payload-surfaces.md
@@ -2,108 +2,120 @@
 
 ## Problem
 
-Serialization choices affect **where meaning appears in cleartext**: HTTP bodies, queue messages, core dumps, APM traces, exception messages, and “temporary” debug flags. A secure transport (TLS) does not protect **logs that capture the body**, nor support engineers pasting payloads into tickets. Incidents often start as performance or schema work and end as privacy breaches.
+Serialization choices affect **where meaning appears in cleartext**: HTTP bodies, queue messages, core dumps, application performance monitoring (APM) traces, exception messages, and “temporary” debug flags. A secure transport such as TLS (Transport Layer Security) does not protect **logs that capture the body**, and it does not stop support engineers from pasting payloads into tickets.
+
+Incidents often start as performance or schema work and end as privacy breaches.
 
 ## Short answer
 
-Treat every serialize path as creating a **payload surface**. Classify fields (public, internal, secret, regulated PII). Keep secrets **out of** routinely logged encodings; prefer references/tokens over raw credentials in messages. Redact at log/trace boundaries; restrict who can decode binary production traffic. Format choice (JSON vs binary) changes **ease of inspection**, not the need for a data-handling policy.
+Treat every serialize path as creating a **payload surface**—a place where serialized meaning can be inspected, copied, or retained. Classify fields into public, internal, secret, and regulated PII (personally identifiable information). Keep secrets **out of** routinely logged encodings. Prefer references or short-lived tokens over raw credentials in messages.
+
+Redact at log and trace boundaries. Restrict who can decode binary production traffic. The choice between JSON and binary changes **ease of inspection**, not the need for a data-handling policy.
 
 ## Constraints that matter
 
 | Surface | Risk |
 |---------|------|
-| **Access/application logs** | Full JSON bodies with PII |
-| **APM / error trackers** | Request capture, breadcrumbs |
-| **Message bus retention** | Long-lived events with personal data |
-| **Support exports** | “Send us a sample payload” |
-| **Client-side storage** | Tokens in local caches |
-| **Core dumps / crash reports** | In-memory objects including secrets |
+| **Access and application logs** | Full JSON bodies that contain PII |
+| **APM and error trackers** | Request capture and breadcrumb storage |
+| **Message bus retention** | Long-lived events that still carry personal data |
+| **Support exports** | “Please send us a sample payload” workflows |
+| **Client-side storage** | Tokens stored in local caches |
+| **Core dumps and crash reports** | In-memory objects that include secrets |
 
 ## Decision frame
 
 | Field class | Prefer |
 |-------------|--------|
-| Auth secrets, keys | Never in durable business events; short-lived tokens only if unavoidable |
-| Regulated PII | Minimize; encrypt or tokenize; retention policy |
-| Internal ids | OK in portable contracts with access control |
-| Debug-only dumps | Explicit flag, sampling, redaction, short TTL |
+| Auth secrets and keys | Never put these in durable business events; use short-lived tokens only if unavoidable |
+| Regulated PII | Minimize what you store; encrypt or tokenize; apply a retention policy |
+| Internal identifiers | Acceptable in portable contracts when access control is in place |
+| Debug-only dumps | Require an explicit flag, sampling, redaction, and a short time-to-live (TTL) |
+
+A useful personal test:
 
 ```text
   Would I paste this payload into a public ticket?
-    no → ensure logs/traces cannot either
+    no → ensure logs and traces cannot paste it either
 ```
+
+If you would not share the payload publicly, your observability stack must not share it either.
 
 ## Failure modes
 
 | Mistake | Outcome |
 |---------|---------|
-| Log full request/response by default | Bulk PII in SIEM |
-| Binary “is safer” myth | Still decoded in tools; false confidence |
-| Redact only in one service | Downstream still logs |
-| Schema fields named `password`, `ssn` in events | Permanent topic pollution |
-| Sharing production MessagePack in Slack | Uncontrolled copies |
+| Logging full request and response bodies by default | Bulk PII lands in the security information and event management (SIEM) system |
+| Believing “binary is safer” | Bytes are still decoded in tools; the myth creates false confidence |
+| Redacting in only one service | Downstream services still log the sensitive fields |
+| Schema fields named `password` or `ssn` in long-lived events | Permanent pollution of the event topic |
+| Sharing production MessagePack dumps in Slack | Uncontrolled copies outside access control |
 
 ## Real-world sketch
 
-A team switches internal RPC to Protobuf for speed. Debugging gets harder, so they enable “log decoded message on error.” Error rates spike during an outage; PII floods the log pipeline. The codec change did not cause the leak—the **error surface** did. A better design: structured error codes, correlation ids, and optional secure debug buckets with access control—not full payload echo.
+A team switches internal RPC to Protobuf for speed. Debugging gets harder, so they enable “log the decoded message on error.” Error rates spike during an outage, and PII floods the log pipeline. The codec change did not cause the leak—the **error surface** did.
+
+A better design uses structured error codes, correlation identifiers, and optional secure debug buckets with access control—not full payload echo on every failure.
 
 ## In this suite
 
 | Resource | Role |
 |----------|------|
-| Fixtures | Synthetic data—not a privacy model |
-| **Results** | Size/time only |
-| [Using this suite](using-this-suite.md) | Measurement honesty, not compliance |
-
+| Fixtures | Synthetic data—not a privacy model for your product |
+| **Results** | Size and time only |
+| [Using this suite](using-this-suite.md) | Measurement honesty, not compliance guidance |
 
 ## Experiments
 
-**Question:** Where can **secrets/PII** in serialized payloads leak (logs, traces, caches, support tools), and what redaction is required?
+**Question:** Where can **secrets and PII** in serialized payloads leak (logs, traces, caches, support tools), and what redaction is required?
 
 ### Setup
-1. Inventory serializers on the path (API bodies, queue payloads, cache values).  
-2. List secondary systems: APM, structured logs, DLQ dumps, admin UIs.  
-3. Mark fields: secret, PII, regulated, benign.
+
+1. Inventory serializers on the path: API bodies, queue payloads, and cache values.
+2. List secondary systems: APM, structured logs, dead-letter queue (DLQ) dumps, and admin user interfaces.
+3. Mark fields as secret, PII, regulated, or benign.
 
 ### Procedure
-1. Trace one request: note every component that might log raw payload or fields.  
-2. Check default log level and exception formatters for body capture.  
-3. For each sink, require allowlist/redaction or payload omission.  
-4. Confirm support tooling cannot pull production payloads without access control.  
-5. Re-test after a deliberate fault (failed deser) to ensure error paths do not dump secrets.
+
+1. Trace one request and note every component that might log the raw payload or individual fields.
+2. Check default log levels and exception formatters for body capture.
+3. For each sink, require an allowlist, redaction, or complete omission of payloads.
+4. Confirm support tooling cannot pull production payloads without access control.
+5. Re-test after a deliberate fault (for example a failed deserialize) to ensure error paths do not dump secrets.
 
 ### Decision rule
-- Any sink with unrestricted payload logging ⇒ fix redaction or drop body logging before ship.  
+
+- Any sink with unrestricted payload logging must be fixed—redact or drop body logging—before ship.
 - Serialization format choice is secondary to **surface control**.
 
 ## Metrics
 
 | Metric / signal | Role |
 |-----------------|------|
-| **Count of sinks that can see raw payload** | **Primary** exposure metric |
-| **Fields classified secret/PII** | Scope of redaction |
-| **Redaction coverage** (% sensitive fields scrubbed) | Control effectiveness |
-| Access-control on DLQ/debug endpoints | Residual risk |
-| Log volume of payload-sized events | Cost + leak amplification |
+| **Count of sinks that can see the raw payload** | **Primary** exposure metric |
+| **Fields classified as secret or PII** | Scope of redaction work |
+| **Redaction coverage** (percentage of sensitive fields scrubbed) | Control effectiveness |
+| Access control on DLQ and debug endpoints | Residual risk |
+| Log volume of payload-sized events | Cost and leak amplification |
 | Suite metrics | Not primary for this decision |
 
-**Conclusion style:** “APM and error logs redacted; DLQ restricted; no full-body info logs.”
+**Conclusion style:** “APM and error logs are redacted; the DLQ is restricted; we never emit full-body info logs.”
 
 ## What this suite cannot tell you
 
-- Legal classification of your fields (GDPR, HIPAA, …).  
-- Correct retention periods.  
-- Whether your log vendor is in-region.
+- The legal classification of your fields (GDPR, HIPAA, and similar regimes).
+- Correct retention periods for your jurisdiction and product.
+- Whether your log vendor stores data in the required region.
 
 ## Common mistakes
 
-- Using production payloads as permanent test fixtures in git.  
-- Assuming encryption at rest on the bus makes logging safe.  
-- Forgetting secondary surfaces (metrics labels with user ids).
+- Using production payloads as permanent test fixtures in git.
+- Assuming encryption at rest on the bus makes logging safe.
+- Forgetting secondary surfaces such as metrics labels that embed user identifiers.
 
 ## Key takeaways
 
-- Serialization creates **inspectable artifacts**; policy must cover them.  
-- JSON vs binary changes friction, not obligation.  
-- Redact and minimize at every payload surface—not only at the TLS hop.  
+- Serialization creates **inspectable artifacts**, and policy must cover them.
+- JSON versus binary changes friction, not obligation.
+- Redact and minimize at every payload surface—not only at the TLS hop.
 - The suite does not substitute for a data-handling review.

--- a/docs/theory/301/polyglot-estates.md
+++ b/docs/theory/301/polyglot-estates.md
@@ -2,41 +2,45 @@
 
 ## Problem
 
-Real estates run **C#**, **Python**, **Go**, **Rust**, **JavaScript**, and more against shared data. Each language has a “fastest” library on some chart. Without a polyglot policy, every team picks a local optimum: one service speaks MessagePack with string keys, another speaks Protobuf, a third pickles to Redis. Integration cost appears later as translation layers, dual-write windows, and incidents that only reproduce at language boundaries.
+Real estates run **C#**, **Python**, **Go**, **Rust**, **JavaScript**, and more against shared data. Each language has a “fastest” library on some chart. Without a polyglot policy, every team picks a local optimum: one service speaks MessagePack with string keys, another speaks Protobuf, and a third pickles values into Redis.
+
+Integration cost appears later as translation layers, dual-write windows, and incidents that only reproduce at language boundaries.
 
 ## Short answer
 
-For each **boundary** (public API, internal RPC, async event, cache, file), pick **one portable contract** and implement it in every language that crosses that boundary. Prefer formats with **mature multi-language implementations** and an explicit evolution story ([two schema cultures](two-schema-cultures.md)). Use this suite to compare **implementations within one language**, not to elect a global winner across languages. Dual contracts are allowed at **edges** (e.g. JSON public + Protobuf internal) when translation is owned and tested—not as accidental drift.
+For each **boundary**—public API, internal RPC, async event, cache, or file—pick **one portable contract** and implement it in every language that crosses that boundary. Prefer formats with **mature multi-language implementations** and an explicit evolution story ([two schema cultures](two-schema-cultures.md)).
 
-Assumes [trust boundaries](trust-boundaries.md) (no language-native interchange) and [using this suite](using-this-suite.md).
+Use this suite to compare **implementations within one language**, not to elect a global winner across languages. Dual contracts are allowed at **edges** (for example JSON on the public surface and Protobuf internally) when translation is owned and tested—not as accidental drift.
+
+This page assumes [trust boundaries](trust-boundaries.md) (no language-native interchange) and [using this suite](using-this-suite.md).
 
 ## Constraints that matter
 
 | Constraint | Implication |
 |------------|-------------|
-| **Languages in the critical path** | Contract must have libraries (or codegen) in each |
-| **Human debuggability** | Public/partner edges often keep JSON even if internal is binary |
-| **Evolution ownership** | One IDL/registry/process—not N ad-hoc JSON dialects |
-| **Team skill** | Exotic codecs with one expert do not survive staff changes |
-| **Fidelity** | Types (decimals, timestamps, maps) must round-trip across languages |
-| **Ops tooling** | Can on-call inspect payloads in incidents? |
+| **Languages in the critical path** | The contract must have libraries or code generation in each of them |
+| **Human debuggability** | Public and partner edges often keep JSON even when internal traffic is binary |
+| **Evolution ownership** | One IDL, registry, or process—not N ad hoc JSON dialects |
+| **Team skill** | Exotic codecs that only one expert understands do not survive staff changes |
+| **Fidelity** | Types such as decimals, timestamps, and maps must round-trip across languages |
+| **Operations tooling** | Can on-call engineers inspect payloads during incidents? |
 
 ## Decision frame
 
 | Boundary | Common polyglot choice | Notes |
 |----------|------------------------|-------|
-| Public HTTP API | JSON + OpenAPI/JSON Schema | Dual Protobuf optional for selected clients |
-| Internal sync RPC | Protobuf/IDL or schemaless binary with validation | One choice per platform, not per service |
-| Async events | Avro/Protobuf + registry **or** JSON with strict schema process | Match [schema culture](two-schema-cultures.md) |
-| Shared cache blob | Portable binary or JSON; document schema | Never pickle as cross-service default |
-| Data lake | Columnar / Avro—not RPC fashion | See [row vs columnar](row-vs-columnar.md) |
+| Public HTTP API | JSON plus OpenAPI or JSON Schema | Dual Protobuf is optional for selected clients |
+| Internal synchronous RPC | Protobuf/IDL or schemaless binary with validation | One choice per platform, not a different choice per service |
+| Async events | Avro or Protobuf plus a registry, **or** JSON with a strict schema process | Match your [schema culture](two-schema-cultures.md) |
+| Shared cache blob | Portable binary or JSON with a documented schema | Never use pickle as the cross-service default |
+| Data lake | Columnar formats or Avro—not whatever is fashionable for RPC | See [row vs columnar](row-vs-columnar.md) |
 
 ```text
   List languages that must speak the boundary
-        → eliminate codecs without multi-lang story
-        → pick family (JSON / schemaless binary / schema-driven)
+        → eliminate codecs without a multi-language story
+        → pick a family (JSON / schemaless binary / schema-driven)
         → pick ONE evolution process
-        → implement + conformance tests across languages
+        → implement and run conformance tests across languages
         → use per-language Results only to pick libraries
 ```
 
@@ -44,16 +48,18 @@ Assumes [trust boundaries](trust-boundaries.md) (no language-native interchange)
 
 | Mistake | Consequence |
 |---------|-------------|
-| **Local leaderboard** | Each team’s fastest lib; no shared bytes |
-| **Native “just for us”** | Second language cannot join |
+| **Local leaderboard** | Each team’s fastest library; no shared byte format |
+| **Native “just for us”** | A second language cannot join the path |
 | **Undocumented JSON dialects** | Field renames break silently |
-| **Number of contracts ∝ number of teams** | N² translators |
-| **Cross-language rank from suite** | “Rust won, rewrite the company” |
-| **Schema only in one repo** | Other languages reverse-engineer production |
+| **Number of contracts grows with the number of teams** | A quadratic mess of translators |
+| **Cross-language rank from the suite** | “Rust won, rewrite the company” |
+| **Schema lives in only one repository** | Other languages reverse-engineer production traffic |
 
 ## Real-world sketch
 
-Platform engineering standardizes **internal RPC on Protobuf** and **public HTTP on JSON**. Python, Go, and TypeScript services generate stubs from the same protos; public gateways map JSON ↔ Protobuf at the edge with explicit field tests. A team proposes MessagePack everywhere because it looked strong on one language Results page. Review asks: do all six languages have maintained libs, a single evolution story, and debug story? Without that, MessagePack becomes another dialect. The suite still helps each language pick **which Protobuf or JSON library** to use.
+Platform engineering standardizes **internal RPC on Protobuf** and **public HTTP on JSON**. Python, Go, and TypeScript services generate stubs from the same protos. Public gateways map JSON to Protobuf at the edge with explicit field tests.
+
+A team proposes MessagePack everywhere because it looked strong on one language Results page. Review asks: do all six languages have maintained libraries, a single evolution story, and a debug story? Without that, MessagePack becomes another dialect. The suite still helps each language pick **which Protobuf or JSON library** to use.
 
 ## In this suite
 
@@ -61,62 +67,64 @@ Platform engineering standardizes **internal RPC on Protobuf** and **public HTTP
 |----------|------|
 | Multi-language Results | Evidence for **library choice per language** under one family |
 | [Serialization categories](../../analysis/serialization_categories.md) | Shared family vocabulary |
-| Shared `schemas/` (e.g. `.proto`) where present | Example of one contract, many harnesses |
+| Shared `schemas/` (for example `.proto` files) where present | Example of one contract, many harnesses |
 | [Using this suite](using-this-suite.md) | Never crown cross-language winners |
 
-A format that appears in **many** language overviews is a candidate for polyglot adoption; absence in one language is a **integration risk**, not a moral failing of that language.
-
+A format that appears in **many** language overviews is a candidate for polyglot adoption. Absence in one language is an **integration risk**, not a moral failing of that language.
 
 ## Experiments
 
 **Question:** Can one **product contract** interoperate across the languages we ship—and where does fidelity break?
 
 ### Setup
-1. List languages on the boundary and candidate contract (e.g. Protobuf + shared `.proto`).  
-2. Shared golden fixtures (logical values).  
-3. Encode/decode matrix plan ([401 cross-language fidelity](../401/protobuf-cross-language-fidelity.md) if Protobuf).
+
+1. List languages on the boundary and the candidate contract (for example Protobuf plus a shared `.proto`).
+2. Prepare shared golden fixtures with logical values.
+3. Plan an encode/decode matrix ([401 cross-language fidelity](../401/protobuf-cross-language-fidelity.md) if you use Protobuf).
 
 ### Procedure
-1. Freeze schema and fixture values.  
-2. Encode in each language; decode in every other; assert **logical** equality.  
-3. Optionally assert bit-identity (document if not required).  
-4. Run per-language suite fidelity for harness round-trip (local only).  
-5. Record footguns (defaults, packed repeated, renames).
+
+1. Freeze the schema and fixture values.
+2. Encode in each language; decode in every other; assert **logical** equality.
+3. Optionally assert bit-identity, and document whether you require it.
+4. Run per-language suite fidelity for harness round-trip (local only).
+5. Record footguns such as defaults, packed repeated fields, and renames.
 
 ### Decision rule
-- Any required language pair failing logical interop ⇒ contract or implementation fix before performance tuning.  
-- Product choice of family stays; suite multi-language speed ranks do **not** pick the estate contract.
+
+- Any required language pair that fails logical interoperability needs a contract or implementation fix before performance tuning.
+- The product choice of family stays fixed; suite multi-language speed ranks do **not** pick the estate contract.
 
 ## Metrics
 
 | Metric / signal | Role |
 |-----------------|------|
-| **Matrix pass rate** (encode A → decode B) | **Primary** |
+| **Matrix pass rate** (encode in A, decode in B) | **Primary** |
 | Logical field equality | Correctness definition |
-| Bit-identical encode (optional) | Caching/signing only |
+| Bit-identical encode (optional) | Relevant only for caching or signing |
 | Per-language `mean_fidelity` | Local harness health |
-| Schema/version alignment | Drift detector |
-| Per-language latency Results | Capacity planning **after** interop |
+| Schema and version alignment | Drift detector |
+| Per-language latency Results | Capacity planning **after** interop works |
 
-**Conclusion style:** “Pb contract green on Py/Go/Rust matrix; pin prost/protobuf versions.”
+**Conclusion style:** “Protobuf contract is green on the Python/Go/Rust matrix; pin `prost` and `protobuf` versions.”
 
 ## What this suite cannot tell you
 
-- Political cost of mandating one IDL monorepo.  
-- Whether your gateway team can own JSON↔binary translation.  
-- Full matrix of type fidelity for every field across all languages (design conformance tests).  
-- Vendor lock-in and staffing for exotic codecs.
+- The political cost of mandating one IDL monorepo.
+- Whether your gateway team can own JSON-to-binary translation.
+- The full matrix of type fidelity for every field across all languages (you must design conformance tests).
+- Vendor lock-in and staffing cost for exotic codecs.
 
 ## Common mistakes
 
-- “We’ll translate later” without an owner.  
-- Different field names per language for the “same” event.  
-- Using suite cross-language plots (if any) as architecture mandates.
+- Saying “we’ll translate later” without an owner.
+- Using different field names per language for the “same” event.
+- Treating suite cross-language plots (if any) as architecture mandates.
 
 ## Key takeaways
 
-- Polyglot estates need **one contract per boundary**, not one library for the company.  
-- Portable + multi-language ecosystem + evolution process beat single-language speed.  
-- Suite = pick implementations **inside** a language after the contract is fixed.  
-- Dual stacks at edges are fine when **owned**; accidental dual stacks are debt.  
+- Polyglot estates need **one contract per boundary**, not one library for the whole company.
+- Portable formats, a multi-language ecosystem, and an evolution process beat single-language speed.
+- The suite picks implementations **inside** a language after the contract is fixed.
+- Dual stacks at edges are fine when **owned**; accidental dual stacks are debt.
 - Native codecs stop at the trust boundary ([trust boundaries](trust-boundaries.md)).

--- a/docs/theory/301/public-api-contracts.md
+++ b/docs/theory/301/public-api-contracts.md
@@ -2,102 +2,108 @@
 
 ## Problem
 
-JSON’s flexibility is a gift for browsers and integrators and a curse for accidental breakage: fields appear, types drift (`"1"` vs `1`), and renames ship without a version bump. Saying “we use JSON” is not a contract. Public APIs need an **external schema and process** as strict as IDL cultures—just with different artifacts.
+JSON’s flexibility is a gift for browsers and integrators and a curse for accidental breakage. Fields appear without notice, types drift (`"1"` versus `1`), and renames ship without a version bump. Saying “we use JSON” is not a contract.
+
+Public APIs need an **external schema and process** as strict as IDL cultures—just with different artifacts.
 
 ## Short answer
 
-For public or cross-org HTTP APIs, pair JSON with a **published contract**: OpenAPI and/or JSON Schema (or equivalent), server-side validation, consumer-driven or contract tests, and a versioning policy ([versioning in the wild](versioning-in-the-wild.md)). Choose JSON libraries for performance and correctness ([implementation variance](implementation-variance.md)); do not skip the contract layer because the bytes are text. Binary dual-stack is optional and earned ([case: public REST](case-public-rest-api.md)).
+For public or cross-organization HTTP APIs, pair JSON with a **published contract**: OpenAPI and/or JSON Schema (or an equivalent), server-side validation, consumer-driven or contract tests, and a versioning policy (see [versioning in the wild](versioning-in-the-wild.md)).
+
+Choose JSON libraries for performance and correctness (see [implementation variance](implementation-variance.md)). Do not skip the contract layer because the bytes happen to be text. A binary dual stack is optional and must be earned (see [case: public REST](case-public-rest-api.md)).
 
 ## Constraints that matter
 
 | Layer | Job |
 |-------|-----|
-| **Wire** | JSON (or dual content-types) |
-| **Contract doc** | OpenAPI / JSON Schema / protobuf if dual |
-| **Runtime validation** | Reject illegal bodies early |
-| **Tests** | Provider + consumer checks |
-| **Process** | Review, deprecation windows, changelog |
+| **Wire** | JSON bodies (or dual content types when a second encoding exists) |
+| **Contract document** | OpenAPI, JSON Schema, or Protobuf if you offer a dual stack |
+| **Runtime validation** | Reject illegal bodies early, before business logic runs |
+| **Tests** | Provider checks and consumer-driven checks |
+| **Process** | Review, deprecation windows, and a changelog |
 
 ## Decision frame
 
 | Need | Action |
 |------|--------|
-| Third-party integrators | Published OpenAPI; stable URLs; deprecation policy |
-| Type-safe clients | Generate from OpenAPI; or offer dual Protobuf |
-| Rapid internal-only iteration | Still validate; shorter deprecation OK |
-| “Schemaless for agility” | Accept silent client breakage—or stop claiming stability |
+| Third-party integrators | Publish OpenAPI; keep URLs stable; write a deprecation policy |
+| Type-safe clients | Generate clients from OpenAPI, or offer dual Protobuf for selected clients |
+| Rapid internal-only iteration | Still validate; shorter deprecation windows may be acceptable |
+| “Schemaless for agility” | Accept silent client breakage—or stop claiming the API is stable |
 
 ## Failure modes
 
 | Mistake | Outcome |
 |---------|---------|
-| OpenAPI stale vs server | Docs lie; clients fail |
-| Validate only in one gateway | Alternate entrypoints drift |
-| Optional everything | No real contract |
-| Breaking change without version | Integrator outages |
-| PII in examples | Doc surface leak ([payload surfaces](payload-surfaces.md)) |
+| OpenAPI goes stale relative to the server | Documentation lies; clients fail in surprising ways |
+| Validation only in one gateway | Alternate entry points drift from the contract |
+| Everything is optional | There is no real contract |
+| Breaking change without a version | Integrator outages |
+| PII in documentation examples | Documentation becomes a leak surface ([payload surfaces](payload-surfaces.md)) |
 
 ## Real-world sketch
 
-A fintech publishes OpenAPI 3 and generates TypeScript and Kotlin clients. CI fails if the server’s request models drift from the spec. A “quick” field rename without version bump is blocked. Performance work swaps Python JSON libraries using suite Results without touching the public contract.
+A fintech publishes OpenAPI 3 and generates TypeScript and Kotlin clients. Continuous integration fails if the server’s request models drift from the specification. A “quick” field rename without a version bump is blocked. Later performance work swaps Python JSON libraries using suite Results without touching the public contract at all.
 
 ## In this suite
 
 | Resource | Role |
 |----------|------|
 | JSON-family **Results** | Pick implementations per language |
-| [Categories](../../analysis/serialization_categories.md) | JSON vs other families |
-| [Using this suite](using-this-suite.md) | Fair comparisons |
-
+| [Categories](../../analysis/serialization_categories.md) | JSON versus other families |
+| [Using this suite](using-this-suite.md) | Fair comparisons inside a family |
 
 ## Experiments
 
-**Question:** Is the public wire **contract** hard enough (schema/OpenAPI/JSON Schema), and what breaks if we only “use JSON”?
+**Question:** Is the public wire **contract** hard enough (schema, OpenAPI, or JSON Schema), and what breaks if we only “use JSON”?
 
 ### Setup
-1. Collect public endpoints and current docs (OpenAPI, ad hoc examples).  
-2. List client languages and critical fields.  
-3. One proposed additive change and one breaking change.
+
+1. Collect public endpoints and current docs (OpenAPI or ad hoc examples).
+2. List client languages and critical fields.
+3. Prepare one proposed additive change and one breaking change.
 
 ### Procedure
-1. Validate production samples against the published schema (should pass).  
-2. Ship additive change; confirm old clients still work.  
-3. Attempt breaking change behind a new version or content-type; confirm old route unchanged.  
-4. Check error bodies for accidental internal leakage ([payload surfaces](payload-surfaces.md)).  
-5. Suite: optional JSON library compare for server language—**after** contract exists.
+
+1. Validate production samples against the published schema (they should pass).
+2. Ship the additive change and confirm old clients still work.
+3. Attempt the breaking change behind a new version or content type; confirm the old route is unchanged.
+4. Check error bodies for accidental internal leakage ([payload surfaces](payload-surfaces.md)).
+5. Optionally compare JSON libraries for the server language—**after** the contract exists.
 
 ### Decision rule
-- No machine-readable contract + multi-party clients ⇒ insufficient; add schema before optimizing codecs.  
-- Performance experiments only among codecs that honor the published contract.
+
+- No machine-readable contract plus multi-party clients is insufficient. Add a schema before optimizing codecs.
+- Run performance experiments only among codecs that honor the published contract.
 
 ## Metrics
 
 | Metric / signal | Role |
 |-----------------|------|
-| **Schema coverage** (% endpoints with formal schema) | **Primary** |
-| Contract-test pass rate in CI | Enforcement |
+| **Schema coverage** (percentage of endpoints with a formal schema) | **Primary** |
+| Contract-test pass rate in CI | Enforcement quality |
 | Breaking-change escape rate | Process quality |
 | Client SDK regenerate success | Contract usability |
-| Suite JSON `deser_median_ns` / size | Secondary server cost |
+| Suite JSON `deser_median_ns` and size | Secondary server cost |
 | `mean_fidelity` | Implementation correctness |
 
-**Conclusion style:** “OpenAPI + JSON Schema required; content-type versioning for breaks.”
+**Conclusion style:** “OpenAPI and JSON Schema are required; breaking changes use content-type versioning.”
 
 ## What this suite cannot tell you
 
-- OpenAPI style guide politics.  
-- Whether to use URL versioning vs header versioning.  
-- Partner communication SLAs.
+- OpenAPI style-guide politics inside your organization.
+- Whether to use URL versioning versus header versioning.
+- Partner communication service-level agreements.
 
 ## Common mistakes
 
-- Treating JSON Schema as optional documentation only.  
-- Generating OpenAPI from code without review (noise and breaks).  
-- Different field names in Android vs web “by accident.”
+- Treating JSON Schema as optional documentation only.
+- Generating OpenAPI from code without review (noise and accidental breaks).
+- Different field names in Android versus web clients “by accident.”
 
 ## Key takeaways
 
-- Public JSON needs a **hard contract process**, not vibes.  
-- Validation and tests enforce what prose promises.  
-- Suite helps choose JSON **libraries**, not whether a contract exists.  
+- Public JSON needs a **hard contract process**, not good intentions.
+- Validation and tests enforce what prose promises.
+- The suite helps you choose JSON **libraries**, not whether a contract exists.
 - Dual binary APIs are additive products—not a substitute for JSON governance.

--- a/docs/theory/301/row-vs-columnar.md
+++ b/docs/theory/301/row-vs-columnar.md
@@ -3,126 +3,131 @@
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/leo-gan/GLD.SerializerBenchmark/blob/master/docs/theory/notebooks/301/row_vs_columnar.ipynb)
 **Lab notebook:** [Row vs columnar experiment](../notebooks/301/row_vs_columnar.ipynb)
 
-
 ## Problem
 
-The same organization often runs:
+The same organization often runs two very different workloads:
 
-- **Services** exchanging whole records (user profile, order command, device event).  
-- **Analytics** scanning billions of rows but only a few columns (revenue by day, feature columns for training).
+- **Services** that exchange whole records (a user profile, an order command, a device event).
+- **Analytics** that scan billions of rows but only a few columns (revenue by day, feature columns for training).
 
-Teams collapse both onto one encoding—“everything is Protobuf” or “everything is Parquet”—and pay either impossible scan costs or impossible per-message overhead. The 101 axis *row vs columnar* becomes a **system boundary** question at 301 scale.
+Teams collapse both onto one encoding—“everything is Protobuf” or “everything is Parquet”—and then pay either impossible scan costs or impossible per-message overhead. The 101 axis *row versus columnar* becomes a **system boundary** question at Serialization 301 scale.
 
 ## Short answer
 
-Use **row-oriented** messages (JSON objects, Protobuf messages, Avro records, MessagePack maps) when the unit of work is **whole records** with low-latency point access or per-event processing. Use **columnar** layouts (Parquet, ORC, Arrow tables) when the unit of work is **bulk scan/aggregate over few columns** on large datasets. Crossing the streams is occasional glue (export jobs), not a default architecture. Do not pick columnar because it compresses well in a blog chart if every request needs the full row in under a millisecond.
+Use **row-oriented** messages (JSON objects, Protobuf messages, Avro records, MessagePack maps) when the unit of work is **whole records** with low-latency point access or per-event processing. Use **columnar** layouts (Parquet, ORC, Arrow tables) when the unit of work is a **bulk scan or aggregate over few columns** on large datasets.
 
-Assumes 101 row/columnar axis; this page owns **workload architecture**.
+Crossing the streams is occasional glue (export jobs), not a default architecture. Do not pick columnar because it compresses well in a blog chart if every request needs the full row in under a millisecond.
+
+This page assumes the 101 row/columnar axis. Here we own **workload architecture**.
 
 ## Constraints that matter
 
-| Axis | Row-oriented messages | Columnar tables / files |
-|------|----------------------|-------------------------|
+| Axis | Row-oriented messages | Columnar tables and files |
+|------|----------------------|---------------------------|
 | **Access** | Get one entity; process one event | Scan column subsets over partitions |
-| **I/O shape** | Whole record contiguous | Column chunks; predicate pushdown |
-| **Latency** | Often µs–ms per message | Throughput-oriented batch/stream jobs |
-| **Evolution** | Per-message schema/IDL culture | Table schema + file footers + catalog |
-| **Compression** | Per message or stream framing | Column stats, dictionary, page compression |
-| **Typical home** | API, RPC, queues, OLTP-style paths | Lakes, warehouses, feature stores, ML batch |
+| **I/O shape** | Whole record stored contiguously | Column chunks; predicate pushdown can skip data |
+| **Latency** | Often microseconds to milliseconds per message | Throughput-oriented batch or stream jobs |
+| **Evolution** | Per-message schema or IDL culture | Table schema, file footers, and a catalog |
+| **Compression** | Per message or stream framing | Column statistics, dictionaries, page compression |
+| **Typical home** | APIs, RPC, queues, OLTP-style paths | Lakes, warehouses, feature stores, machine-learning batch |
 
 ## Decision frame
 
 | Workload | Default encoding class | Poor default |
 |----------|------------------------|--------------|
-| Public or internal RPC | Row (JSON / schema-driven / schemaless binary) | Parquet files per request |
-| Kafka-style event processing (per event) | Row (Avro/Protobuf/JSON) | Columnar unless micro-batch deliberately |
-| Nightly lake on object storage | Columnar (Parquet/ORC) | Millions of tiny Protobuf files as the lake |
-| Interactive notebook on large tables | Arrow / columnar engines | Nested JSON lines as sole store |
+| Public or internal RPC | Row (JSON, schema-driven, or schemaless binary) | Opening Parquet files per request |
+| Kafka-style event processing (one event at a time) | Row (Avro, Protobuf, or JSON) | Columnar unless you deliberately micro-batch |
+| Nightly lake on object storage | Columnar (Parquet or ORC) | Millions of tiny Protobuf files as the lake |
+| Interactive notebook on large tables | Arrow or other columnar engines | Nested JSON Lines as the sole store |
 | Feature training over wide tables | Columnar | Row RPC dumps without projection |
-| Cache get-by-id | Row | Columnar file open per key |
+| Cache get-by-id | Row | Opening a columnar file per key |
 
 ```text
   Do we mostly read ALL fields of FEW records?
         yes → row-oriented message codecs
   Do we mostly read FEW fields of MANY records?
-        yes → columnar storage / Arrow-class interchange
+        yes → columnar storage or Arrow-class interchange
 ```
 
 ## Failure modes
 
 | Mistake | Consequence |
 |---------|-------------|
-| **Protobuf lake** | Tiny files, no column prune, ops nightmare |
-| **Parquet RPC** | Catastrophic per-call overhead; wrong mutability story |
+| **Protobuf lake** | Tiny files, no column pruning, operations nightmare |
+| **Parquet RPC** | Catastrophic per-call overhead and the wrong mutability story |
 | **One format to rule them all** | Either analytics or services becomes second-class |
-| **Ignoring partition design** | Columnar without partition/predicate strategy still scans the world |
-| **Confusing Arrow with Parquet** | Arrow ≈ in-memory/interchange; Parquet ≈ on-disk columnar—related, not identical jobs |
+| **Ignoring partition design** | Columnar storage without partitions or predicates still scans the world |
+| **Confusing Arrow with Parquet** | Arrow is mainly in-memory interchange; Parquet is mainly on-disk columnar—related jobs, not identical ones |
 
 ## Real-world sketch
 
-A metrics pipeline ingests events as Protobuf (good: row, low latency). Analysts dump the same Protobuf messages as the lake format. Queries that need two fields open every message fully. Moving the **serving path** to remain Protobuf while a **batch compact job** writes Parquet partitions by day cuts scan cost without changing the real-time contract. The suite may show excellent Protobuf decode rates; that does not make Protobuf a lake format.
+A metrics pipeline ingests events as Protobuf. That is a good row-oriented, low-latency choice. Analysts then dump the same Protobuf messages as the lake format. Queries that need two fields open every message fully.
+
+A better design keeps the **serving path** on Protobuf and adds a **batch compact job** that writes Parquet partitions by day. Scan cost drops without changing the real-time contract. The suite may show excellent Protobuf decode rates; that does not make Protobuf a lake format.
 
 ## In this suite
 
 | Resource | Role |
 |----------|------|
 | Language harnesses | Predominantly **row-oriented message** codecs and fixtures |
-| [Test Data](../../analysis/test_data_configuration.md) | Record-shaped fixtures (`message`, `document`, `telemetry`, …) |
+| [Test Data](../../analysis/test_data_configuration.md) | Record-shaped fixtures (`message`, `document`, `telemetry`, and others) |
 | [Serialization categories](../../analysis/serialization_categories.md) | Families for message codecs—not a Parquet engine benchmark |
 | [Using this suite](using-this-suite.md) | How to read message-level Results |
 
-**Important:** this suite is **not** a columnar engine benchmark. Absence of Parquet/Arrow from a language Results page means “not measured here,” not “irrelevant for lakes.”
-
+**Important:** this suite is **not** a columnar engine benchmark. Absence of Parquet or Arrow from a language Results page means “not measured here,” not “irrelevant for lakes.”
 
 ## Experiments
 
 **Question:** Is this path **row/RPC-shaped** or **analytical/columnar**, and are we using the wrong codec class for the system?
 
 ### Setup
-1. Describe access pattern: point lookups / RPC vs scan aggregates over many rows.  
-2. Estimate selectivity (few columns vs wide rows) and data volume.  
-3. Candidate stacks: row JSON/Protobuf/Avro vs Parquet/ORC/Arrow-class.
+
+1. Describe the access pattern: point lookups and RPC versus scan aggregates over many rows.
+2. Estimate selectivity (few columns versus wide rows) and data volume.
+3. List candidate stacks: row JSON/Protobuf/Avro versus Parquet/ORC/Arrow-class.
 
 ### Procedure
-1. Classify primary workload using the decision frame.  
-2. If analytical: prototype scan time and compression on columnar layout vs dumping RPC rows.  
-3. If RPC: measure per-message latency with row codecs; do not use lake formats on the hot path.  
-4. Suite Results orient **row** codec costs only—do not treat them as lake rankings.  
-5. Document two-hop design if both patterns exist (events row → lake columnar).
+
+1. Classify the primary workload using the decision frame.
+2. If the path is analytical, prototype scan time and compression on a columnar layout versus dumping RPC rows.
+3. If the path is RPC, measure per-message latency with row codecs. Do not put lake formats on the hot path.
+4. Treat suite Results as **row** codec orientation only—not as lake rankings.
+5. Document a two-hop design if both patterns exist (row events on the bus, columnar data in the lake).
 
 ### Decision rule
-- Scan-heavy lake path ⇒ columnar system format; RPC suite winners are irrelevant.  
-- Hot RPC ⇒ row/schema-driven family; columnar files are not substitutes.
+
+- Scan-heavy lake path means a columnar system format; RPC suite winners are irrelevant.
+- Hot RPC means a row or schema-driven family; columnar files are not substitutes.
 
 ## Metrics
 
 | Metric / signal | Role |
 |-----------------|------|
-| **Query shape** (point vs scan; columns touched) | **Primary** classifier |
-| Scan time / bytes read for analytical job | Columnar effectiveness |
-| RPC p99 per message | Row-path SLO |
+| **Query shape** (point versus scan; columns touched) | **Primary** classifier |
+| Scan time and bytes read for the analytical job | Columnar effectiveness |
+| RPC p99 per message | Row-path service-level objective |
 | Compression ratio on lake files | Storage economics |
-| Suite `total_median_ns` / `median_size_bytes` | Row-codec orientation only |
+| Suite `total_median_ns` and `median_size_bytes` | Row-codec orientation only |
 | Cross-paradigm “winner” charts | Misleading for this decision |
 
-**Conclusion style:** “Ingest RPC uses Protobuf rows; lake uses Parquet; no dual-use of one codec.”
+**Conclusion style:** “Ingest RPC uses Protobuf rows; the lake uses Parquet; we do not dual-use one codec for both jobs.”
 
 ## What this suite cannot tell you
 
-- Scan cost of Parquet vs ORC on your warehouse.  
-- Arrow zero-copy handoff between two specific engines.  
-- Optimal partition/layout for your lake.  
+- Scan cost of Parquet versus ORC on your warehouse.
+- Arrow zero-copy handoff between two specific engines.
+- Optimal partition and layout design for your lake.
 - Whether micro-batch columnar encoding of events is worth the complexity.
 
 ## Common mistakes
 
-- Citing message-codec Results to justify lake format choice.  
-- Forcing analytics to query an operational RPC log format forever.  
-- Using columnar “because compression” on chatty ultra-small RPCs.
+- Citing message-codec Results to justify a lake format choice.
+- Forcing analytics to query an operational RPC log format forever.
+- Using columnar “because compression” on chatty, ultra-small RPCs.
 
 ## Key takeaways
 
-- **Access pattern** chooses row vs columnar more than fashion.  
-- Services ↔ row messages; lakes/analytics ↔ columnar (with deliberate bridges).  
-- Suite Results inform **message codec** choice inside a language—not lake architecture.  
-- Dual paths (row for serve, columnar for analyze) are normal, not failure.
+- **Access pattern** chooses row versus columnar more than fashion.
+- Services want row messages; lakes and analytics want columnar storage, with deliberate bridges between them.
+- Suite Results inform **message codec** choice inside a language—not lake architecture.
+- Dual paths (row for serve, columnar for analyze) are normal, not a design failure.

--- a/docs/theory/301/rpc-and-messaging.md
+++ b/docs/theory/301/rpc-and-messaging.md
@@ -2,50 +2,57 @@
 
 ## Problem
 
-Teams reuse the same payload for synchronous RPC, fan-out events, and UI refresh. The result is chatty RPCs carrying analytics blobs, or events so large that consumers collapse. Serialization format debates hide a prior question: **what is the unit of work, and who needs which fields?**
+Teams often reuse the same payload for synchronous RPC (remote procedure call), fan-out events, and user-interface refresh. The result is chatty RPCs that carry analytics blobs, or events so large that consumers fall behind. Serialization format debates hide a prior question: **what is the unit of work, and who needs which fields?**
 
 ## Short answer
 
-Design **message shape** from access pattern: small, stable records for high-QPS RPC; explicit event types for async backbones; projections or separate APIs for “wide” reads. Prefer **narrow messages** plus references (ids) over embedding entire aggregates on every hop. Partial reads and zero-copy help only when the layout matches the access pattern (201 [zero-copy](../201/zero-copy.md), [zero-copy in production](zero-copy-in-production.md)). Idempotency and ordering are product properties—codecs do not invent them.
+Design **message shape** from the access pattern. Use small, stable records for high-QPS (high requests-per-second) RPC. Use explicit event types for async backbones. Use projections or separate APIs for “wide” reads. Prefer **narrow messages** plus references (identifiers) over embedding entire aggregates on every hop.
+
+Partial reads and zero-copy help only when the layout matches the access pattern (see 201 [zero-copy](../201/zero-copy.md) and [zero-copy in production](zero-copy-in-production.md)). Idempotency and ordering are product properties—codecs do not invent them.
 
 ## Constraints that matter
 
 | Pattern | Payload bias |
 |---------|----------------|
-| **Request/response RPC** | Minimal fields for the decision; low allocation |
-| **Async event** | Fact + ids + enough context for consumers; stable evolution |
-| **Fan-out** | One event, many consumers → avoid single-consumer bloat |
-| **Streaming partial** | Chunking / pagination; not one multi-MB JSON |
-| **Idempotent command** | Stable command id; dedupe keys outside pure codec choice |
+| **Request/response RPC** | Minimal fields for the decision; keep allocations low |
+| **Async event** | The fact, identifiers, and enough context for consumers; stable evolution |
+| **Fan-out** | One event, many consumers—avoid bloating the event for a single consumer |
+| **Streaming partial results** | Chunking or pagination; not one multi-megabyte JSON blob |
+| **Idempotent command** | Stable command identifier; dedupe keys live outside pure codec choice |
 
 ## Decision frame
 
 ```text
-  Sync decision path? → thin RPC DTO, schema-driven often
-  Multiple independent consumers? → event types, not “god struct”
-  Need most fields rarely? → split messages or query API
+  Sync decision path?
+        → thin RPC data-transfer object; schema-driven is often a good fit
+  Multiple independent consumers?
+        → distinct event types, not one “god struct”
+  Need most fields only rarely?
+        → split messages or add a query API
 ```
 
 | Smell | Redesign |
 |-------|----------|
-| RPC returns entire customer graph “just in case” | Field masks / separate resources |
-| Event embeds PDF bytes | Object-store pointer + metadata event |
-| Same proto for UI list and fraud pipeline | Separate contracts or views |
-| Mutation of shared buffer across threads | Copy or freeze policy |
+| RPC returns the entire customer graph “just in case” | Field masks or separate resources |
+| Event embeds PDF bytes | Object-store pointer plus a small metadata event |
+| Same proto for the UI list and the fraud pipeline | Separate contracts or views |
+| Mutation of a shared buffer across threads | Copy or freeze policy |
 
 ## Failure modes
 
 | Mistake | Outcome |
 |---------|---------|
-| God message | Every change breaks everyone |
-| Chatty fine-grained RPC without batching | Latency death by RTT |
+| God message that carries everything | Every change breaks everyone |
+| Chatty fine-grained RPC without batching | Latency death by network round-trip time (RTT) |
 | Huge events on the hot bus | Consumer lag |
-| Relying on codec for exactly-once | False safety |
+| Relying on the codec for exactly-once delivery | False safety |
 | Mixing command and event semantics | Replay nightmares |
 
 ## Real-world sketch
 
-Checkout RPC needs auth result and risk score—tens of fields. Marketing wants full cart contents on `OrderPlaced`. One Protobuf is forced to carry both. Fraud p99 suffers; marketing still joins to a catalog service. Split: thin `AuthorizePayment` RPC; `OrderPlaced` event with line-item ids; marketing consumer loads details asynchronously.
+Checkout RPC needs an authorization result and a risk score—tens of fields. Marketing wants full cart contents on `OrderPlaced`. One Protobuf is forced to carry both. Fraud p99 (99th-percentile latency) suffers, and marketing still has to join a catalog service.
+
+A better split: a thin `AuthorizePayment` RPC; an `OrderPlaced` event with line-item identifiers; and a marketing consumer that loads details asynchronously.
 
 ## In this suite
 
@@ -54,57 +61,59 @@ Checkout RPC needs auth result and risk score—tens of fields. Marketing wants 
 | Fixtures | Record shapes for codec cost—not architecture proof |
 | **Results** | Cost of encoding a *given* shape |
 | [Row vs columnar](row-vs-columnar.md) | Batch analytics path |
-| [Using this suite](using-this-suite.md) | Same fixture when comparing libs |
-
+| [Using this suite](using-this-suite.md) | Same fixture when comparing libraries |
 
 ## Experiments
 
 **Question:** Should this payload be optimized as **sync RPC** (latency, small messages) or **async messaging** (throughput, fan-out, evolution)?
 
 ### Setup
-1. Measure or estimate: RPS, fan-out, max acceptable p99, retention of messages.  
-2. Note whether consumers are lag-tolerant.  
-3. Candidate families for each style.
+
+1. Measure or estimate requests per second, fan-out, maximum acceptable p99, and message retention.
+2. Note whether consumers tolerate lag.
+3. List candidate families for each style.
 
 ### Procedure
-1. Classify the hop with the decision frame.  
-2. For RPC-like: suite + load test on encode/decode latency and size.  
-3. For messaging: prioritize schema evolution, registry, and consumer lag under burst—not only ser mean.  
-4. Reject designs that use chatty RPC patterns on bulk fan-out topics (or the reverse).  
+
+1. Classify the hop with the decision frame.
+2. For RPC-like hops: use the suite plus a load test on encode/decode latency and size.
+3. For messaging: prioritize schema evolution, registry health, and consumer lag under burst—not only mean serialize time.
+4. Reject designs that use chatty RPC patterns on bulk fan-out topics (or the reverse).
 5. Document payload size budgets per pattern.
 
 ### Decision rule
-- Strict sync SLO + request/response ⇒ RPC-shaped codec and size budget.  
-- Multi-consumer durable stream ⇒ messaging evolution + backlog metrics dominate.
+
+- Strict sync service-level objectives with request/response traffic call for an RPC-shaped codec and size budget.
+- Multi-consumer durable streams are dominated by messaging evolution and backlog metrics.
 
 ## Metrics
 
 | Metric / signal | Role |
 |-----------------|------|
-| **RPC p99 / timeout budget** | **Primary** for sync hops |
-| Message size p95 | Network + ser cost |
-| Suite `ser_median_ns` / `deser_median_ns` / size | Codec shortlist |
-| Consumer lag / throughput | **Primary** for async hops |
+| **RPC p99 and timeout budget** | **Primary** for sync hops |
+| Message size at p95 | Network and serialize cost |
+| Suite `ser_median_ns`, `deser_median_ns`, and size | Codec shortlist |
+| Consumer lag and throughput | **Primary** for async hops |
 | Schema-change failure rate | Messaging evolution health |
-| Fan-out factor | Amplification of size/CPU |
+| Fan-out factor | Amplification of size and CPU |
 
-**Conclusion style:** “User RPC: small Protobuf; audit topic: Avro + registry; separate budgets.”
+**Conclusion style:** “User RPC uses small Protobuf messages; the audit topic uses Avro plus a registry; each path has its own size budget.”
 
 ## What this suite cannot tell you
 
-- Correct service boundaries.  
-- Kafka partition key design.  
+- Correct service boundaries for your domain.
+- Kafka partition key design.
 - Whether field masks are supported in your RPC stack.
 
 ## Common mistakes
 
-- Optimizing codec while messages stay bloated.  
-- “We’ll filter in the consumer” as a permanent design.  
-- Ignoring idempotency keys because Protobuf is deterministic.
+- Optimizing the codec while messages stay bloated.
+- Treating “we’ll filter in the consumer” as a permanent design.
+- Ignoring idempotency keys because Protobuf encoding is deterministic.
 
 ## Key takeaways
 
-- **Shape first, codec second.**  
-- RPC and messaging want different payload economics.  
-- Fan-out punishes god structs.  
-- Suite measures encode cost of the shape you already chose.
+- **Shape first, codec second.**
+- RPC and messaging want different payload economics.
+- Fan-out punishes god structs.
+- The suite measures encode cost of the shape you already chose.

--- a/docs/theory/301/schema-registries.md
+++ b/docs/theory/301/schema-registries.md
@@ -2,112 +2,122 @@
 
 ## Problem
 
-Event platforms and multi-team producers need a **control plane** for schemas: where the current schema lives, who may publish a new version, and which old reader/writer combinations remain legal. Without a registry (or equivalent), “we use Avro/Protobuf” becomes tribal knowledge and production breaks on the first incompatible field.
+Event platforms and multi-team producers need a **control plane** for schemas: where the current schema lives, who may publish a new version, and which old reader and writer combinations remain legal. Without a registry (or an equivalent process), “we use Avro” or “we use Protobuf” becomes tribal knowledge, and production breaks on the first incompatible field.
 
 ## Short answer
 
-A **schema registry** (or monorepo + CI that plays the same role) stores versioned schemas and evaluates **compatibility** before a new version is accepted. Common modes—**BACKWARD**, **FORWARD**, **FULL** (and *transitive* variants)—encode which rolling-upgrade stories you support. Pick the mode from deploy topology; enforce it in CI/CD; never rely on human review alone at scale. Culture still matters ([two schema cultures](two-schema-cultures.md)): resolution-oriented stacks lean on registry modes; field-number stacks lean on IDL breaking-change detection—both need a gate.
+A **schema registry** (or a monorepo plus continuous integration that plays the same role) stores versioned schemas and evaluates **compatibility** before a new version is accepted. Common modes—**BACKWARD**, **FORWARD**, **FULL**, and their *transitive* variants—encode which rolling-upgrade stories you support.
 
-Assumes 201 [schema evolution](../201/schema-evolution.md).
+Pick the mode from your deploy topology. Enforce it in CI/CD. Never rely on human review alone once more than a handful of teams publish schemas.
+
+Culture still matters ([two schema cultures](two-schema-cultures.md)). Resolution-oriented stacks lean on registry modes. Field-number stacks lean on IDL breaking-change detection. Both need a gate in the deploy path.
+
+This page assumes 201 [schema evolution](../201/schema-evolution.md).
 
 ## Constraints that matter
 
 | Mode (typical meaning) | Protects | Allows (illustrative) |
 |------------------------|----------|------------------------|
-| **BACKWARD** | New **readers** understand old data | Delete fields readers no longer need; add optional fields carefully per product rules |
-| **FORWARD** | New **writers** understood by old readers | Add fields old readers skip; restrict removing what old readers need |
-| **FULL** | Both directions | Strictest common intersection |
-| **\*_TRANSITIVE** | Across **all** historical versions, not only N vs N-1 | Long retention / many live versions |
+| **BACKWARD** | New **readers** still understand old data | Delete fields that readers no longer need; add optional fields carefully per product rules |
+| **FORWARD** | New **writers** are still understood by old readers | Add fields that old readers skip; restrict removing fields that old readers still need |
+| **FULL** | Both directions at once | The strictest common intersection of BACKWARD and FORWARD |
+| **\*_TRANSITIVE** variants | Compatibility across **all** historical versions, not only version N versus N−1 | Long retention windows and many live schema versions |
 
-Exact rules differ by system (Confluent Avro, Protobuf policies, JSON Schema stores)—read *your* registry docs; do not memorize one vendor table as universal law.
+Exact rules differ by system (Confluent Avro, Protobuf policies, JSON Schema stores, and others). Read *your* registry documentation. Do not memorize one vendor’s table as universal law.
 
 ## Decision frame
 
 ```text
-  Must old consumers read new producers?  → need FORWARD-ish guarantees
-  Must new consumers read old data (lag, replay)? → need BACKWARD-ish guarantees
-  Both (common for shared topics)? → FULL or FULL_TRANSITIVE
-  Single lockstep deploy of all parties? → still version schemas; mode may be looser
+  Must old consumers read new producers?
+        → you need FORWARD-style guarantees
+  Must new consumers read old data (lag, replay)?
+        → you need BACKWARD-style guarantees
+  Both (common for shared topics)?
+        → FULL or FULL_TRANSITIVE
+  Single lockstep deploy of all parties?
+        → still version schemas; the mode may be looser
 ```
 
 | Situation | Lean toward |
 |-----------|-------------|
-| Long retention, replay, many consumer versions | Transitive + BACKWARD or FULL |
-| Short-lived topics, few consumers | BACKWARD may suffice |
-| IDL monorepo, no registry product | Breaking-change CI + review = functional registry |
-| No enforcement | You do not have a registry—you have a wiki |
+| Long retention, replay, many consumer versions | Transitive checks plus BACKWARD or FULL |
+| Short-lived topics with few consumers | BACKWARD may suffice |
+| IDL monorepo without a registry product | Breaking-change CI plus review acts as a functional registry |
+| No enforcement at all | You do not have a registry—you have a wiki |
 
 ## Failure modes
 
 | Mistake | Outcome |
 |---------|---------|
-| Registry without auth/ACLs | Anyone publishes breaking schemas |
-| Mode never set (default surprise) | First break is in production |
-| Compatibility only N vs N-1 with long retention | Version N-5 still in data, breaks |
-| Dual registries / dual subjects per event | Split brain |
-| Treating registry as optional for “small” teams | Growth debt |
+| Registry without authentication or access-control lists (ACLs) | Anyone can publish breaking schemas |
+| Compatibility mode never set (default surprise) | The first break happens in production |
+| Compatibility checked only for N versus N−1 while retention is long | Version N−5 still exists in the data and breaks readers |
+| Dual registries or dual subjects per event | Split brain about which schema is canonical |
+| Treating the registry as optional for “small” teams | Growth debt that appears when the team is no longer small |
 
 ## Real-world sketch
 
-A payments topic uses Avro with BACKWARD. A producer removes a field still read by a slow fraud consumer. Registry rejects the schema in CI; the team dual-writes or waits for consumer lag to drain. Without the gate, the break appears as cryptic deserialize errors at 02:00.
+A payments topic uses Avro with BACKWARD compatibility. A producer removes a field that a slow fraud consumer still reads. The registry rejects the schema in CI. The team either dual-writes for a while or waits for consumer lag to drain. Without that gate, the break appears as cryptic deserialize errors at 02:00.
 
 ## In this suite
 
 | Resource | Role |
 |----------|------|
 | **Results** | Codec cost only—not registry behavior |
-| [Two schema cultures](two-schema-cultures.md) | Which control plane you run |
-| [Case: event backbone](case-event-stream.md) | End-to-end recommendation |
-
+| [Two schema cultures](two-schema-cultures.md) | Which control plane you are running |
+| [Case: event backbone](case-event-stream.md) | End-to-end recommendation under rolling deploy |
 
 ## Experiments
 
 **Question:** Which **compatibility mode** and registry workflow should govern this subject, and does a dry-run change pass?
 
 ### Setup
-1. Identify subject(s), registry product, and producer/consumer deploy order.  
-2. Draft a realistic schema evolution (add optional field; attempt a break).  
-3. Access to registry API or CI check that calls compatibility.
+
+1. Identify the subject or subjects, the registry product, and the producer/consumer deploy order.
+2. Draft a realistic schema evolution: add an optional field, then attempt a known break.
+3. Ensure access to the registry API or a CI check that calls the compatibility endpoint.
 
 ### Procedure
-1. Set proposed mode (e.g. BACKWARD for consumer-first).  
-2. Register new schema in a **dev** subject; confirm accept/reject matches intent.  
-3. Try a known-breaking change; confirm **reject**.  
-4. Roll a canary producer/consumer and watch lag/errors.  
-5. Document mode + who can register.
+
+1. Set the proposed mode (for example BACKWARD for a consumer-first deploy order).
+2. Register the new schema in a **dev** subject and confirm that accept/reject matches intent.
+3. Try a known-breaking change and confirm a **reject**.
+4. Roll a canary producer or consumer and watch lag and errors.
+5. Document the mode and who is allowed to register.
 
 ### Decision rule
-- Mode must match deploy order (see decision frame).  
-- If registry cannot reject breaks, you do not have registry-enforced compatibility—fix process or tool.
+
+- The mode must match deploy order (see the decision frame).
+- If the registry cannot reject breaks, you do not have registry-enforced compatibility—fix the process or the tool.
 
 ## Metrics
 
 | Metric / signal | Role |
 |-----------------|------|
-| **Compatibility check result** (pass/fail) | **Primary** experiment outcome |
+| **Compatibility check result** (pass or fail) | **Primary** experiment outcome |
 | Chosen mode (BACKWARD / FORWARD / FULL / NONE) | Policy variable |
-| Time-to-detect incompatible schema in prod | Safety lag |
-| Consumer error rate on canary | Empirical validation |
+| Time to detect an incompatible schema in production | Safety lag |
+| Consumer error rate on the canary | Empirical validation |
 | Registration ACL violations | Process hygiene |
-| Suite ser/deser metrics | Irrelevant to mode choice |
+| Suite serialize/deserialize metrics | Irrelevant to mode choice |
 
-**Conclusion style:** “Subject orders.v1 stays BACKWARD; breaking change rejected in CI.”
+**Conclusion style:** “Subject `orders.v1` stays on BACKWARD; the breaking change is rejected in CI.”
 
 ## What this suite cannot tell you
 
-- Which vendor registry to buy.  
-- Exact mode matrix for your schema language.  
-- How long dual-write must last.
+- Which vendor registry to buy.
+- The exact mode matrix for your schema language.
+- How long a dual-write period must last in your estate.
 
 ## Common mistakes
 
-- Enabling a registry but skipping CI checks (publish from laptops).  
-- Using FULL when the org cannot meet it—then bypassing the registry.  
-- Ignoring subject naming (per topic vs per record type).
+- Enabling a registry but skipping CI checks so people publish from laptops.
+- Using FULL when the organization cannot meet it—and then bypassing the registry.
+- Ignoring subject naming conventions (per topic versus per record type).
 
 ## Key takeaways
 
-- Registries encode **policy as automation**.  
-- Modes follow **who upgrades first** and **how long data lives**.  
-- Enforcement in the path of deploy matters more than dashboard green checks.  
+- Registries encode **policy as automation**.
+- Modes follow **who upgrades first** and **how long data lives**.
+- Enforcement in the deploy path matters more than a green dashboard check.
 - Suite timings do not replace compatibility testing.

--- a/docs/theory/301/trust-boundaries.md
+++ b/docs/theory/301/trust-boundaries.md
@@ -3,31 +3,36 @@
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/leo-gan/GLD.SerializerBenchmark/blob/master/docs/theory/notebooks/301/trust_boundaries.ipynb)
 **Lab notebook:** [Trust boundaries experiment](../notebooks/301/trust_boundaries.ipynb)
 
-
 ## Problem
 
-Language-native serializers—Python `pickle`, Java serialization, many .NET binary formatters, and similar “dump the object graph” tools—are ergonomic inside one runtime. They often win microbenchmarks on complex graphs and preserve types that portable formats handle awkwardly. Teams then place those bytes on a **queue**, a **cache shared across services**, a **file that other teams can open**, or a **network API**. The security and portability failure modes are not subtle: gadget chains, version skew that only appears at runtime, and permanent lock-in to one language.
+Language-native serializers—Python `pickle`, Java serialization, many .NET binary formatters, and similar “dump the object graph” tools—are convenient inside one runtime. They often win microbenchmarks on complex object graphs and preserve types that portable formats handle awkwardly. Teams then place those same bytes on a **queue**, a **cache shared across services**, a **file that other teams can open**, or a **network API**.
 
-The design question is not “is native fast?” It is **which trust and interoperability boundary the bytes cross**.
+The security and portability failure modes are not subtle. You can get gadget chains that lead to remote code execution, version skew that only appears at runtime, and permanent lock-in to one language.
+
+The design question is not “is the native format fast?” The design question is **which trust and interoperability boundary the bytes cross**.
 
 ## Short answer
 
-Treat **language-native** encodings as **unsafe by default** for anything outside a single process trust domain (or a tightly controlled same-stack path with authenticated peers and no untrusted input). Prefer **portable** formats—text or binary, self-describing or schema-driven—whenever data is stored long-term, shared across languages, accepted from clients, or exposed to multi-tenant input. Native formats remain useful for **trusted, same-runtime** checkpoints and caches when the threat model explicitly allows them and operators accept the lock-in.
+Treat **language-native** encodings as **unsafe by default** for anything outside a single-process trust domain (or a tightly controlled same-stack path with authenticated peers and no untrusted input). Prefer **portable** formats—text or binary, self-describing or schema-driven—whenever data is stored long-term, shared across languages, accepted from clients, or exposed to multi-tenant input.
 
-Assumes 201: [self-describing vs schema](../201/self-describing-vs-schema-dependent.md) for where field identity lives; this page owns **trust and portability policy**.
+Native formats remain useful for **trusted, same-runtime** checkpoints and caches when the threat model explicitly allows them and operators accept the lock-in.
+
+This page assumes the 201 article on [self-describing vs schema](../201/self-describing-vs-schema-dependent.md) for where field identity lives. Here we own **trust and portability policy**.
 
 ## Constraints that matter
 
-| Constraint | Portable (JSON, MessagePack, Protobuf, …) | Language-native (pickle, Java ser, …) |
-|------------|-------------------------------------------|----------------------------------------|
-| **Who may produce bytes?** | Often untrusted clients or other teams | Must be fully trusted writers only |
-| **Who may consume?** | Any language with a library | Typically one runtime family |
-| **Lifetime** | Years on disk / in a log | Often broken by class/layout changes |
-| **Security** | Still need limits and validation | Deserialization can become **code execution** |
-| **Ops** | Debuggable with open tools (especially text) | Opaque without the exact type graph |
-| **Performance** | Implementation-dependent (see suite) | Sometimes excellent on graphs—**irrelevant if unsafe** |
+| Constraint | Portable (JSON, MessagePack, Protobuf, and similar) | Language-native (pickle, Java serialization, and similar) |
+|------------|-----------------------------------------------------|-----------------------------------------------------------|
+| **Who may produce the bytes?** | Often untrusted clients or other teams | Must be fully trusted writers only |
+| **Who may consume the bytes?** | Any language with a suitable library | Typically one runtime family |
+| **Lifetime** | Can live for years on disk or in a log | Often breaks when class or layout definitions change |
+| **Security** | You still need size limits and validation | Deserialization can become **code execution** |
+| **Operations** | Debuggable with open tools (especially text formats) | Opaque without the exact type graph from the original deployment |
+| **Performance** | Implementation-dependent (see the suite) | Sometimes excellent on graphs—and **irrelevant if the path is unsafe** |
 
 ## Decision frame
+
+Ask one primary question first: **do these bytes leave this process or trust domain?**
 
 ```text
   Do bytes leave this process / trust domain?
@@ -36,100 +41,107 @@ Assumes 201: [self-describing vs schema](../201/self-describing-vs-schema-depend
         │    │
         ▼    ▼
    Native    Portable format required
-   may be    (choose family with 101/201 + categories)
-   OK if
+   may be    (choose the family with 101/201
+   OK if      knowledge and the category guide)
+   peers are
    trusted
-   peers only
 ```
+
+If the answer is yes, a portable format is required. If the answer is no, a native format may still be acceptable—only when every peer is trusted and the lock-in is documented.
 
 | Situation | Prefer | Avoid |
 |-----------|--------|-------|
-| Public or partner HTTP/RPC body | Portable (often JSON + validation, or IDL binary) | Native |
-| Multi-language microservices | Portable schema-driven or schemaless binary | Native |
-| Object store / lake / long-lived files | Portable (often columnar or Avro/Parquet-class for data) | Native blobs as system of record |
-| Redis/memcache value, **same service binary only**, private network, no user input | Native *possible* if threat model documented | Native if any other service or language may read |
-| ML checkpoint used only by one training stack | Native *common*; migrate to portable for sharing | Native as the only interchange with production services |
-| “Faster than JSON in one language Results” | Use as **same-language** evidence only | Mandating native on the network |
+| Public or partner HTTP or RPC body | Portable format (often JSON plus validation, or an IDL-based binary format) | Language-native encodings |
+| Multi-language microservices | Portable schema-driven or schemaless binary | Language-native encodings |
+| Object store, data lake, or long-lived files | Portable (often columnar or Avro/Parquet-class for analytics data) | Native blobs as the system of record |
+| Redis or memcache value used by **the same service binary only**, on a private network, with no user input | Native is *possible* if the threat model is written down | Native if any other service or language may read the value |
+| Machine-learning checkpoint used only by one training stack | Native is *common*; migrate to portable when sharing with other systems | Native as the only interchange with production services |
+| “Faster than JSON on one language Results page” | Use that as **same-language** cost evidence only | Mandating native formats on the network |
 
 ## Failure modes
 
 | Failure | What happens |
 |---------|----------------|
-| **Gadget / RCE** | Hostile or merely unexpected bytes trigger class loading or code paths during deserialize |
-| **Silent version skew** | Writer and reader disagree on class shape; errors are runtime and intermittent |
-| **Polyglot surprise** | A second language team cannot consume the cache without rewriting |
-| **Backup / forensics gap** | Incident response cannot inspect payloads without the original deployment |
-| **False safety** | “Internal network” treated as trusted while multi-tenant jobs share the bus |
+| **Gadget chains and remote code execution (RCE)** | Hostile or merely unexpected bytes trigger class loading or dangerous code paths during deserialize |
+| **Silent version skew** | Writer and reader disagree on class shape; errors show up at runtime and can be intermittent |
+| **Polyglot surprise** | A second language team cannot consume the cache without rewriting the format |
+| **Backup and forensics gap** | Incident response cannot inspect payloads without the original deployment’s type graph |
+| **False safety** | “Internal network” is treated as trusted while multi-tenant jobs still share the bus |
 
 ## Real-world sketch
 
-A Python service caches session graphs with `pickle` in Redis for speed. Latency improves on the language Results-style comparison of native vs JSON. Six months later a second service in Go needs the same session. Options become: keep dual writers, reverse-engineer a fragile parser, or migrate to MessagePack/JSON with an explicit schema. Separately, an SSRF-style bug lets an attacker influence a cache key path; if anything ever deserializes attacker-influenced pickle, the incident class changes from “data issue” to “remote code execution.” The original speed win did not price that risk.
+A Python service caches session graphs with `pickle` in Redis for speed. Latency improves in a language Results-style comparison of native versus JSON. Six months later a second service written in Go needs the same session data. The options become: keep dual writers, reverse-engineer a fragile parser, or migrate to MessagePack or JSON with an explicit schema.
+
+Separately, an SSRF-style bug (server-side request forgery) lets an attacker influence a cache key path. If anything ever deserializes attacker-influenced pickle, the incident class changes from “data issue” to “remote code execution.” The original speed win did not price that risk.
 
 ## In this suite
 
 | Resource | Role |
 |----------|------|
-| [Serialization categories](../../analysis/serialization_categories.md) | **Language-native** family vs portable families |
-| Language **Overview** | Which native codecs are registered (if any) and caveats |
-| Language **Results** | Speed/size **within one language**—never a reason to put native on the wire alone |
+| [Serialization categories](../../analysis/serialization_categories.md) | Labels the **language-native** family versus portable families |
+| Language **Overview** | Shows which native codecs are registered (if any) and their caveats |
+| Language **Results** | Speed and size **within one language**—never a reason by itself to put native bytes on the wire |
 | [Using this suite](using-this-suite.md) | How not to misread those numbers |
-| [Engineering perspective](../101/engineer_perspective.md) | Product framing of native vs portable |
+| [Engineering perspective](../101/engineer_perspective.md) | Product framing of native versus portable choices |
 
-When native and portable entries both appear for a language, compare them only to answer “what do we pay for portability **in this runtime**?”—not “is native a good public contract?”
-
+When native and portable entries both appear for a language, compare them only to answer “what do we pay for portability **in this runtime**?” Do not treat the comparison as “is native a good public contract?”
 
 ## Experiments
 
 **Question:** May these bytes use a **language-native** codec, or must they be **portable**?
 
 ### Setup
-1. Draw the data path: producer process → store/queue/API → consumers.  
-2. Mark each hop: same process, same trust domain, multi-tenant, public, multi-language.  
-3. List candidate native vs portable codecs for the language (suite categories help label them).
+
+1. Draw the data path: producer process, then store or queue or API, then consumers.
+2. Mark each hop: same process, same trust domain, multi-tenant, public, multi-language.
+3. List candidate native and portable codecs for the language. Suite categories help label them.
 
 ### Procedure
-1. For each hop, answer: *Can an untrusted or other-language principal supply or read bytes?*  
-2. If **yes** on any long-lived or cross-service hop → portable required; native disqualified for that hop.  
-3. If **no** (trusted same-runtime only) → native allowed *if* threat model and ops accept lock-in.  
-4. Document the policy in the service boundary checklist.  
-5. Optional suite check: compare native vs portable **only** for performance *after* policy allows native—never to override a failed trust test.
+
+1. For each hop, answer: *Can an untrusted principal or another language supply or read these bytes?*
+2. If **yes** on any long-lived or cross-service hop, a portable format is required and native is disqualified for that hop.
+3. If **no** (trusted same-runtime only), native is allowed *if* the threat model and operations team accept the lock-in.
+4. Document the policy in the service boundary checklist.
+5. Optional suite check: compare native versus portable **only** for performance *after* policy allows native. Never use speed to override a failed trust test.
 
 ### Decision rule
-- Trust/portability failure ⇒ portable, regardless of suite speed.  
-- Suite timings may choose *which* portable family/impl, not whether native is safe.
+
+- If trust or portability fails, choose portable, regardless of suite speed.
+- Suite timings may choose *which* portable family or implementation, not whether native is safe.
 
 ## Metrics
 
 | Metric / signal | Role |
 |-----------------|------|
-| **Trust-domain crossing** (yes/no per hop) | **Primary** decision variable |
-| **Consumer language set** | Forces portable if >1 runtime family |
-| **Attack surface** (untrusted producer?) | Forces portable + [untrusted input](untrusted-input.md) controls |
-| **Retention / durability** | Long-lived native = version-skew risk |
-| Suite `total_median_ns` / size | Secondary, only among **policy-allowed** codecs |
-| `mean_fidelity` | Among allowed candidates |
+| **Trust-domain crossing** (yes or no per hop) | **Primary** decision variable |
+| **Consumer language set** | Forces portable if more than one runtime family is involved |
+| **Attack surface** (untrusted producer?) | Forces portable formats plus [untrusted input](untrusted-input.md) controls |
+| **Retention and durability** | Long-lived native data means long-lived version-skew risk |
+| Suite `total_median_ns` and size | Secondary, only among **policy-allowed** codecs |
+| `mean_fidelity` | Correctness filter among allowed candidates |
 
-**Conclusion style:** “Queue hop is multi-tenant → portable only; native pickle rejected despite speed.”  
+**Conclusion style:** “The queue hop is multi-tenant, so only portable formats are allowed; native pickle is rejected despite its speed.”
+
 **Not decision metrics:** native microbenchmark wins on unsafe boundaries.
 
 ## What this suite cannot tell you
 
-- Whether a specific native stack has a known gadget chain in *your* dependency set.  
-- Your network trust model, IAM boundaries, or multi-tenant isolation.  
-- Compliance rules that forbid certain encodings at rest.  
-- Cross-language feasibility of a native blob (by definition: poor).
+- Whether a specific native stack has a known gadget chain in *your* dependency set.
+- Your network trust model, identity and access (IAM) boundaries, or multi-tenant isolation story.
+- Compliance rules that forbid certain encodings at rest.
+- Cross-language feasibility of a native blob (by definition, it is poor).
 
 ## Common mistakes
 
-- Equating “internal” with “trusted for deserialize.”  
-- Using native speed on Results to justify a **public** or **multi-language** API.  
-- Storing native blobs as the system of record “until we rewrite.”  
-- Assuming schema-driven portable formats are “secure” without resource limits—portable reduces *portability* risk, not all parser risk.
+- Equating “internal” with “trusted for deserialize.”
+- Using native speed on Results to justify a **public** or **multi-language** API.
+- Storing native blobs as the system of record “until we rewrite.”
+- Assuming schema-driven portable formats are “secure” without resource limits. Portable formats reduce *portability* risk; they do not remove all parser risk.
 
 ## Key takeaways
 
-- **Trust boundary** decides portable vs native more than peak ops/s.  
-- Native = same-runtime convenience; default **no** for interchange.  
-- Portable formats are the default once bytes leave the process or meet other languages.  
-- Suite Results may show native as fast; that is a **cost of portability** data point, not a security clearance.  
+- The **trust boundary** decides portable versus native more than peak operations per second.
+- Native formats are same-runtime convenience. The default answer for interchange is **no**.
+- Portable formats are the default once bytes leave the process or meet other languages.
+- Suite Results may show native formats as fast. That is a **cost of portability** data point, not a security clearance.
 - Document the threat model if you still choose native for a private cache.

--- a/docs/theory/301/two-schema-cultures.md
+++ b/docs/theory/301/two-schema-cultures.md
@@ -3,31 +3,34 @@
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/leo-gan/GLD.SerializerBenchmark/blob/master/docs/theory/notebooks/301/two_schema_cultures.ipynb)
 **Lab notebook:** [Two schema cultures experiment](../notebooks/301/two_schema_cultures.ipynb)
 
-
 ## Problem
 
-Both Apache Avro and Protocol Buffers are **schema-driven**. Teams still fail migrations because they treat “we have a schema” as one practice. In reality, two mature cultures dominate industry systems:
+Both Apache Avro and Protocol Buffers are **schema-driven**. Teams still fail migrations because they treat “we have a schema” as if that were one single practice. In reality, two mature cultures dominate industry systems:
 
-1. **Resolution culture** (classic Avro): writer and reader schemas may differ; a **resolution** algorithm fills defaults, projects fields, and defines compatibility.  
-2. **Field-number culture** (classic Protobuf): field **numbers** are the stable contract; names are local; evolution is “add optional fields, never reuse numbers,” enforced by process more than by runtime resolution of two full schemas on every read.
+1. **Resolution culture** (classic Avro): the writer’s schema and the reader’s schema may differ. A **resolution** algorithm fills defaults, projects fields, and defines what counts as compatible.
+2. **Field-number culture** (classic Protobuf): field **numbers** are the stable contract; names are mostly local documentation. Evolution means “add optional fields, never reuse numbers,” enforced by process more than by runtime resolution of two full schemas on every read.
 
-Choosing the wrong culture for the ops model—or mixing habits—breaks consumers under rolling deploy.
+Choosing the wrong culture for your operations model—or mixing the habits of both—breaks consumers under rolling deploy.
 
 ## Short answer
 
-Use **Avro-like resolution** when producers and consumers evolve independently, schemas are published to a **registry**, and you want compatibility rules (BACKWARD / FORWARD / FULL) checked as policy artifacts. Use **Protobuf-like field-number discipline** when a shared `.proto` (or equivalent IDL) is the product interface, codegen is central, and change control is “reserve numbers, additive fields, CI breaks on incompatible edits.” Both can serve RPC and events; the difference is **how change is governed**, not a universal speed ranking.
+Use **Avro-like resolution** when producers and consumers evolve independently, schemas are published to a **registry**, and you want compatibility rules such as BACKWARD, FORWARD, or FULL checked as policy artifacts. (Those modes describe which old and new reader/writer combinations remain legal; the [schema registries](schema-registries.md) article expands them.)
 
-Assumes 201: [schema evolution](../201/schema-evolution.md) for forward/backward vocabulary; [self-describing vs schema](../201/self-describing-vs-schema-dependent.md) for why schemas exist. This page owns **culture and operations**.
+Use **Protobuf-like field-number discipline** when a shared `.proto` file (or equivalent IDL) is the product interface, code generation is central, and change control means “reserve numbers, add fields, and fail continuous integration (CI) on incompatible edits.”
+
+Both families can serve RPC and events. The difference is **how change is governed**, not a universal speed ranking.
+
+This page assumes 201 [schema evolution](../201/schema-evolution.md) for forward/backward vocabulary and [self-describing vs schema](../201/self-describing-vs-schema-dependent.md) for why schemas exist. Here we own **culture and operations**.
 
 ## Constraints that matter
 
 | Axis | Resolution culture (Avro-class) | Field-number culture (Protobuf-class) |
 |------|----------------------------------|----------------------------------------|
-| **Stable identity** | Often **names** (+ namespace) in schema | **Field numbers** on the wire |
-| **Who holds schemas at read** | Writer schema + reader schema (registry/file) | Shared IDL / descriptor set agreed out of band |
-| **Compatibility** | Explicit modes; resolution applies defaults | Process + lint; unknown fields typically retained/skipped per rules |
-| **Tooling center of gravity** | Schema registry, subject versioning | `protoc`/buf, codegen, breaking-change detectors |
-| **Typical homes** | Event logs, data platform rows | RPC APIs, multi-language service stubs |
+| **Stable identity** | Often **names** (plus namespace) in the schema | **Field numbers** on the wire |
+| **Who holds schemas at read time** | Writer schema plus reader schema (from a registry or file) | Shared IDL or descriptor set agreed out of band |
+| **Compatibility** | Explicit modes; resolution applies defaults | Process and lint; unknown fields are typically retained or skipped per runtime rules |
+| **Tooling center of gravity** | Schema registry and subject versioning | `protoc` or buf, code generation, breaking-change detectors |
+| **Typical homes** | Event logs and data-platform rows | RPC APIs and multi-language service stubs |
 | **Failure style** | Resolution errors; incompatible subject versions | Reused field numbers; silent semantic overwrite |
 
 Neither column is “more schema-driven.” Both are schema-driven with different **control planes**.
@@ -36,36 +39,36 @@ Neither column is “more schema-driven.” Both are schema-driven with differen
 
 | If you need… | Lean toward |
 |--------------|-------------|
-| Many producer versions, long-lived topics, registry gates in CI/CD | Resolution culture (Avro-class or equivalent) |
-| Strong multi-language stubs, one IDL repo, RPC-first | Field-number culture (Protobuf-class) |
-| Data lake / analytics row encoding with schema evolution | Often Avro-class (or columnar formats—see row vs columnar) |
-| Public HTTP with human JSON | Neither alone—JSON + external contract (OpenAPI/JSON Schema); dual stack possible |
-| “We already standardized on protos for RPC” | Stay field-number; do not invent ad-hoc resolution without tooling |
-| “We already run a schema registry for Kafka” | Stay resolution; do not ignore compatibility mode |
+| Many producer versions, long-lived topics, and registry gates in CI/CD | Resolution culture (Avro-class or equivalent) |
+| Strong multi-language stubs, one IDL repository, and an RPC-first design | Field-number culture (Protobuf-class) |
+| Data lake or analytics row encoding with schema evolution | Often Avro-class (or columnar formats—see [row vs columnar](row-vs-columnar.md)) |
+| Public HTTP with human-readable JSON | Neither culture alone—JSON plus an external contract such as OpenAPI or JSON Schema; a dual stack is possible |
+| “We already standardized on protos for RPC” | Stay with field-number culture; do not invent ad-hoc resolution without tooling |
+| “We already run a schema registry for Kafka” | Stay with resolution culture; do not ignore the compatibility mode |
 
 ```text
-  Independent producer/consumer versions + registry?
+  Independent producer/consumer versions + a registry?
         yes → resolution culture
         no  → shared IDL + field-number discipline
-              (still need CI for breaks)
+              (you still need CI for breaking changes)
 ```
 
 ## Failure modes
 
 | Mistake | Consequence |
 |---------|-------------|
-| **Reuse Protobuf field numbers** | Old readers misinterpret new meaning; worst class of silent corruption |
-| **Delete Avro fields carelessly under wrong compatibility mode** | Consumers fail or drop data depending on mode |
-| **Rename-as-replace without dual-write** | JSON/Avro name identity breaks; Protobuf renames are safer if numbers hold—but APIs and docs lag |
-| **Registry without enforcement** | “We have Avro” but anyone can push incompatible schemas |
-| **Protobuf without ownership** | `.proto` forks per team; numbers collide when merged |
+| **Reusing Protobuf field numbers** | Old readers misinterpret the new meaning—this is the worst class of silent corruption |
+| **Deleting Avro fields carelessly under the wrong compatibility mode** | Consumers fail or drop data depending on the mode |
+| **Rename-as-replace without dual-write** | JSON and Avro name identity breaks; Protobuf renames are safer if numbers hold, but APIs and docs still lag |
+| **Registry without enforcement** | You “have Avro,” but anyone can push incompatible schemas |
+| **Protobuf without ownership** | `.proto` files fork per team; numbers collide when someone merges |
 | **Culture mashup** | Expecting registry-style resolution from raw Protobuf bytes without descriptors |
 
 ## Real-world sketch
 
-**Events:** an orders topic uses Avro with BACKWARD compatibility. Producers deploy a new optional field; old consumers resolve defaults. The control plane is the registry subject, not a monorepo merge of stubs.
+**Events.** An orders topic uses Avro with BACKWARD compatibility. Producers deploy a new optional field; old consumers resolve defaults. The control plane is the registry subject, not a monorepo merge of stubs.
 
-**RPC:** a billing API uses Protobuf. Field `3` is `amount_cents` forever. A new `currency_code` becomes field `7`. Codegen updates services that care; old binaries ignore unknown fields per runtime rules. The control plane is the IDL review + breaking-change CI.
+**RPC.** A billing API uses Protobuf. Field `3` is `amount_cents` forever. A new `currency_code` becomes field `7`. Code generation updates services that care; old binaries ignore unknown fields according to runtime rules. The control plane is IDL review plus breaking-change CI.
 
 Swapping habits—treating Protobuf field names as the long-term identity, or deploying Avro without a compatibility mode—recreates the outages each culture evolved to prevent.
 
@@ -73,65 +76,67 @@ Swapping habits—treating Protobuf field names as the long-term identity, or de
 
 | Resource | Role |
 |----------|------|
-| Language **Overview** / **Results** | Where Avro, Protobuf, or similar **implementations** are registered |
-| [Serialization categories](../../analysis/serialization_categories.md) | Both sit in **schema-driven** family—do not rank cultures by a mixed chart |
-| [Using this suite](using-this-suite.md) | Same language + paradigm before comparing libraries |
+| Language **Overview** and **Results** | Where Avro, Protobuf, or similar **implementations** are registered |
+| [Serialization categories](../../analysis/serialization_categories.md) | Both sit in the **schema-driven** family—do not rank cultures with a mixed chart |
+| [Using this suite](using-this-suite.md) | Same language and paradigm before comparing libraries |
 | 201 [schema evolution](../201/schema-evolution.md) | Mechanism vocabulary |
 
-Suite timings compare **libraries**, not “Avro culture vs Protobuf culture” as governance systems. Use Results to pick an implementation **after** the culture fits the ops model.
-
+Suite timings compare **libraries**, not “Avro culture versus Protobuf culture” as governance systems. Use Results to pick an implementation **after** the culture fits the operations model.
 
 ## Experiments
 
-**Question:** Should this system’s evolution culture be **writer-schema resolution** (Avro-like) or **field-number discipline** (Protobuf-like)—and are we operating it consistently?
+**Question:** Should this system’s evolution culture be **writer-schema resolution** (Avro-like) or **field-number discipline** (Protobuf-like)—and are we operating that culture consistently?
 
 ### Setup
-1. List producers, consumers, and whether a **registry** or shared `.proto`/IDL repo exists.  
-2. Note deploy topology: independent services vs monorepo lockstep.  
-3. Sample one planned schema change (add field, rename, remove).
+
+1. List producers, consumers, and whether a **registry** or shared `.proto`/IDL repository exists.
+2. Note deploy topology: independent services versus monorepo lockstep.
+3. Sample one planned schema change (add a field, rename a field, or remove a field).
 
 ### Procedure
-1. Classify current stack: resolution-at-read vs tag/field-id binary.  
-2. Walk the planned change through **both** cultures’ rules; list breakages.  
-3. Check whether ops actually enforce the culture (registry compatibility mode vs proto review + reserved).  
-4. Suite optional: same logical fixture encoded by Avro vs Protobuf implementations for **size/speed orientation only**—not culture choice.  
-5. Write the chosen culture + enforcement owner into the architecture note.
+
+1. Classify the current stack: resolution-at-read versus tag or field-id binary.
+2. Walk the planned change through **both** cultures’ rules and list breakages.
+3. Check whether operations actually enforce the culture (registry compatibility mode versus proto review and reserved numbers).
+4. Optionally encode the same logical fixture with Avro and Protobuf implementations for **size and speed orientation only**—not for culture choice.
+5. Write the chosen culture and the enforcement owner into the architecture note.
 
 ### Decision rule
-- Prefer the culture your **ops can enforce** (registry modes vs IDL governance).  
+
+- Prefer the culture your **operations team can enforce** (registry modes versus IDL governance).
 - Do not mix cultures on one topic without an explicit dual-stack plan.
 
 ## Metrics
 
 | Metric / signal | Role |
 |-----------------|------|
-| **Compatibility mode** (BACKWARD/FORWARD/FULL) or **proto breaking-change policy** | **Primary** ops metric |
-| Schema-change lead time / failed deploys from skew | Health of the culture |
-| Registry reject rate vs silent consumer errors | Enforcement quality |
-| Consumer languages count | Pressure toward explicit contracts |
-| Suite `median_size_bytes` / speed | Secondary cost of a culture’s typical stack |
-| Conformance across languages ([401 fidelity](../401/protobuf-cross-language-fidelity.md) for Pb) | Implementation discipline |
+| **Compatibility mode** (BACKWARD / FORWARD / FULL) or **proto breaking-change policy** | **Primary** operations metric |
+| Schema-change lead time and failed deploys from skew | Health of the culture |
+| Registry reject rate versus silent consumer errors | Enforcement quality |
+| Count of consumer languages | Pressure toward explicit contracts |
+| Suite `median_size_bytes` and speed | Secondary cost of a culture’s typical stack |
+| Conformance across languages ([401 fidelity](../401/protobuf-cross-language-fidelity.md) for Protobuf) | Implementation discipline |
 
-**Conclusion style:** “Event bus uses Avro + BACKWARD registry; RPC uses Protobuf field-id discipline.”
+**Conclusion style:** “The event bus uses Avro with BACKWARD registry mode; RPC uses Protobuf field-id discipline.”
 
 ## What this suite cannot tell you
 
-- Which **compatibility mode** your registry should enforce.  
-- Whether your monorepo can own all `.proto` files.  
-- Multi-hop dual-write duration for a rename.  
-- Legal retention of old writer schemas for resolution.
+- Which **compatibility mode** your registry should enforce.
+- Whether your monorepo can own all `.proto` files.
+- How long a multi-hop dual-write must last for a rename.
+- Legal retention requirements for old writer schemas used in resolution.
 
 ## Common mistakes
 
-- Picking Avro “because Kafka” without choosing and enforcing a compatibility mode.  
-- Picking Protobuf “because gRPC” then reusing field numbers under pressure.  
-- Using suite speed to choose the culture.  
-- Assuming JSON needs no culture—public JSON still needs a contract process (later 301 article).
+- Picking Avro “because Kafka” without choosing and enforcing a compatibility mode.
+- Picking Protobuf “because gRPC” and then reusing field numbers under pressure.
+- Using suite speed to choose the culture.
+- Assuming JSON needs no culture—public JSON still needs a contract process (see [public API contracts](public-api-contracts.md)).
 
 ## Key takeaways
 
-- Two schema-driven cultures: **resolution** vs **field-number discipline**.  
-- Match culture to **how producers and consumers version**, not to a brand preference alone.  
-- 201 explains evolution *rules*; 301 chooses the *operating model*.  
-- Suite evidence is for implementations inside a family—after culture is fixed.  
+- There are two schema-driven cultures: **resolution** and **field-number discipline**.
+- Match culture to **how producers and consumers version**, not to a brand preference alone.
+- Serialization 201 explains evolution *rules*; Serialization 301 chooses the *operating model*.
+- Suite evidence is for implementations inside a family—after culture is fixed.
 - Mixing cultures without tooling reproduces classic migration failures.

--- a/docs/theory/301/untrusted-input.md
+++ b/docs/theory/301/untrusted-input.md
@@ -3,120 +3,129 @@
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/leo-gan/GLD.SerializerBenchmark/blob/master/docs/theory/notebooks/301/untrusted_input.ipynb)
 **Lab notebook:** [Untrusted input experiment](../notebooks/301/untrusted_input.ipynb)
 
-
 ## Problem
 
-Every public or multi-tenant deserialize path accepts **attacker-controlled bytes**. Classic failures are not slow codecs—they are remote code execution via native deserializers, resource exhaustion via nested or huge payloads, and logic bugs from unvalidated schemaless data. Teams discover this after an incident, then retrofit limits that should have been part of the original boundary design.
+Every public or multi-tenant deserialize path accepts **attacker-controlled bytes**. The classic failures are not “the codec was a bit slow.” They are remote code execution through native deserializers, resource exhaustion through nested or huge payloads, and logic bugs from unvalidated schemaless data.
+
+Teams often discover these risks after an incident. They then retrofit limits that should have been part of the original boundary design.
 
 ## Short answer
 
-Assume untrusted input is **hostile**. Prefer **portable pure-data formats** with explicit validation at the trust boundary ([trust boundaries](trust-boundaries.md)). Enforce **maximum body size, nesting depth, and collection cardinality** before or during parse. Never run language-native deserialize (pickle, Java serialization, unsafe YAML load, legacy binary formatters) on untrusted bytes. For zero-copy layouts, **verify** before field access (201 [zero-copy](../201/zero-copy.md)). Suite speed numbers do not measure adversarial robustness.
+Assume untrusted input is **hostile**. Prefer **portable pure-data formats** with explicit validation at the trust boundary (see [trust boundaries](trust-boundaries.md)). Enforce **maximum body size, nesting depth, and collection cardinality** before or during parse.
 
-Assumes 101 engineering security notes; this page owns the **operational playbook**.
+Never run language-native deserialize—pickle, Java serialization, unsafe YAML load, legacy binary formatters—on untrusted bytes. For zero-copy layouts, **verify** the buffer before field access (see 201 [zero-copy](../201/zero-copy.md)). Suite speed numbers do not measure adversarial robustness.
+
+This page assumes the security notes from the 101 engineering lens. Here we own the **operational playbook**.
 
 ## Constraints that matter
 
 | Control | Why it matters |
 |---------|----------------|
-| **Who can send bytes?** | Internet, partner, internal multi-tenant, same process |
-| **Deserializer power** | Arbitrary types / code vs pure data |
-| **Resource budget** | CPU, memory, wall time per request |
-| **Validation layer** | Schema, typed models, allowlists |
-| **Logging of payloads** | See [payload surfaces](payload-surfaces.md) |
+| **Who can send bytes?** | Internet clients, partners, internal multi-tenant callers, or only the same process |
+| **Deserializer power** | Can the format reconstruct arbitrary types and code, or only pure data? |
+| **Resource budget** | CPU, memory, and wall-clock time allowed per request |
+| **Validation layer** | Schema checks, typed models, allowlists of accepted shapes |
+| **Logging of payloads** | Captured bodies create cost and leak risk; see [payload surfaces](payload-surfaces.md) |
 
 ## Decision frame
 
 ```text
   Untrusted producer?
-    no  → still size-limit; threat model may be weaker
-    yes → portable format + hard limits + validate
+    no  → still enforce size limits; the threat model may be weaker
+    yes → portable format + hard limits + validation
            never native deserialize
 ```
 
+Even when the producer is trusted, size limits remain a good default. When the producer is untrusted, portable formats, hard resource caps, and validation are mandatory.
+
 | Risk class | Typical vectors | Mitigations |
 |------------|-----------------|-------------|
-| **Code execution** | pickle, Java ser, gadget chains, unsafe YAML | Ban on boundary; pure data only |
-| **Expansion / DoS** | Entity expansion, nested bombs, huge arrays | Disable dangerous features; depth/size caps |
-| **Allocation storms** | Many small objects from one message | Caps; streaming parsers where appropriate |
-| **Type confusion** | JSON number vs string; duplicate keys | Schema / typed decode; strict parsers |
-| **Unverified zero-copy** | Crafted offsets | Verifier before use |
+| **Code execution** | pickle, Java serialization, gadget chains, unsafe YAML | Ban these on the boundary; accept pure data only |
+| **Expansion and denial of service (DoS)** | Entity expansion, nested bombs, huge arrays | Disable dangerous features; enforce depth and size caps |
+| **Allocation storms** | Many small objects created from one message | Caps; streaming parsers where appropriate |
+| **Type confusion** | JSON number versus string; duplicate keys | Schema or typed decode; strict parsers |
+| **Unverified zero-copy** | Crafted offsets into a buffer | Run a verifier before use |
 
 ## Failure modes
 
 | Mistake | Outcome |
 |---------|---------|
-| “Internal network = trusted” | Lateral movement becomes RCE |
-| Limits only at the gateway | Sidecar or admin path bypasses them |
-| Validate after full materialization | DoS already paid |
-| Fuzz never run | Edge cases ship to production |
-| Choosing codec by Results alone | Fast unsafe path wins the ADR |
+| Treating “internal network” as fully trusted | Lateral movement inside the network becomes remote code execution |
+| Putting limits only at the gateway | A sidecar or admin path bypasses them |
+| Validating only after full materialization | You already paid the denial-of-service cost |
+| Never running fuzz tests | Edge cases ship straight to production |
+| Choosing a codec by Results alone | A fast but unsafe path wins the architecture decision record |
 
 ## Real-world sketch
 
-An internal API accepts MessagePack from other services and later from a partner VPN. No max depth. A nested map bomb locks workers. Separately, a debug endpoint still accepts pickle “for support tools.” The pickle path is the incident class that ends careers; the depth bomb is the one that ends SLOs. Both are **boundary design** failures, not “we picked the wrong MessagePack library.”
+An internal API accepts MessagePack from other services and later from a partner VPN. There is no maximum nesting depth. A nested map bomb locks workers. Separately, a debug endpoint still accepts pickle “for support tools.”
+
+The pickle path is the incident class that ends careers. The depth bomb is the one that ends service-level objectives (SLOs). Both are **boundary design** failures, not “we picked the wrong MessagePack library.”
 
 ## In this suite
 
 | Resource | Role |
 |----------|------|
-| Language **Overview** | Notes on native / fidelity—not security proofs |
-| **Results** | Encode/decode cost under **benign** fixtures |
-| [Using this suite](using-this-suite.md) | Do not treat speed as safety |
-| [Trust boundaries](trust-boundaries.md) | Portable vs native policy |
+| Language **Overview** | Notes on native codecs and fidelity—not security proofs |
+| **Results** | Encode and decode cost under **benign** fixtures |
+| [Using this suite](using-this-suite.md) | Why you must not treat speed as safety |
+| [Trust boundaries](trust-boundaries.md) | Portable versus native policy |
 
 This harness does **not** run adversarial fuzz campaigns or claim parser security.
-
 
 ## Experiments
 
 **Question:** For this deserialize path, are **hostile-payload controls** sufficient, and is the codec class acceptable?
 
 ### Setup
-1. Identify every public or multi-tenant parse entrypoint.  
-2. Note codec (JSON, Protobuf, native, …) and max request size at the edge.  
-3. Gather parser settings: depth limits, document size, known CVE posture.
+
+1. Identify every public or multi-tenant parse entry point.
+2. Note the codec (JSON, Protobuf, native, and so on) and the maximum request size at the edge.
+3. Gather parser settings: depth limits, document size limits, and known CVE posture (common vulnerabilities and exposures).
 
 ### Procedure
-1. Threat checklist: code execution (native deser), expansion bombs, huge alloc, deeply nested structures.  
-2. Verify **hard limits** (body size, depth, collection cardinality) before or during parse.  
-3. Confirm native/pickle/Java serialization are **banned** on untrusted paths.  
-4. Optional: fuzz or adversarial fixtures; watch process memory and time-to-failure.  
-5. Suite Results optional for performance among **safe** portable codecs only.
+
+1. Walk a threat checklist: code execution through native deserialize, expansion bombs, huge allocations, deeply nested structures.
+2. Verify **hard limits** on body size, depth, and collection cardinality before or during parse.
+3. Confirm that native, pickle, and Java serialization paths are **banned** on untrusted routes.
+4. Optionally fuzz or inject adversarial fixtures; watch process memory and time-to-failure.
+5. Use suite Results only for performance among **safe** portable codecs.
 
 ### Decision rule
-- Any untrusted path with native deserialize or no size/depth limits ⇒ **fail**; fix before optimizing.  
-- Among safe codecs, use implementation-variance + latency experiments as usual.
+
+- Any untrusted path with native deserialize or no size/depth limits is a **fail**. Fix that before optimizing.
+- Among safe codecs, use the implementation-variance and latency experiments as usual.
 
 ## Metrics
 
 | Metric / signal | Role |
 |-----------------|------|
 | **Max body size enforced** | **Primary** control metric |
-| **Max depth / array size** | Expansion / stack risk |
-| **Time and memory to reject** huge/nested payloads | DoS resistance |
-| Parser error rate on fuzz | Robustness |
-| CVE / advisory state of library | Eligibility |
-| Suite speed / size | Secondary after safety pass |
+| **Max depth and array size** | Expansion and stack risk |
+| **Time and memory to reject** huge or nested payloads | Denial-of-service resistance |
+| Parser error rate on fuzz inputs | Robustness signal |
+| CVE and advisory state of the library | Eligibility filter |
+| Suite speed and size | Secondary after the safety pass |
 | `mean_fidelity` on valid fixtures | Still required for correctness |
 
-**Conclusion style:** “Edge enforces 1 MB + depth 32; JSON library X; native deser banned.”
+**Conclusion style:** “The edge enforces 1 MB and depth 32; we use JSON library X; native deserialize is banned.”
 
 ## What this suite cannot tell you
 
-- Whether a library is free of known CVEs.  
-- Correct absolute limits for *your* memory budget.  
-- Effectiveness of WAF rules or mesh policies.  
-- Gadget availability in *your* dependency graph.
+- Whether a library is free of known CVEs.
+- The correct absolute limits for *your* memory budget.
+- How effective your WAF rules or service-mesh policies are.
+- Whether gadgets exist in *your* dependency graph.
 
 ## Common mistakes
 
-- Enabling “convenient” native deserialize behind auth only.  
-- Logging full hostile bodies (amplifies cost and leak risk).  
+- Enabling “convenient” native deserialize behind authentication only.
+- Logging full hostile bodies (this amplifies cost and leak risk).
 - Skipping verification on FlatBuffers-class buffers for speed.
 
 ## Key takeaways
 
-- Deserialize is an **attack surface**; design limits first.  
-- Portable + validate + size/depth caps is the default for untrusted bytes.  
-- Native deserialize is a special case of “trusted only.”  
+- Deserialize is an **attack surface**. Design limits first.
+- Portable formats plus validation plus size and depth caps is the default for untrusted bytes.
+- Native deserialize is a special case of “trusted only.”
 - Suite Results answer cost under honest fixtures—not adversarial hardness.

--- a/docs/theory/301/using-this-suite.md
+++ b/docs/theory/301/using-this-suite.md
@@ -8,29 +8,31 @@ This multi-language suite is built to support **fair, local** comparisons. It is
 
 ## Short answer
 
-Treat every published number as the answer to a **narrow question**: for a given **language**, **fixture** (`TestDataName`), and **string vs stream mode**, how do registered serializers compare on encode time, decode time, size, and related metrics **after** the analysis pipeline’s warmup and optional outlier rules? Prefer comparisons **within one paradigm family** (JSON text, schemaless binary, schema-driven, language-native). Do not promote cross-language or cross-paradigm “champions” into architecture policy without re-stating the workload. When the decision is about trust, evolution, or multi-hop design, suite timings are **inputs**, not the whole argument—see the rest of Serialization 301.
+Treat every published number as the answer to a **narrow question**: for a given **language**, **fixture** (`TestDataName`), and **string versus stream mode**, how do registered serializers compare on encode time, decode time, size, and related metrics **after** the analysis pipeline’s warmup and optional outlier rules?
+
+Prefer comparisons **within one paradigm family** (JSON text, schemaless binary, schema-driven, language-native). Do not promote cross-language or cross-paradigm “champions” into architecture policy without re-stating the workload. When the decision is about trust, evolution, or multi-hop design, suite timings are **inputs**, not the whole argument—see the rest of Serialization 301.
 
 ## Constraints that matter
 
 | Constraint | Why it breaks naive rankings |
 |------------|------------------------------|
-| **Language / runtime** | Different VMs, GC, and stdlibs; “Protobuf in Python” is not “Protobuf in C.” |
+| **Language and runtime** | Different virtual machines, garbage collectors, and standard libraries; “Protobuf in Python” is not “Protobuf in C.” |
 | **Paradigm family** | JSON and schema-driven binary solve different product problems; speed alone is not interchangeability. |
-| **Payload shape** | Dense structs vs deep graphs change cost centers (see [Encode/decode cost](../201/encode-decode-cost.md)). |
+| **Payload shape** | Dense structs versus deep graphs change cost centers (see [Encode/decode cost](../201/encode-decode-cost.md)). |
 | **Implementation** | Several libraries can share a format label and differ by an order of magnitude. |
-| **What is timed** | Harness paths measure ser/deser of prepared fixtures—not network RTT, disk I/O, or your production validation layer. |
-| **Analysis policy** | Warmup exclusion and outlier filters change means; raw CSV ≠ published table unless you re-run analysis with the same config. |
+| **What is timed** | Harness paths measure serialize and deserialize of prepared fixtures—not network round-trip time, disk I/O, or your production validation layer. |
+| **Analysis policy** | Warmup exclusion and outlier filters change means; raw CSV is not the published table unless you re-run analysis with the same config. |
 
 ## Decision frame
 
 Use this checklist **before** quoting a Result:
 
-1. **Same language?** If no, stop—use numbers only as rough orientation, not as a pick.  
-2. **Same paradigm?** Prefer [Serialization categories](../../analysis/serialization_categories.md) families. Cross-family only when the product decision is “which family,” and then treat speed as one axis among many.  
-3. **Same fixture?** `message` vs `telemetry` (and other type ids) are different jobs.  
-4. **Same mode?** String vs stream (and any stream-mode caveats on the language Overview) must match.  
-5. **Which metric?** Mean encode, mean decode, size, ops/s, tails—pick the one your SLO cares about; do not swap them mid-argument.  
-6. **Still missing?** Compression on the wire, auth, schema registry, multi-hop fan-out—outside core tables unless you design a separate experiment.
+1. **Same language?** If no, stop. Use the numbers only as rough orientation, not as a pick.
+2. **Same paradigm?** Prefer [Serialization categories](../../analysis/serialization_categories.md) families. Cross family only when the product decision is “which family,” and then treat speed as one axis among many.
+3. **Same fixture?** `message` versus `telemetry` (and other type identifiers) are different jobs.
+4. **Same mode?** String versus stream (and any stream-mode caveats on the language Overview) must match.
+5. **Which metric?** Mean encode, mean decode, size, operations per second, or tails—pick the one your service-level objective cares about, and do not swap them mid-argument.
+6. **Still missing?** Compression on the wire, authentication, schema registry behavior, multi-hop fan-out—these sit outside the core tables unless you design a separate experiment.
 
 ```text
   Question: “Is X better than Y for us?”
@@ -39,10 +41,10 @@ Use this checklist **before** quoting a Result:
   Fix language + paradigm + fixture + mode + metric
         │
         ▼
-  Read Results / dashboard for that slice only
+  Read Results or the dashboard for that slice only
         │
         ▼
-  Re-check product constraints (trust, evolution, ops)
+  Re-check product constraints (trust, evolution, operations)
         │
         ▼
   Decide — or design a measurement this suite cannot do
@@ -54,92 +56,97 @@ Use this checklist **before** quoting a Result:
 |---------|-----------------|
 | **Global leaderboard thinking** | Picking the top row of a mixed chart as “the company format.” |
 | **Cross-language crowning** | Mandating a library because it looked fast in another runtime. |
-| **Format brand = one speed** | “We moved to binary” without naming the implementation. |
-| **Ignoring warmup / cold path** | Production cold starts differ from steady-state tables (analysis drops `RepetitionIndex == 0` by default). |
-| **Confusing size with latency** | Smallest payload on a local network may not win p99 if CPU or allocations dominate. |
+| **Format brand equals one speed** | “We moved to binary” without naming the implementation. |
+| **Ignoring warmup and cold path** | Production cold starts differ from steady-state tables (analysis drops `RepetitionIndex == 0` by default). |
+| **Confusing size with latency** | The smallest payload on a local network may not win p99 if CPU or allocations dominate. |
 | **Treating fidelity notes as optional** | Some codecs are registered with documented shape limits; Overview caveats bound the claim. |
-| **Policy from means only** | GC pauses and tail latency may not appear as a single mean encode time. |
+| **Policy from means only** | Garbage-collection pauses and tail latency may not appear as a single mean encode time. |
 
 ## Real-world sketch
 
-A team sees that a schema-driven library is fastest on **Rust** Results for a dense fixture and mandates it for a **public multi-language HTTP API**. Clients are browser and mobile; operators need human-readable debug logs; the public contract is already JSON. The suite result answered “fastest schema path in Rust for this fixture,” not “best public API contract.” A better use of the suite: compare **JSON implementations within each language** that must speak the public contract, and measure schema-driven codecs only on internal hops that already accept an IDL.
+A team sees that a schema-driven library is fastest on **Rust** Results for a dense fixture and mandates it for a **public multi-language HTTP API**. Clients are browser and mobile; operators need human-readable debug logs; the public contract is already JSON.
+
+The suite result answered “fastest schema path in Rust for this fixture,” not “best public API contract.” A better use of the suite is to compare **JSON implementations within each language** that must speak the public contract, and to measure schema-driven codecs only on internal hops that already accept an IDL.
 
 ## In this suite
 
 | Resource | Use it for |
 |----------|------------|
 | [Serialization categories](../../analysis/serialization_categories.md) | Paradigm families and the within-paradigm rule |
-| Language **Overview** | Registered names, categories, fidelity caveats (inventory SoT) |
+| Language **Overview** | Registered names, categories, fidelity caveats (inventory source of truth) |
 | Language **Results** | Published timings and sizes for that language |
 | [Analysis methodology](../../analysis/ANALYSIS_METHODOLOGY.md) | Warmup, outliers, grouping keys, units |
 | [Metrics catalog](../../analysis/METRICS.md) | What each field means |
 | [Test Data](../../analysis/test_data_configuration.md) | Fixture meanings and size knobs |
 | [Benchmark architecture](../../analysis/architecture.md) | What the harness times |
-| Dashboard (Benchmarks nav) | Interactive slices of the same analysis story |
+| Dashboard (Benchmarks navigation) | Interactive slices of the same analysis story |
 
 **Grouping key for fair peers (conceptually):**  
 `(Language, paradigm, TestDataName, StringOrStream)` — then compare `SerializerName` rows inside that cell.
 
-**Illustrative only:** prose in theory pages must not invent winners; when you need a number, open **Results** for the language you will actually run.
-
+**Illustrative only:** prose in theory pages must not invent winners. When you need a number, open **Results** for the language you will actually run.
 
 ## Experiments
 
 **Question:** Am I about to quote a **fair** suite comparison for a real decision—or a misaligned chart?
 
 ### Setup
-1. Write the decision question in one sentence (e.g. “Which JSON library in Python for message-shaped RPC?”).  
-2. Open [categories](../../analysis/serialization_categories.md) and the language **Results** / Overview for the runtime you will ship.  
-3. Note analysis config (warmup, outlier policy) from [methodology](../../analysis/ANALYSIS_METHODOLOGY.md) if you will re-derive tables.
+
+1. Write the decision question in one sentence (for example “Which JSON library in Python for message-shaped RPC?”).
+2. Open [categories](../../analysis/serialization_categories.md) and the language **Results** / Overview for the runtime you will ship.
+3. Note analysis configuration (warmup, outlier policy) from [methodology](../../analysis/ANALYSIS_METHODOLOGY.md) if you will re-derive tables.
 
 ### Procedure
-1. Apply the checklist in **Decision frame** (language → paradigm → fixture → mode → metric).  
-2. Pull only the matching rows from Results or dashboard; discard cross-family and cross-language ranks for the policy claim.  
-3. Record which metric column you will use (encode vs decode vs size vs ops/s).  
-4. List product constraints the suite does **not** measure (trust, registry, RTT).  
-5. Either decide from that slice or design an out-of-suite experiment for missing constraints.
+
+1. Apply the checklist in **Decision frame** (language, then paradigm, then fixture, then mode, then metric).
+2. Pull only the matching rows from Results or the dashboard; discard cross-family and cross-language ranks for the policy claim.
+3. Record which metric column you will use (encode versus decode versus size versus operations per second).
+4. List product constraints the suite does **not** measure (trust, registry, network RTT).
+5. Either decide from that slice or design an out-of-suite experiment for the missing constraints.
 
 ### Decision rule
-- If any checklist box fails, **do not** use the number as architecture policy.  
-- If the slice is fair but the product question is non-performance, treat suite data as **supporting**, not decisive.
+
+- If any checklist box fails, **do not** use the number as architecture policy.
+- If the slice is fair but the product question is not about performance, treat suite data as **supporting**, not decisive.
 
 ## Metrics
 
 | Metric / signal | Role |
 |-----------------|------|
 | **Comparison validity** (same language, paradigm, fixture, mode) | **Primary gate**—binary pass/fail before any number |
-| Chosen SLO metric (e.g. decode median, size) | The one number allowed in the argument |
+| Chosen SLO metric (for example decode median or size) | The one number allowed in the argument |
 | `total_median_ns` / `ser_median_ns` / `deser_median_ns` | Default speed ranks on Results |
-| `median_size_bytes` | Density / bandwidth axis |
-| `mean_fidelity` | Eligibility: non-faithful rows out |
+| `median_size_bytes` | Density and bandwidth axis |
+| `mean_fidelity` | Eligibility filter: non-faithful rows are out |
 | `serializer_version` | Reproducibility of the claim |
-| `runs` / warmup / outliers removed | Trust in the statistic |
-| Dashboard / CSV **filter state** | Document what you hid |
+| `runs`, warmup, outliers removed | Trust in the statistic |
+| Dashboard or CSV **filter state** | Document what you hid |
 
-**Conclusion style:** “Under Python + JSON family + message + bytes mode, A beats B on deser median; size similar; fidelity 1.0.”  
+**Conclusion style:** “Under Python, JSON family, message fixture, and bytes mode, A beats B on deserialize median; size is similar; fidelity is 1.0.”
+
 **Not decision metrics:** mixed-paradigm leaderboards; cross-language “champions.”
 
 ## What this suite cannot tell you
 
-- End-to-end **service** latency (queueing, network, TLS, framework overhead).  
-- **Correctness of your schema evolution policy** under rolling deploys (see 201 [schema evolution](../201/schema-evolution.md) and later 301 contract articles).  
-- **Security** of deserializing untrusted bytes (native formats, hostile inputs).  
-- Whether **gzip/zstd** on the wire wins for your message size mix (compression is orthogonal; see 201 [compression vs format](../201/compression-is-not-a-format.md)).  
-- Cross-language byte identity for every registered pair (harnesses are per-language unless you design a fidelity experiment).  
+- End-to-end **service** latency (queueing, network, TLS, framework overhead).
+- **Correctness of your schema evolution policy** under rolling deploys (see 201 [schema evolution](../201/schema-evolution.md) and later 301 contract articles).
+- **Security** of deserializing untrusted bytes (native formats, hostile inputs).
+- Whether **gzip or zstd** on the wire wins for your message size mix (compression is orthogonal; see 201 [compression vs format](../201/compression-is-not-a-format.md)).
+- Cross-language byte identity for every registered pair (harnesses are per-language unless you design a fidelity experiment).
 - Business constraints: compliance, team skill, vendor lock-in, existing public contracts.
 
 ## Common mistakes
 
-- Screenshotting one latency distribution into an ADR without stating language, fixture, and paradigm.  
-- Averaging ranks across languages “to be fair.”  
-- Changing fixture generation parameters and comparing to old published snapshots without regenerating both sides.  
+- Screenshotting one latency distribution into an architecture decision record without stating language, fixture, and paradigm.
+- Averaging ranks across languages “to be fair.”
+- Changing fixture generation parameters and comparing to old published snapshots without regenerating both sides.
 - Using language-native serializers’ speed as an argument for **network** interchange.
 
 ## Key takeaways
 
-- Suite numbers answer **narrow, local** questions—not “what format should the industry use.”  
-- Fix **language, paradigm, fixture, mode, and metric** before comparing serializers.  
-- Implementation quality and payload shape often dominate format brand.  
-- Analysis policies (warmup, outliers) are part of the claim—know them.  
-- Use Results as evidence inside a larger 301 decision (trust, contracts, workload).  
+- Suite numbers answer **narrow, local** questions—not “what format should the industry use.”
+- Fix **language, paradigm, fixture, mode, and metric** before comparing serializers.
+- Implementation quality and payload shape often dominate format brand.
+- Analysis policies (warmup, outliers) are part of the claim—know them.
+- Use Results as evidence inside a larger 301 decision about trust, contracts, and workload.
 - Explicitly list what you still must measure outside this harness.

--- a/docs/theory/301/versioning-in-the-wild.md
+++ b/docs/theory/301/versioning-in-the-wild.md
@@ -2,112 +2,116 @@
 
 ## Problem
 
-Schemas and APIs change while old clients and old data remain. Pure theory (“never break”) collides with product deadlines. Without a playbook, teams mix silent renames, hard cuts, and dual stacks until no one knows which version is canonical.
+Schemas and APIs change while old clients and old data remain. Pure theory (“never break anything”) collides with product deadlines. Without a playbook, teams mix silent renames, hard cutovers, and dual stacks until no one knows which version is canonical.
 
 ## Short answer
 
-Prefer **additive, backward-compatible** changes first. When a break is unavoidable, use an explicit **versioning surface** (URL, header, content-type, topic name, schema subject version) plus a **migration window**: dual-read and/or dual-write, metrics on old-path usage, then remove. Align the tactic with schema culture ([two schema cultures](two-schema-cultures.md), [registries](schema-registries.md)) and with public vs internal boundaries ([public API contracts](public-api-contracts.md)).
+Prefer **additive, backward-compatible** changes first. When a break is unavoidable, use an explicit **versioning surface**—URL, header, content type, topic name, or schema subject version—plus a **migration window**. During that window you dual-read and/or dual-write, watch metrics on old-path usage, and only then remove the old path.
 
-Assumes 201 [schema evolution](../201/schema-evolution.md).
+Align the tactic with schema culture ([two schema cultures](two-schema-cultures.md), [registries](schema-registries.md)) and with public versus internal boundaries ([public API contracts](public-api-contracts.md)).
+
+This page assumes 201 [schema evolution](../201/schema-evolution.md).
 
 ## Constraints that matter
 
 | Tactic | Best when | Cost |
 |--------|-----------|------|
-| **Additive optional fields** | Default path | Low if defaults exist |
-| **Dual-write** | Old and new consumers during transition | Storage/CPU; consistency rules |
-| **Dual-read** | New code understands both shapes | Complexity in one service |
-| **Content-type / Accept** | Multiple encodings or versions on one URL | Client discipline |
-| **URL / topic version** | Hard breaks; clear isolation | Proliferation of endpoints |
-| **Expand/contract** | DB-like migrations applied to messages | Multi-step discipline |
+| **Additive optional fields** | Default path for almost every change | Low if defaults exist for old readers |
+| **Dual-write** | Old and new consumers must run during a transition | Extra storage and CPU; you need consistency rules |
+| **Dual-read** | New code must understand both shapes | Complexity concentrated in one service |
+| **Content-type or Accept headers** | Multiple encodings or versions on one URL | Requires client discipline |
+| **URL or topic version** | Hard breaks that need clear isolation | Proliferation of endpoints or topics |
+| **Expand/contract** | Database-style migrations applied to messages | Multi-step discipline over several deploys |
 
 ## Decision frame
 
 ```text
-  Can change be additive with defaults?
-    yes → do that; document; test old×new
-    no  → pick version surface + dual period + kill criteria
+  Can the change be additive with defaults?
+    yes → do that; document it; test old writers × new readers and the reverse
+    no  → pick a version surface + dual period + kill criteria
 ```
 
 | Break type | Example playbook |
 |------------|------------------|
-| Rename field | Dual-write both names; readers prefer new; then drop old |
-| Type change | New field number/name; migrate; never overload old id |
-| Semantic change | New version; do not silently reuse |
-| Remove field | Ensure no readers; registry/CI gate; then remove |
+| Rename a field | Dual-write both names; readers prefer the new name; then drop the old one |
+| Change a type | Introduce a new field number or name; migrate; never overload the old identity |
+| Change semantics | Ship a new version; do not silently reuse the old field |
+| Remove a field | Ensure no readers remain; use a registry or CI gate; then remove |
 
 ## Failure modes
 
 | Mistake | Outcome |
 |---------|---------|
-| Big-bang cutover | Partial deploy outage |
-| Dual-write forever | Permanent complexity |
-| No usage metrics | Never know when to remove old path |
-| Version only in docs | Clients ignore it |
-| Reuse Protobuf field numbers | Silent corruption |
+| Big-bang cutover | Partial deploy causes outage |
+| Dual-write forever | Permanent complexity with no end date |
+| No usage metrics | You never know when it is safe to remove the old path |
+| Version only in documentation | Clients ignore it |
+| Reuse of Protobuf field numbers | Silent corruption |
 
 ## Real-world sketch
 
-An orders API must change `amount` from float to integer cents. Team adds `amount_cents`, dual-writes, readers prefer `amount_cents` when present, dashboards track old field usage, then deprecate `amount` after 90 days. A parallel event subject uses registry FULL compatibility so accidental removal fails CI.
+An orders API must change `amount` from floating point to integer cents. The team adds `amount_cents`, dual-writes both fields, and teaches readers to prefer `amount_cents` when present. Dashboards track old-field usage. After 90 days they deprecate `amount`. A parallel event subject uses registry FULL compatibility so accidental removal fails continuous integration.
 
 ## In this suite
 
 | Resource | Role |
 |----------|------|
-| **Results** | Cost of encoding two shapes during dual-write (if you model it) |
+| **Results** | Cost of encoding two shapes during dual-write, if you model that scenario |
 | Fixtures | Stable logical models—not multi-version simulators |
-| Capstones | Decision context for REST / events / RPC |
-
+| Capstones | Decision context for REST, events, and RPC |
 
 ## Experiments
 
-**Question:** For a breaking wire change, which **versioning strategy** (dual-write, content-type, parallel subject, flag) meets kill criteria with acceptable cost?
+**Question:** For a breaking wire change, which **versioning strategy** (dual-write, content-type, parallel subject, feature flag) meets kill criteria with acceptable cost?
 
 ### Setup
-1. Define the break and the set of producers/consumers.  
-2. Pick 1–2 candidate strategies from the article’s options.  
-3. Metrics backend for error rate, lag, and traffic % on old vs new.
+
+1. Define the break and the set of producers and consumers.
+2. Pick one or two candidate strategies from the options above.
+3. Ensure a metrics backend for error rate, lag, and traffic percentage on old versus new.
 
 ### Procedure
-1. Implement strategy in a non-prod environment with both versions live.  
-2. Migrate a canary % of traffic; watch errors and lag.  
-3. Exercise rollback: force old path; confirm recovery.  
-4. Write kill criteria (e.g. “old version <1% for 7 days”).  
-5. Only then schedule old-path removal.
+
+1. Implement the strategy in a non-production environment with both versions live.
+2. Migrate a canary percentage of traffic; watch errors and lag.
+3. Exercise rollback: force the old path and confirm recovery.
+4. Write kill criteria (for example “old version under 1% of traffic for seven days”).
+5. Only then schedule removal of the old path.
 
 ### Decision rule
-- Strategy wins if canary meets SLOs **and** rollback works within your incident budget.  
-- No kill criteria ⇒ do not start dual-running.
+
+- A strategy wins if the canary meets service-level objectives **and** rollback works within your incident budget.
+- If you have no kill criteria, do not start dual-running.
 
 ## Metrics
 
 | Metric / signal | Role |
 |-----------------|------|
-| **% traffic on old vs new version** | **Primary** migration progress |
+| **Percentage of traffic on old versus new version** | **Primary** migration progress |
 | Error rate by version | Safety |
-| Consumer lag / DLQ rate | Event-path health |
+| Consumer lag and dead-letter queue (DLQ) rate | Event-path health |
 | Dual-run cost (CPU, storage) | Economic limit |
 | Time to rollback | Operational risk |
-| Kill-criteria boolean | Go/no-go for decommission |
-| Suite benchmarks | Not primary for versioning ops |
+| Kill-criteria boolean | Go or no-go for decommission |
+| Suite benchmarks | Not primary for versioning operations |
 
-**Conclusion style:** “Dual-write 2 weeks; kill old when <1% and zero DLQ spike.”
+**Conclusion style:** “Dual-write for two weeks; kill the old path when traffic is under 1% and the DLQ shows no spike.”
 
 ## What this suite cannot tell you
 
-- How long *your* clients need.  
-- Political cost of a forced upgrade.  
-- Exact feature-flag design.
+- How long *your* clients need before they upgrade.
+- The political cost of a forced upgrade.
+- The exact feature-flag design for your platform.
 
 ## Common mistakes
 
-- Calling a break “minor” because JSON is flexible.  
-- Shipping dual-write without idempotent merge rules.  
-- Dropping v1 while mobile app binaries still call it.
+- Calling a break “minor” because JSON is flexible.
+- Shipping dual-write without idempotent merge rules.
+- Dropping version 1 while mobile app binaries still call it.
 
 ## Key takeaways
 
-- Additive first; versioned break second; metrics close the loop.  
-- Dual periods need **kill criteria**, not hope.  
-- Registry/CI and public OpenAPI are how strategy becomes enforceable.  
-- Suite does not simulate your client estate—instrument production.
+- Prefer additive changes first; use a versioned break second; let metrics close the loop.
+- Dual periods need **kill criteria**, not hope.
+- Registry/CI gates and public OpenAPI are how strategy becomes enforceable.
+- The suite does not simulate your client estate—instrument production.

--- a/docs/theory/301/zero-copy-in-production.md
+++ b/docs/theory/301/zero-copy-in-production.md
@@ -2,108 +2,113 @@
 
 ## Problem
 
-Marketing claims “no deserialize” and microbenchmarks look excellent for large, mostly-read messages. Production then hits: missing verifiers, painful updates, language/tooling gaps, and debugging friction. The 201 mechanism is sound; the **operations** story decides whether zero-copy ships.
+Marketing claims “no deserialize,” and microbenchmarks look excellent for large, mostly-read messages. Production then hits missing verifiers, painful updates, language and tooling gaps, and debugging friction. The 201 mechanism is sound; the **operations** story decides whether zero-copy ships.
 
 ## Short answer
 
-Use zero-copy layouts when messages are **large or partially read**, mostly **immutable** after build, and you will pay for **schema tooling + verification** on untrusted paths. Avoid them for tiny chatty RPCs, heavily mutated documents, or teams that require universal text debugging without investment. Always verify untrusted buffers. Measure with realistic access patterns—not only full materializing competitors on cold data.
+Use zero-copy layouts when messages are **large or partially read**, mostly **immutable** after they are built, and you are willing to pay for **schema tooling plus verification** on untrusted paths. Avoid them for tiny chatty RPCs, heavily mutated documents, or teams that require universal text debugging without investment.
 
-Assumes 201 [zero-copy](../201/zero-copy.md).
+Always verify untrusted buffers. Measure with realistic access patterns—not only full materializing competitors on cold data.
+
+This page assumes 201 [zero-copy](../201/zero-copy.md).
 
 ## Constraints that matter
 
 | Factor | Favors zero-copy | Argues against |
 |--------|------------------|----------------|
-| Message size / sparse reads | Large, partial field use | Tiny full reads |
+| Message size and sparse reads | Large messages with partial field use | Tiny messages that are fully read |
 | Mutation | Rare rebuilds | Frequent field edits |
-| Languages | Strong codegen support | Missing or immature bindings |
-| Trust | Verifier in path | “Skip verify for speed” |
-| Debug | Invest in tools | Must `curl` everything as JSON |
-| Team skill | Comfortable with offsets/builders | Only JSON experience |
+| Languages | Strong code-generation support | Missing or immature bindings |
+| Trust | Verifier runs in the path | “Skip verify for speed” |
+| Debug | Willingness to invest in tools | Must `curl` everything as JSON |
+| Team skill | Comfortable with offsets and builders | Only JSON experience |
 
 ## Decision frame
 
 ```text
-  Mostly read-only large messages + polyglot codegen OK?
-    yes → evaluate FlatBuffers/Cap’n Proto-class
+  Mostly read-only large messages, and polyglot codegen is OK?
+    yes → evaluate FlatBuffers/Cap’n Proto-class layouts
     no  → classical schema-driven or JSON/schemaless binary
-  Untrusted input? → verifier mandatory (non-negotiable)
+  Untrusted input?
+    → verifier is mandatory (non-negotiable)
 ```
 
 ## Failure modes
 
 | Mistake | Outcome |
 |---------|---------|
-| Skip verifier | Memory safety / crash bugs |
-| Hold views past buffer lifetime | Use-after-free / corruption |
-| Benchmark without verification | Lied speed |
+| Skip the verifier | Memory-safety bugs and crashes |
+| Hold views past buffer lifetime | Use-after-free and corruption |
+| Benchmark without verification | Lied-about speed |
 | Force zero-copy for CRUD APIs | Builder pain for no gain |
 | Compare against unvalidated peers | Invalid ranking |
 
 ## Real-world sketch
 
-A game state blob (100KB+) is read by many services for a few fields per request. FlatBuffers with verification cuts allocations vs full JSON trees. An admin API that mutates ten fields per call stays on Protobuf. Both coexist at different boundaries ([polyglot estates](polyglot-estates.md)).
+A game-state blob of 100KB or more is read by many services for a few fields per request. FlatBuffers with verification cuts allocations compared with full JSON trees. An admin API that mutates ten fields per call stays on Protobuf. Both coexist at different boundaries ([polyglot estates](polyglot-estates.md)).
 
 ## In this suite
 
 | Resource | Role |
 |----------|------|
 | Language **Overview** | Whether FlatBuffers-class entries are registered |
-| **Results** | Same-language compare; note validation settings if documented |
+| **Results** | Same-language comparison; note validation settings if documented |
 | [Using this suite](using-this-suite.md) | Fair paradigm-local reads |
 
 Absence from a language harness means “not measured,” not “bad technology.”
 
-
 ## Experiments
 
-**Question:** Does a **zero-copy / random-access** layout pay off in *our* read path after verification cost—and can ops verify safely?
+**Question:** Does a **zero-copy / random-access** layout pay off in *our* read path after verification cost—and can operations verify safely?
 
 ### Setup
-1. Workload: full materialization vs field touches / mmap reads.  
-2. Candidates: classic deser vs flatbuffer/cap’n-style (language Overview).  
-3. Ability to run verifier and fault inject truncated/corrupt buffers.
+
+1. Describe the workload: full materialization versus field touches or memory-mapped reads.
+2. List candidates: classic deserialize versus FlatBuffers/Cap’n Proto-style layouts (see the language Overview).
+3. Ensure you can run a verifier and fault-inject truncated or corrupt buffers.
 
 ### Procedure
-1. Measure end-to-end time for **actual access pattern** (not only full parse).  
-2. Include **verify** step cost on untrusted or untrusted-adjacent paths.  
-3. Suite Results: compare relevant serializers; read caveats for fidelity and access.  
-4. Chaos: corrupt buffer; ensure verifier fails closed.  
-5. Decide adopt vs stick to ordinary deser.
+
+1. Measure end-to-end time for the **actual access pattern**, not only full parse.
+2. Include **verify** step cost on untrusted or untrusted-adjacent paths.
+3. Compare relevant serializers in suite Results; read caveats for fidelity and access patterns.
+4. Chaos-test: corrupt a buffer and ensure the verifier fails closed.
+5. Decide whether to adopt zero-copy or stick with ordinary deserialize.
 
 ### Decision rule
-- Adopt only if access-pattern benchmark wins **including verify** and ops can version the schema.  
-- Untrusted input without verify ⇒ do not adopt.
+
+- Adopt only if the access-pattern benchmark wins **including verification** and operations can version the schema.
+- Untrusted input without a verifier means do not adopt.
 
 ## Metrics
 
 | Metric / signal | Role |
 |-----------------|------|
 | **Time-to-first-field / access path latency** | **Primary** benefit metric |
-| Full `deser_median_ns` (classic) | Baseline |
-| Verify time / fail rate on corrupt input | Safety |
+| Full `deser_median_ns` (classic deserialize) | Baseline |
+| Verify time and fail rate on corrupt input | Safety |
 | `median_size_bytes` | Density tradeoff |
-| Schema rollout complexity | Ops cost |
-| Suite `mean_fidelity` | Correctness under harness |
+| Schema rollout complexity | Operations cost |
+| Suite `mean_fidelity` | Correctness under the harness |
 | Planned `time_access_ns` (if available) | Direct suite support when present |
 
-**Conclusion style:** “Flat layout wins field touches + verify OK; adopt for cache blob, not public API.”
+**Conclusion style:** “The flat layout wins on field touches with verification OK; adopt it for the cache blob, not the public API.”
 
 ## What this suite cannot tell you
 
-- Builder ergonomics for *your* schema.  
-- Cross-language binding maturity beyond registration.  
-- Correct buffer ownership in *your* async runtime.
+- Builder ergonomics for *your* schema.
+- Cross-language binding maturity beyond what is registered in the suite.
+- Correct buffer ownership rules in *your* async runtime.
 
 ## Common mistakes
 
-- Equating zero-copy with “no CPU.”  
-- Using suite means without matching access pattern (full scan vs sparse).  
-- Shipping without verifier because internal network.
+- Equating zero-copy with “no CPU work.”
+- Using suite means without matching the access pattern (full scan versus sparse reads).
+- Shipping without a verifier because the network is “internal.”
 
 ## Key takeaways
 
-- Zero-copy is a **layout + ops** choice, not a free lunch.  
-- Verify untrusted data always.  
-- Prefer it for large, immutable, sparse-read paths.  
-- Mechanism lives in 201; production fit lives here.
+- Zero-copy is a **layout plus operations** choice, not a free lunch.
+- Always verify untrusted data.
+- Prefer zero-copy for large, immutable, sparse-read paths.
+- The mechanism lives in Serialization 201; production fit lives here.

--- a/docs/theory/401/index.md
+++ b/docs/theory/401/index.md
@@ -1,28 +1,30 @@
 # Serialization 401: Implementing Contemporary Serializers
 
-> Protobuf wire encoding and language runtime paths (Python, Rust, C), plus a thin subset lab—for serializer developers and deep integrators.
+> This course walks through Protocol Buffers binary encoding on the wire, then follows how Python, Rust, and C runtimes turn those bytes into language values. A small subset lab ties the theory to code you write yourself. It is aimed at people who build or deeply integrate codecs—not only people who choose formats from a menu.
 
 ## Who this is for
 
-People who **build or deeply integrate** codecs—not only choose formats. This is a **senior elective** after [Serialization 201](../201/index.md). It does **not** replace [Serialization 301](../301/index.md) (production judgment).
+You should take this elective if you need to **implement, debug, or deeply integrate** serializers. It sits after [Serialization 201](../201/index.md) and is deliberately more hands-on than the production-judgment track. It does **not** replace [Serialization 301](../301/index.md): 301 is about multi-constraint product choices under real pressure; 401 is about wire rules and runtime paths.
+
+You do not need to have written a codec from scratch already. You do need intermediate reading comfort in at least one of Python, Rust, or C, and a working memory of schema-dependent binary ideas from 201.
 
 ## Prerequisites
 
 | Type | Requirement |
 |------|-------------|
-| **Hard** | [101](../101/index.md) + [201](../201/index.md) (schema identity, encode cost, evolution, dynamic vs IDL) |
-| **Soft** | [301](../301/index.md) recommended (trust, polyglot, honest measurement) |
-| **Skills** | Intermediate reading level in at least one of Python, Rust, C |
+| **Hard** | [101](../101/index.md) and [201](../201/index.md) (schema identity, encode cost, evolution, dynamic vs IDL binary) |
+| **Soft** | [301](../301/index.md) is recommended (trust boundaries, polyglot estates, honest measurement) |
+| **Skills** | Intermediate reading level in at least one of Python, Rust, or C |
 
 ## Learning outcomes
 
 By the end of this course you should be able to:
 
-1. **Encode and decode** (on paper / with tables) core Protobuf wire structures: tags, varints, length-delimited, nested, simple repeated, skip unknowns.  
-2. **Trace** encode/decode paths in Python (`google.protobuf`), Rust (`prost`), and C (`protobuf-c`), including buffer ownership.  
-3. **Contrast** classic C runtime (protobuf-c) vs embedded nanopb design axes.  
-4. **Construct** a mini subset codec and **validate** against golden bytes or an official parser.  
-5. **State** deliberate omissions (subset honesty).
+1. **Encode and decode** core Protocol Buffers wire structures on paper and with tables: tags (keys that name a field), varints (variable-length integers), length-delimited fields, nested messages, simple repeated fields, and skipping unknown fields.  
+2. **Trace** encode and decode paths in Python (`google.protobuf`), Rust (`prost`), and C (`protobuf-c`), including **buffer ownership** (who allocates the bytes, who frees them, and how long a buffer must stay valid).  
+3. **Contrast** the classic C runtime (protobuf-c) with the embedded-oriented design of **nanopb** (a C library that prefers static size budgets over free-form heap trees).  
+4. **Build** a mini subset encoder/decoder and **validate** it against golden byte sequences and at least one official parser.  
+5. **State** deliberate omissions honestly—this lab is a teaching subset, not a full production Protocol Buffers implementation.
 
 ## How this course fits the program
 
@@ -30,32 +32,32 @@ By the end of this course you should be able to:
 |--------|------|
 | [101](../101/index.md) | Foundations |
 | [201](../201/index.md) | Mechanisms |
-| [301](../301/index.md) | Production judgment (core advanced) |
-| **401 (this course)** | Implementer elective — wire + paths + lab |
+| [301](../301/index.md) | Production judgment (core advanced track) |
+| **401 (this course)** | Implementer elective — wire format, language paths, and a thin subset lab |
 
-This course teaches **wire encoding, runtime paths, and a thin subset lab**—not a full Protobuf reimplementation, not multi-constraint product choice (that is 301).
+This course teaches **wire encoding, runtime paths, and a thin subset lab**. It is not a full reimplementation of Protocol Buffers, and it is not a multi-constraint product-choice guide (that is 301).
 
 ## Modules
 
 | Article | You should be able to… |
 |---------|------------------------|
-| [Protobuf wire format step-by-step](protobuf-wire-format.md) | Read/emit tags, varints, LEN, nested, unpacked/packed repeated; skip unknowns |
-| [Lab: mini encoder/decoder](lab-mini-protobuf-encoder.md) | Build a MiniUser subset codec; pass goldens + bounds + official parse |
-| [Python: google.protobuf path](protobuf-python.md) | Trace codegen → backend → SerializeToString / ParseFromString and ownership |
-| [Rust: prost path](protobuf-rust-prost.md) | Trace `encoded_len` / `encode_raw` / `merge_field` and monomorphized codegen |
-| [C: protobuf-c path](protobuf-c-protobuf-c.md) | Trace descriptor pack/unpack and heap free discipline |
-| [C: nanopb vs protobuf-c](protobuf-c-nanopb-compare.md) | Choose heap-friendly vs static-budget C engines for a deployment |
-| [Same bytes, three runtimes](protobuf-cross-language-fidelity.md) | Design interop matrix tests; separate bit-identity from logical fidelity |
+| [Protobuf wire format step-by-step](protobuf-wire-format.md) | Read and emit tags, varints, length-delimited (LEN) fields, nested messages, unpacked and packed repeated fields; skip unknowns safely |
+| [Lab: mini encoder/decoder](lab-mini-protobuf-encoder.md) | Build a MiniUser subset codec; pass goldens G1–G5, bounds tests, and an official-parser check |
+| [Python: google.protobuf path](protobuf-python.md) | Trace codegen → backend → `SerializeToString` / `ParseFromString` and who owns the bytes |
+| [Rust: prost path](protobuf-rust-prost.md) | Trace `encoded_len` / `encode_raw` / `merge_field` and monomorphized (per-type specialized) codegen |
+| [C: protobuf-c path](protobuf-c-protobuf-c.md) | Trace descriptor-driven pack/unpack and heap free discipline |
+| [C: nanopb vs protobuf-c](protobuf-c-nanopb-compare.md) | Choose a heap-friendly C engine versus a static-budget C engine for a deployment |
+| [Same bytes, three runtimes](protobuf-cross-language-fidelity.md) | Design interop matrix tests; separate bit-identical encodings from logical fidelity |
 
-**Suggested path** (matches self-check; side nav lists the same pages):
+**Suggested path** (this matches the self-check below; the side navigation lists the same pages):
 
 1. [Wire format](protobuf-wire-format.md)  
-2. [Lab](lab-mini-protobuf-encoder.md) *(start as soon as wire is readable)*  
+2. [Lab](lab-mini-protobuf-encoder.md) *(start as soon as the wire article is readable)*  
 3. [Python](protobuf-python.md) → [Rust](protobuf-rust-prost.md) → [C protobuf-c](protobuf-c-protobuf-c.md)  
 4. [nanopb compare](protobuf-c-nanopb-compare.md)  
 5. [Cross-language fidelity](protobuf-cross-language-fidelity.md)  
 
-Flagship schema in the suite: `schemas/v2/protobuf/benchmark_v2.proto`. Teaching pages use a smaller **MiniUser** message (not the suite schema).
+The flagship schema in this benchmark suite is `schemas/v2/protobuf/benchmark_v2.proto`. Teaching pages intentionally use a much smaller message called **MiniUser**. MiniUser is not the suite schema; it exists so you can study hex dumps without drowning in fields.
 
 ## Lab notebooks (Python / Colab)
 
@@ -64,43 +66,43 @@ Flagship schema in the suite: `schemas/v2/protobuf/benchmark_v2.proto`. Teaching
 | [Wire format playground](../notebooks/401/wire_format_playground.ipynb) | [Wire format](protobuf-wire-format.md) |
 | [MiniUser encoder lab](../notebooks/401/lab_mini_protobuf_encoder.ipynb) | [Lab article](lab-mini-protobuf-encoder.md) |
 
-Index and install notes: [notebooks README](../notebooks/README.md).  
-Multi-lang homework (same G1–G5 hex): [companions/go](../notebooks/companions/go/) · [companions/rust](../notebooks/companions/rust/).
+Index and install notes live in the [notebooks README](../notebooks/README.md).  
+If you want the same golden hex sequences G1–G5 in another language, see the multi-language homework companions: [companions/go](../notebooks/companions/go/) · [companions/rust](../notebooks/companions/rust/).
 
 ## Three engines at a glance
 
-Same wire format; different engineering of the codec:
+The **wire format** (the layout of tags and payloads on the byte stream) is shared. The **codec engineering**—how each library walks the schema, allocates buffers, and reports errors—differs a lot:
 
 | | **Python** (`google.protobuf`) | **Rust** (`prost`) | **C** (`protobuf-c`) | **C** (nanopb) |
 |--|--------------------------------|--------------------|----------------------|----------------|
-| Schema at encode time | Runtime descriptors + backend (upb / pure Python) | Monomorphized per-type code | Runtime descriptor tables | Field list + static max sizes |
-| Output ownership | New immutable `bytes` | Caller-owned `Vec<u8>` | Caller-allocated buffer | Static / stream budget |
-| Decode ownership | GC-managed Message | Owned Rust struct | Heap message → `free_unpacked` | Preallocated static struct |
-| Typical failure | Parse error / Python exception | `DecodeError` | `NULL` / leak if free skipped | Fail if data exceeds max |
+| Schema at encode time | Runtime descriptors plus a backend (upb or pure Python) | Monomorphized per-type code (specialized at compile time for each message type) | Runtime descriptor tables | Field list plus static maximum sizes |
+| Output ownership | New immutable `bytes` object | Caller-owned `Vec<u8>` | Caller-allocated buffer | Static buffer or stream budget |
+| Decode ownership | Garbage-collected Message object | Owned Rust struct | Heap message that you must free with `free_unpacked` | Preallocated static struct |
+| Typical failure | Parse error raised as a Python exception | `DecodeError` | `NULL` return, or a leak if you skip free | Encode/decode fails when data exceeds a configured max |
 
-Details: language path articles and [nanopb compare](protobuf-c-nanopb-compare.md).
+Details appear in the language-path articles and in [nanopb compare](protobuf-c-nanopb-compare.md).
 
 ## Honesty rules
 
-Program rules (no universal winners; implementation beats brand; suite Results own numbers).  
-**401-specific:**
+The program-wide rules still apply: there are no universal winners; implementation quality beats brand name; suite **Results** pages own measured numbers.  
+**401-specific honesty:**
 
-1. Wire truth is shared; runtimes differ.  
-2. Subset lab labels omissions.  
-3. Suite harnesses illustrate integration—they are not the reference design for Protobuf.  
-4. Results are optional cost context—not the focus of this course.  
-5. Hostile input: [301 untrusted input](../301/untrusted-input.md).  
-6. Parallel language tours—not “Rust wins.”
+1. **Wire truth is shared; runtimes differ.** Python, Rust, and C can all speak the same binary layout and still own buffers differently.  
+2. **The subset lab labels its omissions.** Packed repeated fields, zigzag signed integers, maps, oneofs, and full production hardening are out of scope on purpose.  
+3. **Suite harnesses illustrate integration.** They are not the reference design for how you should structure production Protocol Buffers.  
+4. **Results are optional cost context.** Speed tables are not the focus of this course.  
+5. **Hostile input is a 301 topic.** For operational controls on untrusted payloads, see [301 untrusted input](../301/untrusted-input.md). Codec-side bounds (truncated varints, overlong lengths) still belong in every decoder.  
+6. **Language tours are parallel, not ranked.** This course does not crown “Rust wins.”
 
 ## Assessment (self-check)
 
-1. Complete the lab golden vectors G1–G5 (and G2 empty), unknown-field skip, bounds failures, and at least one official-parser cross-check.  
-2. Explain pack/unpack ownership in one of Python, Rust, or C.  
-3. State when nanopb is preferable to protobuf-c (and the reverse)—see [nanopb compare](protobuf-c-nanopb-compare.md).  
-4. Design a 3-language encode/decode matrix test and say when `memcmp` of encodings is required—see [cross-language fidelity](protobuf-cross-language-fidelity.md).
+1. Complete the lab golden vectors **G1–G5** (including the empty G2), unknown-field skip, bounds failures, and at least one official-parser cross-check.  
+2. Explain pack/unpack **ownership** in one of Python, Rust, or C: who allocates, who frees, and what must stay valid during the call.  
+3. State when **nanopb** is preferable to **protobuf-c**, and when the reverse is true—see [nanopb compare](protobuf-c-nanopb-compare.md).  
+4. Design a three-language encode/decode **matrix test** and say when bit-identity (`memcmp` of encodings) is required versus when logical equality is enough—see [cross-language fidelity](protobuf-cross-language-fidelity.md).
 
 ## Where to go next
 
-- [Serialization 201](../201/index.md) if schema-dependent concepts are rusty.  
+- [Serialization 201](../201/index.md) if schema-dependent concepts feel rusty.  
 - [Serialization 301](../301/index.md) for multi-constraint product choices.  
-- Shared schema: repository `schemas/v2/protobuf/benchmark_v2.proto`.
+- Shared suite schema in this repository: `schemas/v2/protobuf/benchmark_v2.proto`.

--- a/docs/theory/401/lab-mini-protobuf-encoder.md
+++ b/docs/theory/401/lab-mini-protobuf-encoder.md
@@ -1,29 +1,31 @@
 # Lab: mini Protobuf subset encoder/decoder
 
-> Build a **deliberately small** Protobuf binary codec for a teaching message—not production Protobuf, not a full suite fixture.
+> Build a **deliberately small** Protocol Buffers binary codec for a teaching message. This is not production Protocol Buffers, and it is not the full benchmark suite fixture.
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/leo-gan/GLD.SerializerBenchmark/blob/master/docs/theory/notebooks/401/lab_mini_protobuf_encoder.ipynb)
 **Lab notebook:** [lab_mini_protobuf_encoder.ipynb](../notebooks/401/lab_mini_protobuf_encoder.ipynb) · wire playground: [wire_format_playground.ipynb](../notebooks/401/wire_format_playground.ipynb)
 
 ## Goal
 
-Implement a MiniUser subset encoder/decoder, validate against **golden bytes** and an official parser, and refuse truncated/hostile shapes. You will practice the wire rules from [Protobuf wire format](protobuf-wire-format.md)—not rebuild `protoc`.
+Implement a MiniUser subset encoder and decoder. Validate your bytes against **golden sequences** (known-correct hex) and against an official parser. Refuse truncated or hostile shapes instead of reading past the end of a buffer. You will practice the wire rules from [Protobuf wire format](protobuf-wire-format.md). You are not rebuilding `protoc` (the Protocol Buffers compiler that turns `.proto` files into language code).
 
 ## Subset (in / out)
 
+Labeling what you leave out is part of being honest about a teaching subset.
+
 | In scope | Out of scope (do not implement for “done”) |
 |----------|-----------------------------------------------|
-| `uint32` as varint | `sint32` zigzag, all 64-bit edge cases |
-| `string` (UTF-8, length-delimited) | `bytes` blobs beyond strings you need |
+| `uint32` as a varint (variable-length integer) | `sint32` zigzag, full 64-bit edge cases |
+| `string` (UTF-8, length-delimited) | `bytes` blobs beyond the strings you need |
 | Nested message (length-delimited) | `google.protobuf.Any`, well-known types |
-| `repeated uint32` **unpacked** | Packed repeated (stretch goal only) |
-| Skip unknown varint / len-delimited on decode | Store/round-trip unknown fields |
-| proto3-style omit empty/default scalars | proto2 required, extensions, maps, oneofs |
-| Reject truncated LEN / short buffer / overlong varint | Full production hardening |
+| `repeated uint32` **unpacked** (one tag per element) | Packed repeated (stretch goal only) |
+| Skip unknown varint and length-delimited fields on decode | Store or round-trip unknown fields for re-encode |
+| proto3-style omit empty/default scalars | proto2 required fields, extensions, maps, oneofs |
+| Reject truncated LEN, short buffers, overlong varints | Full production hardening |
 
 ### Teaching schema
 
-Not the suite `schemas/v2/protobuf/benchmark_v2.proto`. Use a tiny local `mini.proto` (or equivalent) when you need an official oracle:
+This is **not** the suite schema at `schemas/v2/protobuf/benchmark_v2.proto`. Use a tiny local `mini.proto` (or equivalent) when you need an official oracle:
 
 ```protobuf
 syntax = "proto3";
@@ -37,17 +39,19 @@ message MiniUser {
 
 ## Wire checklist
 
+Work through these until each item is true of your code:
+
 - [ ] `key = (field_number << 3) | wire_type`  
-- [ ] Varint encode/decode (unsigned), with max length  
-- [ ] LEN fields: key, len varint, payload (on the wire in that order)  
-- [ ] Nested: payload is a full message encoding  
-- [ ] Repeated unpacked: one tag per element  
-- [ ] Decode: loop until input exhausted; skip unknown by wire type  
-- [ ] Bounds: never read past end of buffer  
+- [ ] Varint encode and decode for unsigned values, with a maximum length  
+- [ ] LEN fields on the wire: key, then length varint, then payload (in that order)  
+- [ ] Nested messages: the payload is a full message encoding  
+- [ ] Unpacked repeated fields: one tag per element  
+- [ ] Decode: loop until the input is exhausted; skip unknown fields by wire type  
+- [ ] Bounds: never read past the end of the buffer  
 
 ## Steps (encode)
 
-Implement in **any language you choose**. The pseudocode below is deliberately language-agnostic; the validation section uses Python as one convenient oracle, but protobuf-c or prost work equally well.
+Implement in **any language you choose**. The pseudocode below is deliberately language-agnostic. The validation section uses Python as one convenient official oracle, but **protobuf-c** or **prost** work equally well.
 
 ```text
 function encode_varint(u):
@@ -80,6 +84,8 @@ function encode_mini_user(u):
 
 ### Golden vectors
 
+These hex sequences are fixed reference answers. Your encoder should match them under the same “omit default fields” rules.
+
 | Case | Logical value | Hex (spaces optional) |
 |------|---------------|------------------------|
 | G1 | `id=1, name="Ada"` | `08 01 12 03 41 64 61` |
@@ -88,11 +94,11 @@ function encode_mini_user(u):
 | G4 | `tags=[1,2]` only | `20 01 20 02` |
 | G5 | `manager={id=2}` only | `1a 02 08 02` |
 
-**G1 detail:** field1 key `08`, varint `01`; field2 key `12`, len `03`, `41 64 61` = `Ada`.  
+**G1 detail:** field 1 key is `08`, value varint is `01`; field 2 key is `12`, length is `03`, payload `41 64 61` is UTF-8 for `Ada`.  
 **G4:** field 4 key = `(4<<3)|0` = `32` = `0x20`.  
-**G5:** field 3 key = `(3<<3)|2` = `26` = `0x1a`; inner len 2; inner `08 02`.
+**G5:** field 3 key = `(3<<3)|2` = `26` = `0x1a`; the inner message is two bytes long; those bytes are `08 02`.
 
-Your encoder may omit default fields; decoders must accept any field order. Empty `name=""` should encode like G2 if you omit defaults (no field 2 on the wire).
+Your encoder may omit default fields. Decoders must accept any field order. An empty `name=""` should encode like G2 if you omit defaults (no field 2 appears on the wire).
 
 ## Steps (decode)
 
@@ -137,35 +143,35 @@ function decode_mini_user(buf):
   return user
 ```
 
-**Unknown field test:** append `28 63` (field 5, varint 99) to G1; decoder should yield same logical `id`/`name` and ignore field 5.
+**Unknown field test:** append `28 63` (field 5 with varint value 99) to the G1 bytes. Your decoder should still yield the same logical `id` and `name`, and should ignore field 5.
 
-**Bounds tests (required for done):**
+**Bounds tests (required for “done”):**
 
 | Input idea | Expected |
 |------------|----------|
 | LEN claims `n=10` but only 2 bytes remain | error |
-| Single byte `0x80` (varint continues, EOF) | error |
+| Single byte `0x80` (varint says “more follows,” then end of file) | error |
 | Fixed64 wire type with fewer than 8 bytes left | error |
 
 ## Done when
 
-All of the following:
+All of the following are true:
 
-1. **Encode** matches goldens G1–G5 (and G2 empty) under the same omit-default rules.  
-2. **Unknown skip:** G1 + `28 63` decodes to same logical `id`/`name`.  
-3. **Round-trip:** `decode(encode(x)) == x` for a small set (ids, names, one manager level, a few tags).  
-4. **Bounds:** at least the three bounds tests above fail cleanly (error, not silent truncate / OOB).  
-5. **Official parser (required):** at least G1 encode (or the hex golden) parses in Python `google.protobuf`, prost, or protobuf-c from a local `mini.proto`.
+1. **Encode** matches goldens G1–G5 (including empty G2) under the same omit-default rules.  
+2. **Unknown skip:** G1 plus `28 63` decodes to the same logical `id` and `name`.  
+3. **Round-trip:** `decode(encode(x)) == x` for a small set of values (several ids and names, one manager level, a few tags).  
+4. **Bounds:** at least the three bounds tests above fail cleanly (an error, not a silent truncate or an out-of-bounds read).  
+5. **Official parser (required):** at least the G1 encode (or the hex golden) parses in Python `google.protobuf`, in prost, or in protobuf-c from a local `mini.proto`.
 
 ## Validate
 
 ### 1. Golden match
 
-Encoder output for G1–G5 must equal the hex tables (for the same logical omit rules).
+Encoder output for G1–G5 must equal the hex table above (for the same logical omit rules).
 
 ### 2. Official parser
 
-Install `protoc` (or use any official decoder). Minimal `.proto` + Python:
+Install `protoc` (or use any official decoder). Minimal `.proto` plus Python:
 
 ```python
 # After: protoc --python_out=. mini.proto
@@ -184,29 +190,29 @@ m2.ParseFromString(mine)
 assert m2.id == 1 and m2.name == "Ada"
 ```
 
-protobuf-c or prost work equally as oracles if you prefer those stacks.
+protobuf-c or prost work equally well as oracles if you prefer those stacks.
 
 ### 3. Round-trip and bounds
 
-As in **Done when**.
+Match the criteria listed under **Done when**.
 
 ## Extension ideas
 
-- Packed `repeated uint32` (single LEN field, concatenated varints)—see wire article packed hex.  
-- `uint64` / fixed32.  
+- Packed `repeated uint32` (a single LEN field whose payload is concatenated varints)—see the packed hex in the wire article.  
+- `uint64` or fixed32.  
 - Reject remaining garbage after a nested length (strict nested consume).  
-- Fuzz skip paths with random unknown tags ([301 untrusted input](../301/untrusted-input.md) mindset).  
+- Fuzz skip paths with random unknown tags, using the [301 untrusted input](../301/untrusted-input.md) mindset.  
 - **Same goldens in another language:** [Go](../notebooks/companions/go/) · [Rust](../notebooks/companions/rust/) appendices (encode MiniUser until G1–G5 match).
 
 ## What this lab is not
 
-- Production-grade Protobuf.  
+- Production-grade Protocol Buffers.  
 - Full fidelity to suite fixtures.  
-- A replacement for language runtimes in [Python](protobuf-python.md) / [Rust](protobuf-rust-prost.md) / [C](protobuf-c-protobuf-c.md).
+- A replacement for the language runtimes described in [Python](protobuf-python.md), [Rust](protobuf-rust-prost.md), and [C](protobuf-c-protobuf-c.md).
 
 ## Key takeaways
 
-- A few wire primitives implement a useful subset.  
-- Golden bytes + official parse beat “looks right in hex.”  
+- A few wire primitives are enough to implement a useful teaching subset.  
+- Golden bytes plus an official parse beat “this hex dump looks plausible.”  
 - Skipping unknowns **and** refusing truncated input are both part of being a real decoder.  
-- Real systems still use codegen runtimes—this lab builds **judgment**, not a product codec.
+- Real systems still use code-generated runtimes. This lab builds **judgment**, not a product codec.

--- a/docs/theory/401/protobuf-c-nanopb-compare.md
+++ b/docs/theory/401/protobuf-c-nanopb-compare.md
@@ -2,11 +2,11 @@
 
 ## Problem
 
-Both **protobuf-c** and **nanopb** claim “Protobuf for C,” but they optimize for different worlds: general services with heap messages versus **embedded** systems with static budgets. Treating them as interchangeable APIs produces the wrong memory model, the wrong failure modes, and unfair suite comparisons.
+Both **protobuf-c** and **nanopb** claim “Protocol Buffers for C,” but they optimize for different worlds. **protobuf-c** targets general services with heap-allocated messages. **nanopb** targets **embedded** systems with static memory budgets. Treating them as interchangeable APIs produces the wrong memory model, the wrong failure modes, and unfair suite comparisons.
 
 ## Short answer
 
-Use **protobuf-c** when you want classic generated structs, descriptor-driven pack/unpack, and heap-friendly services ([protobuf-c path](protobuf-c-protobuf-c.md)). Use **nanopb** when RAM/flash are tight, you can declare **maximum sizes** in options, and you accept stream/callback-oriented encode/decode instead of free-form heap trees. Wire format remains Protobuf binary ([wire format](protobuf-wire-format.md)); **engineering**—allocation, codegen, APIs—diverges.
+Use **protobuf-c** when you want classic generated structs, descriptor-driven pack/unpack, and heap-friendly services ([protobuf-c path](protobuf-c-protobuf-c.md)). Use **nanopb** when RAM or flash is tight, you can declare **maximum sizes** in options, and you accept stream- and callback-oriented encode/decode instead of free-form heap trees. The **wire format** remains Protocol Buffers binary ([wire format](protobuf-wire-format.md)). What diverges is the **engineering**: allocation, code generation, and APIs.
 
 **Suite pins (this monorepo):** protobuf-c **v1.5.0**; nanopb **0.4.9** (`c/third_party/VERSIONS.md`, registration in `ser_nanopb.c`).
 
@@ -14,7 +14,7 @@ Use **protobuf-c** when you want classic generated structs, descriptor-driven pa
 
 - [C: protobuf-c path](protobuf-c-protobuf-c.md).  
 - [Wire format](protobuf-wire-format.md).  
-- Soft: [301 untrusted input](../301/untrusted-input.md) (bounds matter even more on embedded).
+- Soft: [301 untrusted input](../301/untrusted-input.md) (bounds matter even more on embedded targets).
 
 ## Mental model
 
@@ -32,16 +32,16 @@ Use **protobuf-c** when you want classic generated structs, descriptor-driven pa
 
 | Axis | **protobuf-c** | **nanopb** |
 |------|----------------|------------|
-| **Primary goal** | General C interoperability | Embedded / constrained |
+| **Primary goal** | General C interoperability | Embedded / constrained devices |
 | **Schema at runtime** | `ProtobufCMessageDescriptor` tables | Field lists / generated bind info; options in `.proto` or `.options` |
-| **Allocation** | `unpack` typically **heap**; free with `*_free_unpacked` | Prefer **static** structs; optional dynamic with care |
-| **Size limits** | Practical heap limits | **Max count/size** often required for repeated/string/bytes |
-| **API shape** | Fill struct → `get_packed_size` / `pack`; `unpack` | `pb_ostream_t` / `pb_istream_t`; `pb_encode` / `pb_decode` |
-| **Callbacks** | Less central | Common for large/unknown-length fields |
-| **Submessages** | Pointers + recursive unpack | Nested structs or callbacks depending on options |
-| **Unknown fields** | Often retained for round-trip | Policy/options; not “always keep” like desktop stacks |
-| **Typical failure** | OOM / leak if free skipped | Encode/decode fail if data exceeds static max |
-| **Suite registration** | `protobuf-c` | `nanopb` (separate name—compare within C + schema family) |
+| **Allocation** | `unpack` typically uses the **heap**; free with `*_free_unpacked` | Prefer **static** structs; optional dynamic allocation only with care |
+| **Size limits** | Practical heap limits | **Max count/size** often required for repeated fields, strings, and bytes |
+| **API shape** | Fill a struct → `get_packed_size` / `pack`; then `unpack` | `pb_ostream_t` / `pb_istream_t`; `pb_encode` / `pb_decode` |
+| **Callbacks** | Less central | Common for large or unknown-length fields |
+| **Submessages** | Pointers plus recursive unpack | Nested structs or callbacks, depending on options |
+| **Unknown fields** | Often retained for round-trip | Policy and options; not “always keep” the way desktop stacks often do |
+| **Typical failure** | Out of memory, or a leak if free is skipped | Encode/decode fails if data exceeds a static max |
+| **Suite registration** | `protobuf-c` | `nanopb` (a separate log name—compare within C and the schema-driven family) |
 
 **Ownership contrast**
 
@@ -89,28 +89,28 @@ if (!pb_decode(&istream, MiniUser_fields, &out)) {
 }
 ```
 
-### When valid Protobuf still fails nanopb
+### When valid Protocol Buffers still fails nanopb
 
-Suppose `name` is generated as a 8-byte array (`max_size:8` including null in some setups) and the peer sends a longer string that is **valid** length-delimited Protobuf:
+Suppose `name` is generated as an 8-byte array (`max_size:8`, including a null terminator in some setups) and the peer sends a longer string that is still **valid** length-delimited Protocol Buffers:
 
-1. protobuf-c `unpack` → heap string of full length (until you OOM).  
-2. nanopb `pb_decode` → **false** / error: value does not fit the static contract.
+1. protobuf-c `unpack` → a heap string of full length (until you run out of memory).  
+2. nanopb `pb_decode` → **false** / error: the value does not fit the static contract.
 
-That is intentional for embedded safety, not a wire-format bug. The same applies to `repeated` counts above `max_count`.
+That is intentional for embedded safety, not a wire-format bug. The same pattern applies when a `repeated` field’s count exceeds `max_count`.
 
 ## Step-by-step: how nanopb thinks about encode
 
-(Logical model of [nanopb](https://jpa.kapsi.fi/nanopb/); always check your nanopb version docs.)
+Logical model of [nanopb](https://jpa.kapsi.fi/nanopb/). Always check your nanopb version’s documentation for details.
 
 ### N1 — Describe fields with size budgets
 
-Codegen (from `.proto` + optional `.options`) produces a C struct where:
+Code generation (from `.proto` plus optional `.options`) produces a C struct where:
 
 - Scalars are plain fields.  
-- Strings/bytes often are **fixed arrays** or pointer+callback with a **maximum length**.  
-- Repeated fields have a **max count** (or callback to stream elements).
+- Strings and bytes are often **fixed arrays**, or a pointer-plus-callback pair with a **maximum length**.  
+- Repeated fields have a **max count** (or a callback that streams elements).
 
-If the logical Protobuf message can be unbounded, nanopb forces you to **cap** it at design time—the opposite of “malloc until it fits.”
+If the logical Protocol Buffers message can be unbounded, nanopb forces you to **cap** it at design time. That is the opposite of “malloc until it fits.”
 
 ### N2 — Output stream
 
@@ -121,14 +121,14 @@ pb_encode(&stream, FieldList, &struct)
 
 Encode walks the field list:
 
-1. For each present field, emit **tag** (same wire key rule).  
-2. Emit payload (varint, fixed, length-delimited).  
-3. Nested messages encode into the stream (length-delimited).  
+1. For each present field, emit a **tag** (same wire key rule as everywhere else).  
+2. Emit the payload (varint, fixed, or length-delimited).  
+3. Nested messages encode into the stream as length-delimited blobs.  
 4. On buffer full or max exceeded → **false** / error (no silent realloc by default).
 
 ### N3 — No separate “get_packed_size then malloc” requirement
 
-You can size a static buffer from worst-case maxima, or use a sizing stream. The mental model is **stream into a budget**, not “measure unlimited tree then allocate.”
+You can size a static buffer from worst-case maxima, or use a sizing stream. The mental model is **stream into a budget**, not “measure an unlimited tree and then allocate.”
 
 ## Step-by-step: how nanopb thinks about decode
 
@@ -141,67 +141,67 @@ pb_decode(&stream, FieldList, &struct)
 
 ### N5 — Tag loop with hard limits
 
-1. Read tag → field number / wire type.  
+1. Read a tag → field number and wire type.  
 2. Match against the field list.  
-3. Decode into static storage; if repeated count would exceed max → **fail**.  
+3. Decode into static storage; if a repeated count would exceed its max → **fail**.  
 4. Unknown fields: skip by wire type (and optional callbacks).  
-5. Nested: decode length-delimited into nested struct (or callback).
+5. Nested messages: decode a length-delimited blob into a nested struct (or a callback).
 
 ### N6 — Success means “fits the static contract”
 
-A message that is valid Protobuf for protobuf-c can still be **rejected** by nanopb if it exceeds configured maxima—by design for embedded safety.
+A message that is valid Protocol Buffers for protobuf-c can still be **rejected** by nanopb if it exceeds configured maxima. That is by design for embedded safety.
 
 ## Side-by-side with protobuf-c pack/unpack
 
 | Stage | protobuf-c | nanopb |
 |-------|------------|--------|
-| Prepare | Fill struct (heap pointers OK) | Fill static struct / set counts |
-| Size | `get_packed_size` unlimited logical | Worst-case from maxima or sizing encode |
-| Encode | `pack` into caller buffer | `pb_encode` to `pb_ostream_t` |
-| Decode | `unpack` → heap tree | `pb_decode` into preallocated struct |
-| Teardown | `free_unpacked` | Usually nothing (stack/static) |
-| Hostility | Need external size cap | Maxima + stream limits help; still validate |
+| Prepare | Fill a struct (heap pointers are fine) | Fill a static struct / set counts |
+| Size | `get_packed_size` over an unlimited logical tree | Worst-case size from maxima, or a sizing encode |
+| Encode | `pack` into a caller buffer | `pb_encode` to a `pb_ostream_t` |
+| Decode | `unpack` → heap tree | `pb_decode` into a preallocated struct |
+| Teardown | `free_unpacked` | Usually nothing (stack or static) |
+| Hostility | Need an external size cap | Maxima and stream limits help; you still validate |
 
 ## When to choose which
 
 | Situation | Lean |
 |-----------|------|
-| Linux/service C, variable-length documents | **protobuf-c** |
-| MCU, no heap or tiny heap | **nanopb** |
-| Same process as desktop tools needing full unknown-field round-trip | Often **protobuf-c** |
-| Sensor stream with fixed max samples | **nanopb** |
-| Team already owns protobuf-c everywhere | Stay; don’t dual-stack without reason |
+| Linux or service C with variable-length documents | **protobuf-c** |
+| MCU with no heap or a tiny heap | **nanopb** |
+| Same process as desktop tools that need full unknown-field round-trip | Often **protobuf-c** |
+| Sensor stream with a fixed maximum number of samples | **nanopb** |
+| Team already owns protobuf-c everywhere | Stay with it; do not dual-stack without a reason |
 
-Product/polyglot choice of “Protobuf or not” is [301](../301/index.md); this page is **which C engine**.
+Whether to use Protocol Buffers at all is a [301](../301/index.md) product and polyglot question. This page is about **which C engine** once that choice is made.
 
 ## In this suite
 
 | Entry | Role |
 |-------|------|
-| `protobuf-c` | Classic path; see [protobuf-c article](protobuf-c-protobuf-c.md) |
+| `protobuf-c` | Classic path; see the [protobuf-c article](protobuf-c-protobuf-c.md) |
 | `nanopb` | `c/src/serializers/ser_nanopb.c` — separate log name; version **0.4.9** |
-| Shared helpers | Some C schema entries share fixture/wire helpers—read the language [C Overview](../../c/index.md) and serializer notes for what is timed and what fidelity means |
-| [C Results](../../c/results.md) | Compare **within C** and schema-driven family ([301 using this suite](../301/using-this-suite.md)) |
+| Shared helpers | Some C schema entries share fixture and wire helpers—read the language [C Overview](../../c/index.md) and serializer notes for what is timed and what fidelity means |
+| [C Results](../../c/results.md) | Compare **within C** and the schema-driven family ([301 using this suite](../301/using-this-suite.md)) |
 
-Do not treat a faster `nanopb` row as “protobuf-c is wrong for servers,” or the reverse for MCUs.
+Do not treat a faster `nanopb` row as “protobuf-c is wrong for servers,” or the reverse for microcontrollers.
 
 ## Common mistakes
 
-- Using nanopb without setting max sizes, then “fixing” by enabling unbounded dynamic mode everywhere (loses the point).  
+- Using nanopb without setting max sizes, then “fixing” by enabling unbounded dynamic mode everywhere (that loses the point of nanopb).  
 - Assuming nanopb decode allocates like protobuf-c.  
 - Mixing generated headers from different generators in one translation unit.  
-- Cross-ranking C Results against Python/Rust for engine choice ([cross-language fidelity](protobuf-cross-language-fidelity.md)).  
+- Cross-ranking C Results against Python or Rust when choosing an engine ([cross-language fidelity](protobuf-cross-language-fidelity.md)).  
 - Calling a max-size reject a “wire bug” when the peer used protobuf-c with no caps.
 
 ## What this article is not
 
-- Full nanopb options reference (see upstream nanopb docs).  
+- A full nanopb options reference (see upstream nanopb docs).  
 - upb-C or other C bindings.  
-- Hand-rolled wire lab ([lab](lab-mini-protobuf-encoder.md)).
+- A hand-rolled wire lab (see the [lab](lab-mini-protobuf-encoder.md)).
 
 ## Key takeaways
 
-- **Same wire, different memory contracts.**  
-- protobuf-c = descriptor + heap-friendly pack/unpack.  
-- nanopb = static budgets + streams; fails closed when data exceeds caps.  
-- Suite: two names, one language—compare fairly, choose by deployment constraints.
+- **Same wire format, different memory contracts.**  
+- protobuf-c = descriptor tables plus heap-friendly pack/unpack.  
+- nanopb = static budgets plus streams; fails closed when data exceeds caps.  
+- In this suite there are two names under one language—compare fairly, and choose by deployment constraints.

--- a/docs/theory/401/protobuf-c-protobuf-c.md
+++ b/docs/theory/401/protobuf-c-protobuf-c.md
@@ -2,20 +2,22 @@
 
 ## Problem
 
-C clients call `pack` / `unpack` without seeing that protobuf-c is a **descriptor-driven interpreter**: generated structs supply field **offsets** and **types**; a shared runtime walks those descriptors to emit or parse wire data. Serializer developers need that split—and how it differs from prost’s monomorphized `encode_raw`.
+C clients often call `pack` and `unpack` without seeing that **protobuf-c** is a **descriptor-driven interpreter**. Generated structs supply field **offsets** (byte distances into the struct) and **types**. A shared runtime walks those descriptors to emit or parse wire data. Serializer developers need that split—and how it differs from prost’s monomorphized (per-type specialized) `encode_raw`.
 
 ## Short answer
 
-Codegen emits C structs plus a `ProtobufCMessageDescriptor` (field array: id, type, offset, label, …). **`protobuf_c_message_get_packed_size`** sums sizes; **`protobuf_c_message_pack`** writes tags/payloads into a caller buffer; **`protobuf_c_message_unpack`** scans the buffer into a **heap** message; **`protobuf_c_message_free_unpacked`** frees it. Implementation lives mainly in [`protobuf-c/protobuf-c.c`](https://github.com/protobuf-c/protobuf-c/blob/master/protobuf-c/protobuf-c.c); API overview: [packing docs](https://protobuf-c.github.io/protobuf-c/pack.html). **nanopb** is a different design—short box below; full compare: [nanopb vs protobuf-c](protobuf-c-nanopb-compare.md).
+Code generation emits C structs plus a `ProtobufCMessageDescriptor`: a field array that records id, type, offset, label, and related metadata. **`protobuf_c_message_get_packed_size`** walks the descriptor and sums sizes. **`protobuf_c_message_pack`** writes tags and payloads into a **caller-owned** buffer. **`protobuf_c_message_unpack`** scans the buffer into a **heap** message. **`protobuf_c_message_free_unpacked`** frees that tree. The implementation lives mainly in [`protobuf-c/protobuf-c.c`](https://github.com/protobuf-c/protobuf-c/blob/master/protobuf-c/protobuf-c.c); API overview: [packing docs](https://protobuf-c.github.io/protobuf-c/pack.html).
 
-Assumes [wire format](protobuf-wire-format.md).
+**nanopb** is a different C design (static budgets and streams). See the short comparison box below and the full article [nanopb vs protobuf-c](protobuf-c-nanopb-compare.md).
+
+This article assumes the [wire format](protobuf-wire-format.md) article.
 
 **Suite pin (this monorepo):** **protobuf-c v1.5.0** (`c/third_party/VERSIONS.md`).
 
 ## Prerequisites
 
-- Intermediate C (pointers, `malloc`, struct layout).  
-- 201 schema-dependent encoding.  
+- Intermediate C: pointers, `malloc`, struct layout.  
+- Serialization 201: schema-dependent encoding.  
 - Soft: [301 untrusted input](../301/untrusted-input.md).
 
 ## Mental model
@@ -49,19 +51,19 @@ benchmark_data__person__free_unpacked(out, NULL);
 free(buf);
 ```
 
-Codegen:
+Code generation:
 
 ```bash
 protoc --c_out=gen -I schemas schemas/v2/protobuf/benchmark_v2.proto
 ```
 
-Alternatively **`protobuf_c_message_pack_to_buffer`** streams chunks through a `ProtobufCBuffer` vtable (append callback) without precomputing a single allocation size.
+Alternatively, **`protobuf_c_message_pack_to_buffer`** streams chunks through a `ProtobufCBuffer` vtable (an append callback) without precomputing a single allocation size.
 
-For the teaching [MiniUser](lab-mini-protobuf-encoder.md) goldens, compile a separate tiny `mini.proto`—not suite `benchmark_data.proto`.
+For the teaching [MiniUser](lab-mini-protobuf-encoder.md) goldens, compile a separate tiny `mini.proto`—not the suite `benchmark_data.proto`.
 
 ## How protobuf-c implements serialization (step-by-step)
 
-The following follows the structure of `protobuf_c_message_get_packed_size` / `protobuf_c_message_pack` in `protobuf-c.c` (descriptor iteration + per-label helpers).
+The following follows the structure of `protobuf_c_message_get_packed_size` and `protobuf_c_message_pack` in `protobuf-c.c` (descriptor iteration plus per-label helpers).
 
 ### S1 — Descriptor is the schema at runtime
 
@@ -70,13 +72,13 @@ Each field descriptor carries at least:
 | Metadata | Use in pack |
 |----------|-------------|
 | **id** (field number) | Tag |
-| **type** (int32, string, message, …) | Wire type + pack helper |
-| **label** (required / optional / none / repeated) | Whether/how to emit |
+| **type** (int32, string, message, …) | Wire type and pack helper |
+| **label** (required / optional / none / repeated) | Whether and how to emit |
 | **offset** | `member = (char*)message + offset` → field storage |
 | **quantifier_offset** | `has` bit, repeated count, or oneof case |
-| **flags** | oneof, packed repeated, etc. |
+| **flags** | oneof, packed repeated, and similar |
 
-Codegen fills this table once; the runtime never parses `.proto` text at pack time.
+Code generation fills this table once. The runtime never parses `.proto` text at pack time.
 
 ### S2 — `protobuf_c_message_get_packed_size`
 
@@ -99,11 +101,11 @@ for each unknown_field:
 return size
 ```
 
-Size helpers account for **tag bytes + payload** (varint length of integers, string length + bytes, nested `get_packed_size` for submessages, etc.).
+Size helpers account for **tag bytes plus payload** (varint length of integers, string length plus bytes, nested `get_packed_size` for submessages, and so on).
 
 ### S3 — `protobuf_c_message_pack`
 
-Same field loop; instead of summing, call pack helpers that **write** into `out + rv` and return bytes written:
+Same field loop; instead of summing, call pack helpers that **write** into `out + rv` and return the number of bytes written:
 
 ```text
 rv = 0
@@ -116,30 +118,30 @@ return rv
 
 ### S4 — Type dispatch (tag + payload)
 
-Regardless of label, the core write is **tag (field id + wire type) then payload**, dispatched on the field **type** in the descriptor:
+Regardless of label, the core write is **tag (field id plus wire type) then payload**, dispatched on the field **type** in the descriptor:
 
 - Varint types (int, bool, enum) → varint encoding  
 - Fixed32 / float → 4-byte little-endian  
 - Fixed64 / double → 8-byte  
-- String / bytes → length prefix + data  
-- Message → length prefix + recursive pack of the sub-message  
+- String / bytes → length prefix plus data  
+- Message → length prefix plus recursive pack of the sub-message  
 
-(Source helpers are often named like `required_field_pack` even when called from optional/repeated paths—think “type dispatch pack,” not “proto2 required only.”)
+Source helpers are often named like `required_field_pack` even when called from optional or repeated paths. Think “type-dispatch pack,” not “proto2 required only.”
 
-This is descriptor-driven (one interpreter loop) rather than monomorphized per-message code.
+This design is **descriptor-driven** (one shared interpreter loop) rather than monomorphized per-message code.
 
 ### S5 — Optional / repeated / oneof
 
 | Label | Gate before pack |
 |-------|------------------|
-| Optional | `has` quantifier (or pointer non-NULL for message/string variants) |
-| Repeated | `count` at quantifier; loop or packed encoding |
+| Optional | `has` quantifier (or a non-NULL pointer for some message/string variants) |
+| Repeated | `count` at the quantifier; loop or packed encoding |
 | Oneof | case enum must equal this field’s id |
 | Unknown | re-emitted so round-trips can preserve them |
 
 ### S6 — Buffer responsibility
 
-`pack` assumes **`out` has at least `get_packed_size` bytes**. Undersized buffers are undefined/truncated—**you** measure then allocate (or use `pack_to_buffer`).
+`pack` assumes that **`out` has at least `get_packed_size` bytes**. Undersized buffers are undefined or truncated—**you** measure, then allocate (or use `pack_to_buffer`).
 
 ```text
   struct + descriptor  →  size walk  →  pack walk (tag|wire + payload)  →  buffer
@@ -147,19 +149,19 @@ This is descriptor-driven (one interpreter loop) rather than monomorphized per-m
 
 ## How protobuf-c implements deserialization (step-by-step)
 
-Public entry: **`protobuf_c_message_unpack(descriptor, allocator, len, data)`** (generated `foo__unpack` wrappers pass the type’s descriptor). Result must be freed with **`protobuf_c_message_free_unpacked`** / generated `foo__free_unpacked`.
+Public entry: **`protobuf_c_message_unpack(descriptor, allocator, len, data)`** (generated `foo__unpack` wrappers pass the type’s descriptor). The result must be freed with **`protobuf_c_message_free_unpacked`** or the generated `foo__free_unpacked`.
 
 ### D1 — Scan phase
 
-The unpacker walks the byte buffer as a Protobuf stream:
+The unpacker walks the byte buffer as a Protocol Buffers stream:
 
-1. Read tag → field number + wire type.  
-2. Slice the **payload** for that field (varint length, fixed width, or length-prefixed blob).  
-3. Build a list of **scanned members** (pointer into input + field metadata when the number is known).
+1. Read a tag → field number plus wire type.  
+2. Slice the **payload** for that field (varint, fixed width, or length-prefixed blob).  
+3. Build a list of **scanned members** (a pointer into the input plus field metadata when the number is known).
 
 This separates “find fields in the buffer” from “store into C structs.”
 
-**Sketch — G1 bytes `08 01 12 03 41 64 61` (`id=1`, `name=Ada` on MiniUser-shaped schema):**
+**Sketch — G1 bytes `08 01 12 03 41 64 61` (`id=1`, `name=Ada` on a MiniUser-shaped schema):**
 
 | Scan step | Bytes | Result |
 |-----------|-------|--------|
@@ -171,30 +173,30 @@ This separates “find fields in the buffer” from “store into C structs.”
 
 ### D2 — Lookup field by number
 
-Known numbers map through descriptor **field ranges** / tables to a `ProtobufCFieldDescriptor *`. Unknown numbers become **unknown field** entries (stored for later pack) after skipping by wire type.
+Known numbers map through descriptor **field ranges** and tables to a `ProtobufCFieldDescriptor *`. Unknown numbers become **unknown field** entries (stored for later pack) after the runtime skips them by wire type.
 
 ### D3 — Parse into struct members
 
-For each scanned member the code calls type-specific helpers that write into the struct at the descriptor's offset:
+For each scanned member the code calls type-specific helpers that write into the struct at the descriptor’s offset:
 
 - Scalars → direct store  
-- String/bytes → allocate + copy  
+- String/bytes → allocate and copy  
 - Message → recursive unpack  
-- Repeated → grow array and append  
+- Repeated → grow the array and append  
 
-The key point: everything is driven by the runtime descriptor, not generated straight-line code per field.
+The key point: everything is driven by the runtime descriptor, not by generated straight-line code per field.
 
 ### D4 — Merge when the same field appears twice
 
-Protobuf allows multiple occurrences; protobuf-c **merges** (documented in-source near `merge_messages`): repeated concatenate; submessages merge; singulars prefer later values with care not to double-free. That is why unpack is not always “last write wins” with naive overwrites for messages.
+Protocol Buffers allows multiple occurrences of the same field. protobuf-c **merges** them (documented in-source near `merge_messages`): repeated fields concatenate, submessages merge, and singulars prefer later values with care not to double-free. That is why unpack is not always a naive “last write wins” overwrite for messages.
 
 ### D5 — Allocator
 
-Unpack takes a `ProtobufCAllocator *` (NULL → default libc-like). All heap nodes from unpack must be released with the matching free_unpacked so nested strings/messages are not leaked.
+Unpack takes a `ProtobufCAllocator *` (`NULL` means a default libc-like allocator). All heap nodes from unpack must be released with the matching `free_unpacked` so nested strings and messages are not leaked.
 
 ### D6 — Errors
 
-On failure, unpack returns **NULL** (and should not leak partial trees—implementation frees on error paths). Always check the pointer; always bound `len` for untrusted data.
+On failure, unpack returns **NULL** (and should not leak partial trees—the implementation frees on error paths). Always check the pointer. Always bound `len` for untrusted data.
 
 ```text
   bytes  →  scan tags  →  lookup descriptor  →  parse/merge into heap struct
@@ -207,23 +209,24 @@ On failure, unpack returns **NULL** (and should not leak partial trees—impleme
 | Schema at runtime | Descriptor tables | Compiled into `encode_raw` / `merge_field` |
 | Pack loop | One shared interpreter | Per-type specialized code |
 | Typical use | C without heavy templates | Rust type system |
-| Teaching value | Offsets + labels are explicit | Trait methods are explicit |
+| Teaching value | Offsets and labels are explicit | Trait methods are explicit |
 
-Both emit the **same wire format** if schemas and field numbers match. Hub [three engines table](index.md#three-engines-at-a-glance) includes Python and nanopb as well.
+Both emit the **same wire format** if schemas and field numbers match. The hub [three engines table](index.md#three-engines-at-a-glance) includes Python and nanopb as well.
 
 ## nanopb comparison box
 
 Short form only—full treatment: [nanopb vs protobuf-c](protobuf-c-nanopb-compare.md).
 
-
 | Axis | **protobuf-c** | **nanopb** |
 |------|----------------|------------|
-| Allocation | Heap unpack common | Static buffers / callbacks |
+| Allocation | Heap unpack is common | Static buffers / callbacks |
 | Engine | Descriptor pack/unpack | Stream encode/decode with max sizes |
 | Suite | `protobuf-c` | Separate registration |
 | When | General C services | Embedded / constrained RAM |
 
-## Buffers & ownership (simple diagram)
+## Buffers and ownership (simple diagram)
+
+**Ownership** in C is manual: whoever allocates must free, and buffers you pass to `pack` must be large enough.
 
 ```text
 struct (stack or heap)
@@ -239,8 +242,8 @@ heap message → free_unpacked()
 |-------|-----------|
 | Input struct for pack | Caller (stack or heap) |
 | Packed `uint8_t[]` | Caller-allocated |
-| Unpacked message | Heap via allocator; **free_unpacked** |
-| Nested/repeated | Owned by parent free |
+| Unpacked message | Heap via the allocator; free with **free_unpacked** |
+| Nested/repeated | Owned by the parent free |
 
 ## In this suite
 
@@ -252,25 +255,25 @@ heap message → free_unpacked()
 | Pin | protobuf-c v1.5.0 |
 | [C Results](../../c/results.md) | Schema-driven C peers |
 
-Do not rank C against Python/Rust from Results alone ([cross-language fidelity](protobuf-cross-language-fidelity.md)).
+Do not rank C against Python or Rust from Results alone ([cross-language fidelity](protobuf-cross-language-fidelity.md)).
 
 ## Common mistakes
 
 - Skipping `free_unpacked` (leaks under load).  
 - Packing into an undersized buffer.  
-- Using a descriptor from a different `.proto` revision than peers.  
-- Treating unpack success as “safe for untrusted input” without size/depth policy.
+- Using a descriptor from a different `.proto` revision than your peers.  
+- Treating unpack success as “safe for untrusted input” without a size and depth policy.
 
 ## What this article is not
 
-- Full nanopb tutorial.  
-- Custom allocator cookbook.  
-- Hand-rolled varint lab ([lab](lab-mini-protobuf-encoder.md)).
+- A full nanopb tutorial.  
+- A custom-allocator cookbook.  
+- A hand-rolled varint lab (see the [lab](lab-mini-protobuf-encoder.md)).
 
 ## Key takeaways
 
-- protobuf-c = **generated layout + shared descriptor runtime**.  
-- Pack: **size walk → pack walk** with tag|wire + payload type dispatch.  
-- Unpack: **scan → lookup → parse/merge → heap message** (see G1 scan sketch).  
-- Same wire as Python/Rust; different engineering of the engine.  
-- Parallel: [Python](protobuf-python.md), [Rust prost](protobuf-rust-prost.md).
+- protobuf-c is **generated layout plus a shared descriptor runtime**.  
+- Pack is a **size walk then a pack walk**, with tag|wire plus payload type dispatch.  
+- Unpack is **scan → lookup → parse/merge → heap message** (see the G1 scan sketch).  
+- Same wire as Python and Rust; different engineering of the engine.  
+- Parallel articles: [Python](protobuf-python.md), [Rust prost](protobuf-rust-prost.md).

--- a/docs/theory/401/protobuf-cross-language-fidelity.md
+++ b/docs/theory/401/protobuf-cross-language-fidelity.md
@@ -2,15 +2,17 @@
 
 ## Problem
 
-“We all use Protobuf” does not guarantee that Python, Rust, and C produce **bit-identical** payloads or that round-trips preserve every logical field across languages. Fidelity bugs hide in defaults, field naming, timestamps, packed repeated, UTF-8, and test harness mapping—not in the marketing name.
+Saying “we all use Protocol Buffers” does not guarantee that Python, Rust, and C produce **bit-identical** payloads, or that round-trips preserve every logical field across languages. Fidelity bugs hide in defaults, field naming, timestamps, packed repeated fields, UTF-8 handling, and test-harness mapping—not in the marketing name of the format.
 
 ## Short answer
 
-**Fidelity** here means: given one logical value and one `.proto`, each runtime’s encode/decode behaves as a correct Protobuf implementation for that schema, and **cross-language** pairs interoperate for the fields you care about. Prefer proving interoperability with **golden vectors** and **matrix tests** (encode in A, decode in B), not with suite speed tables. This suite’s harnesses are **per-language**; they do not automatically prove cross-runtime byte identity ([301 polyglot estates](../301/polyglot-estates.md) is product contract choice; this page is **byte/logic discipline**).
+**Fidelity** here means two related claims. First, given one logical value and one `.proto`, each runtime’s encode and decode behaves as a correct Protocol Buffers implementation for that schema. Second, **cross-language** pairs interoperate for the fields you care about: bytes produced in language A decode correctly in language B.
 
-Assumes [wire format](protobuf-wire-format.md) and at least one language path ([Python](protobuf-python.md), [Rust](protobuf-rust-prost.md), [C](protobuf-c-protobuf-c.md)).
+Prefer proving interoperability with **golden vectors** (known-correct hex sequences) and **matrix tests** (encode in A, decode in B). Do not treat suite speed tables as fidelity proofs. This suite’s harnesses are **per-language**; they do not automatically prove cross-runtime byte identity. [301 polyglot estates](../301/polyglot-estates.md) is about product contract choice; this page is about **byte and logic discipline**.
 
-This monorepo already has Python, Rust, and C Protobuf entries—use them when available. Outside the suite, the same discipline applies with any three official runtimes.
+This article assumes the [wire format](protobuf-wire-format.md) article and at least one language path ([Python](protobuf-python.md), [Rust](protobuf-rust-prost.md), [C](protobuf-c-protobuf-c.md)).
+
+This monorepo already has Python, Rust, and C Protocol Buffers entries—use them when available. Outside the suite, the same discipline applies with any three official runtimes.
 
 ## Prerequisites
 
@@ -29,7 +31,7 @@ This monorepo already has Python, Rust, and C Protobuf entries—use them when a
   bytes₁ == bytes₂ ?   nice when true; NOT required by the Protobuf spec
 ```
 
-Protobuf requires **semantic** compatibility (decode understands encode), not that two encoders emit the same field order or the same omission pattern for defaults.
+Protocol Buffers requires **semantic** compatibility: a decoder must understand what an encoder wrote. It does **not** require that two encoders emit the same field order or the same omission pattern for default values.
 
 ## What “same bytes” can mean (be precise)
 
@@ -37,28 +39,28 @@ Protobuf requires **semantic** compatibility (decode understands encode), not th
 |-------|---------|-------------------|
 | **Interoperable** | A’s bytes decode in B to the same logical fields | **Yes** (for the schema subset you use) |
 | **Bit-identical encode** | A and B produce equal `bytes` for one value | **No** |
-| **Harness fidelity** | Serialize then deserialize in **one** language matches fixture compare | Suite-local only |
+| **Harness fidelity** | Serialize then deserialize in **one** language matches the fixture compare | Suite-local only |
 | **Canonical encode** | Deterministic field order / map order | Optional (`deterministic` in some APIs) |
 
-Serializer developers should chase **interoperability** first; bit-identity second (debugging, signing, caches).
+Serializer developers should chase **interoperability** first and **bit-identity** second (useful for debugging, signing, and caches).
 
 ## Step-by-step fidelity discipline
 
 ### 1. Freeze the schema
 
-- One `.proto` (or generated sources from one commit).  
-- No silent field renumbering.  
-- Document packed vs unpacked repeated if versions differ.
+- Use one `.proto` file (or generated sources from one commit).  
+- Do not renumber fields silently.  
+- Document packed versus unpacked repeated fields if generator versions differ.
 
 ### 2. Freeze the logical fixture
 
 Define values in a language-neutral way:
 
-- Integers and bools exact.  
-- Strings: Unicode code points (not “whatever my editor saved”).  
-- Timestamps: explicit unit (suite often uses ms—see harness notes).  
-- Floats/doubles: prefer values with exact binary reps when asserting bit-identity; otherwise assert with tolerances only where product allows.  
-- Nested/repeated: full structure, including empty vs omitted.
+- Integers and bools are exact.  
+- Strings are defined by Unicode code points (not “whatever my editor saved”).  
+- Timestamps use an explicit unit (this suite often uses milliseconds—see harness notes).  
+- Floats and doubles: prefer values with exact binary representations when asserting bit-identity; otherwise assert with tolerances only where the product allows it.  
+- Nested and repeated fields: specify the full structure, including empty versus omitted.
 
 ### 3. Encode matrix
 
@@ -68,7 +70,7 @@ Define values in a language-neutral way:
 | Rust | A→B cross-decode | A→A round-trip | A→B cross-decode |
 | C | A→B cross-decode | A→B cross-decode | A→A round-trip |
 
-Every cell asserts `logical_equal(fixture, decode(encode(fixture)))`. Diagonal = same-language round-trip; off-diagonal = cross-language interop. Minimum useful set: **all round-trips** + **each encoder once into each other decoder**.
+Every cell asserts `logical_equal(fixture, decode(encode(fixture)))`. The diagonal is same-language round-trip. Off-diagonal cells are cross-language interop. A minimum useful set is **all round-trips** plus **each encoder once into each other decoder**.
 
 ### 4. Assert logical equality, not only `memcmp`
 
@@ -89,33 +91,33 @@ If bit-identity fails but logical cross-decode works, document **why** (field or
 
 ### 5. Golden vectors for the subset you hand-rolled
 
-Use the [lab](lab-mini-protobuf-encoder.md) goldens (e.g. `08 01 12 03 41 64 61`) as the **minimal cross-runtime test**. Encode the same logical `MiniUser` in Python, Rust, and C, then decode in the other two runtimes. This is the cheapest way to prove that your three implementations actually speak the same wire.
+Use the [lab](lab-mini-protobuf-encoder.md) goldens (for example `08 01 12 03 41 64 61`) as the **minimal cross-runtime test**. Encode the same logical `MiniUser` in Python, Rust, and C, then decode in the other two runtimes. That is the cheapest way to prove that your three implementations actually speak the same wire language.
 
 ### 6. Track known semantic footguns
 
 | Footgun | What breaks |
 |---------|-------------|
-| proto3 default omission | One side sets `0`/`""` explicitly, other omits; both valid |
-| Enum unknown values | Preservation vs error differs by runtime/settings |
-| UTF-8 validation | Strict vs lenient string decode |
+| proto3 default omission | One side sets `0` or `""` explicitly; the other omits the field; both encodings can be valid |
+| Enum unknown values | Preservation versus error differs by runtime and settings |
+| UTF-8 validation | Strict versus lenient string decode |
 | `int64` in JSON mapping | Not wire binary—but dual APIs confuse tests |
 | Float ordering / NaN | Equality and bit patterns |
-| Field name vs number | Codegen renames (`FirstName` vs `first_name`)—wire is numbers only |
-| Harness mapping | Suite `prepare` converts domain objects—bugs look like codec bugs |
+| Field name vs number | Codegen renames (`FirstName` vs `first_name`)—the wire carries numbers only |
+| Harness mapping | Suite `prepare` converts domain objects—bugs can look like codec bugs |
 
 ### 7. Separate harness fidelity from product fidelity
 
 This suite may:
 
 - Convert fixtures to native messages **outside** timed paths.  
-- Apply language-specific compare callbacks (in C, the per-serializer compare function often named something like `fidelity_fx`—**suite-local round-trip check**, not multi-language proof).  
-- Exclude fixtures a given language schema does not define.
+- Apply language-specific compare callbacks (in C, the per-serializer compare function is often named something like `fidelity_fx`—a **suite-local round-trip check**, not multi-language proof).  
+- Exclude fixtures that a given language schema does not define.
 
-Passing suite fidelity means **that language entry** round-trips under **that** compare function—not that three languages share bytes.
+Passing suite fidelity means **that language entry** round-trips under **that** compare function. It does not mean that three languages share the same bytes.
 
 ## MiniUser matrix runbook (~10 minutes)
 
-Teaching schema only—create `mini.proto` (same as the [lab](lab-mini-protobuf-encoder.md)); it is **not** suite `benchmark_data.proto`.
+Teaching schema only—create `mini.proto` (same as the [lab](lab-mini-protobuf-encoder.md)). It is **not** the suite `benchmark_data.proto`.
 
 **Logical fixture:** `MiniUser { id = 1, name = "Ada" }`  
 **Golden:** `08 01 12 03 41 64 61`
@@ -123,60 +125,60 @@ Teaching schema only—create `mini.proto` (same as the [lab](lab-mini-protobuf-
 | Step | Action |
 |------|--------|
 | 1 | Write `mini.proto` with MiniUser fields 1–4 as in the lab. |
-| 2 | **Python:** `protoc --python_out=. mini.proto` → `mini_pb2.MiniUser`, set fields, `SerializeToString()`, assert hex equals golden (or logical equal after parse). |
-| 3 | **Rust:** `prost-build` on `mini.proto` (or temporary `build.rs`), `encode_to_vec()`, same asserts. |
+| 2 | **Python:** `protoc --python_out=. mini.proto` → `mini_pb2.MiniUser`, set fields, call `SerializeToString()`, assert hex equals the golden (or logical equality after parse). |
+| 3 | **Rust:** `prost-build` on `mini.proto` (or a temporary `build.rs`), call `encode_to_vec()`, same asserts. |
 | 4 | **C:** `protoc --c_out=. mini.proto`, pack with protobuf-c (or label nanopb separately—**do not mix engines mid-matrix without labeling**). |
-| 5 | Cross-decode: each language’s bytes → other two decoders → `id==1`, `name=="Ada"`. |
-| 6 | Record whether the three encodes are bit-identical (`memcmp` / `==` on bytes). |
-| 7 | Append unknown field `28 63` to Python bytes; confirm Rust and C still yield id/name (skip-unknown). |
+| 5 | Cross-decode: feed each language’s bytes into the other two decoders; check `id==1` and `name=="Ada"`. |
+| 6 | Record whether the three encodes are bit-identical (`memcmp` or `==` on bytes). |
+| 7 | Append the unknown field `28 63` to the Python bytes; confirm Rust and C still yield id and name (skip-unknown). |
 
 Optional second fixture: lab G5 `1a 02 08 02` (nested manager) for nested LEN confidence.
 
 ## Worked mini protocol (summary)
 
-1. Take lab message `MiniUser { id=1, name="Ada" }`.  
-2. Encode with Python `SerializeToString`, Rust `encode_to_vec`, C `protobuf_c_message_pack` (or nanopb if that is your C choice—label it).  
-3. Decode each blob with the other two.  
-4. Record whether encodes are bit-identical.  
-5. Append unknown field `28 63` and confirm logical id/name still round-trip where skip-unknown works.
+1. Take the lab message `MiniUser { id=1, name="Ada" }`.  
+2. Encode with Python `SerializeToString`, Rust `encode_to_vec`, and C `protobuf_c_message_pack` (or nanopb if that is your C choice—label it).  
+3. Decode each blob with the other two runtimes.  
+4. Record whether the encodes are bit-identical.  
+5. Append the unknown field `28 63` and confirm logical id and name still round-trip where skip-unknown works.
 
 ## Decision frame: when bit-identity matters
 
 | Need | Practice |
 |------|----------|
-| Cache key = hash(bytes) | Force one encoder, or canonical deterministic mode |
-| Digital signature over payload | Same—canonicalize or sign logical fields |
-| Multi-language microservices | Interoperability matrix; bit-identity optional |
-| Debugging “who is wrong?” | Golden vector + one reference implementation |
+| Cache key = hash(bytes) | Force one encoder, or use a canonical deterministic mode |
+| Digital signature over payload | Same—canonicalize, or sign logical fields instead of raw bytes |
+| Multi-language microservices | Interoperability matrix; bit-identity is optional |
+| Debugging “who is wrong?” | Golden vector plus one reference implementation |
 
 ## In this suite
 
 | Asset | Fidelity role |
 |-------|----------------|
 | `schemas/v2/protobuf/benchmark_v2.proto` | Shared field numbers for suite types |
-| Python `protobuf` / Rust `prost` / C `protobuf-c` & `nanopb` | Separate encode paths (pins on language articles) |
+| Python `protobuf` / Rust `prost` / C `protobuf-c` and `nanopb` | Separate encode paths (pins are on the language articles) |
 | Per-language fidelity hooks | Local round-trip checks only |
 | Results / ops | **Not** interoperability proofs |
-| [301 polyglot estates](../301/polyglot-estates.md) | One **product** contract; this page tests **bytes/logic** |
+| [301 polyglot estates](../301/polyglot-estates.md) | One **product** contract; this page tests **bytes and logic** |
 
 ## Common mistakes
 
 - Declaring victory from three green language Results charts.  
 - Testing only A→A round-trips.  
 - Comparing floats with `==` across languages without a policy.  
-- Mixing nanopb static limits with “full” protobuf-c fixtures and calling it a wire bug.  
+- Mixing nanopb static limits with “full” protobuf-c fixtures and calling the mismatch a wire bug.  
 - Editing generated code in one language only (schema drift).  
 - Using suite fixtures for a first matrix when MiniUser goldens are enough.
 
 ## What this article is not
 
-- A full conformance suite (use upstream Protobuf conformance tests for serious work).  
-- Product advice on JSON vs Protobuf ([301](../301/index.md)).  
-- Engine deep-dives (see language path articles).
+- A full conformance suite (use upstream Protocol Buffers conformance tests for serious work).  
+- Product advice on JSON versus Protocol Buffers ([301](../301/index.md)).  
+- Engine deep-dives (see the language-path articles).
 
 ## Key takeaways
 
-- Require **cross-decode interoperability**; treat **bit-identical encode** as optional/strict.  
-- Prove with **matrix tests and goldens**, not benchmark ranks.  
-- Defaults, packing, and harness mapping cause most “Protobuf mismatch” bugs.  
-- Suite fidelity ≠ multi-runtime fidelity—bridge them with explicit tests you own.
+- Require **cross-decode interoperability**. Treat **bit-identical encode** as an optional strict check.  
+- Prove fidelity with **matrix tests and goldens**, not with benchmark ranks.  
+- Defaults, packing, and harness mapping cause most “Protocol Buffers mismatch” bugs.  
+- Suite fidelity is not multi-runtime fidelity—bridge them with explicit tests you own.

--- a/docs/theory/401/protobuf-python.md
+++ b/docs/theory/401/protobuf-python.md
@@ -2,21 +2,23 @@
 
 ## Problem
 
-Python services often “use Protobuf” via generated `*_pb2.py` modules without a clear picture of **what is timed**, **what owns the bytes**, **which runtime backend runs under the hood**, and **how that backend turns a message into tags**. Client call sites alone do not train serializer developers.
+Python services often “use Protocol Buffers” through generated `*_pb2.py` modules without a clear picture of **what is timed in a benchmark**, **who owns the output bytes**, **which runtime backend runs under the hood**, and **how that backend turns a message into wire tags**. Reading only client call sites does not train serializer developers.
 
 ## Short answer
 
-With `google.protobuf`, `protoc` generates message classes that implement the `Message` API (`SerializeToString`, `ParseFromString`, …). At import time the library selects an **implementation backend** (default **upb**, else pure Python; legacy **cpp** exists but is no longer what PyPI ships). Serialize walks the message’s fields using **descriptors** (field numbers + types) and emits standard Protobuf binary; parse consumes tags and fills a message instance. In this suite, **dataclass → Message is untimed `prepare_data`**; timed work is serialize/parse of the Message.
+With the `google.protobuf` package, **`protoc`** (the Protocol Buffers compiler) generates message classes that implement the `Message` API—methods such as `SerializeToString` and `ParseFromString`. At import time the library selects an **implementation backend** (by default **upb**, a fast native core; otherwise pure Python; a legacy **cpp** extension still exists but is no longer what PyPI ships for ordinary installs). Serialize walks the message’s fields using **descriptors** (metadata that records field numbers and types) and emits standard Protocol Buffers binary. Parse consumes tags and fills a message instance.
 
-Assumes [wire format](protobuf-wire-format.md). Package: `protobuf` ([Python tutorial](https://protobuf.dev/getting-started/pythontutorial/), [encoding guide](https://protobuf.dev/programming-guides/encoding/), [python/README backends](https://github.com/protocolbuffers/protobuf/blob/main/python/README.md)).
+In this benchmark suite, converting a domain object into a Message is untimed **`prepare_data`**. Timed work is only serialize and parse of the Message.
 
-**Suite pin (this monorepo):** `protobuf>=7.34.1,<8` in `python/pyproject.toml`—patterns below track that line; always re-check your installed version.
+This article assumes the [wire format](protobuf-wire-format.md) article. Package: `protobuf` ([Python tutorial](https://protobuf.dev/getting-started/pythontutorial/), [encoding guide](https://protobuf.dev/programming-guides/encoding/), [python/README backends](https://github.com/protocolbuffers/protobuf/blob/main/python/README.md)).
+
+**Suite pin (this monorepo):** `protobuf>=7.34.1,<8` in `python/pyproject.toml`. Patterns below track that line; always re-check your installed version.
 
 ## Prerequisites
 
-- 201: schema-dependent encoding.  
+- Serialization 201: schema-dependent encoding.  
 - Ability to read generated Python modules.  
-- Soft: [301 trust](../301/trust-boundaries.md) / [untrusted input](../301/untrusted-input.md).
+- Soft: [301 trust](../301/trust-boundaries.md) and [untrusted input](../301/untrusted-input.md).
 
 ## Mental model
 
@@ -40,7 +42,7 @@ Assumes [wire format](protobuf-wire-format.md). Package: `protobuf` ([Python tut
 protoc -I schemas --python_out=python/generated schemas/v2/protobuf/benchmark_v2.proto
 ```
 
-Generated modules define message classes with field numbers from the `.proto`—Python attribute names are bindings, not wire identity.
+Generated modules define message classes whose field numbers come from the `.proto` file. Python attribute names are language bindings; **wire identity is the field number**, not the Python name.
 
 ### 2. Build a message (generated class)
 
@@ -53,11 +55,11 @@ msg.f_int32 = 36
 msg.f_bool = True
 ```
 
-proto3: unset scalars with default values are typically **omitted** on the wire.
+In proto3, unset scalars that still hold their default values are typically **omitted** on the wire.
 
 ### 3. Teaching MiniUser (not suite codegen)
 
-`MiniUser` is the [wire](protobuf-wire-format.md) / [lab](lab-mini-protobuf-encoder.md) teaching message. It is **not** part of the suite wire schema. Generate from a local `mini.proto`:
+`MiniUser` is the teaching message from the [wire](protobuf-wire-format.md) and [lab](lab-mini-protobuf-encoder.md) articles. It is **not** part of the suite wire schema. Generate it from a local `mini.proto`:
 
 ```bash
 protoc --python_out=. mini.proto   # defines message MiniUser
@@ -74,7 +76,7 @@ data = msg.SerializeToString()   # b'\x08\x01\x12\x03Ada'
 
 ### 4. Encode / decode (API)
 
-Same APIs on any generated message (including teaching MiniUser):
+The same APIs work on any generated message (including teaching MiniUser):
 
 ```python
 data: bytes = msg.SerializeToString()
@@ -90,32 +92,38 @@ out = type(msg).FromString(data)
 # out.MergeFromString(data)
 ```
 
-Public API documentation: [Message.SerializeToString / ParseFromString](https://googleapis.dev/python/protobuf/latest/google/protobuf/message.html). Optional `deterministic=True` on serialize requests stable map key ordering when maps are present.
+Public API documentation: [Message.SerializeToString / ParseFromString](https://googleapis.dev/python/protobuf/latest/google/protobuf/message.html). The optional `deterministic=True` argument on serialize requests stable map-key ordering when maps are present.
 
 ## How the package implements serialization (step-by-step)
 
-The logical flow is the same across backends. The package turns a populated message into wire bytes using **descriptors** (field numbers, types, labels) that come from code generation.
+The logical flow is the same across backends. The package turns a populated message into wire bytes using **descriptors**—tables of field numbers, types, and labels that code generation baked in.
 
 ### S1 — Resolve backend
 
-At import time the library selects an **implementation backend**: **upb** by default in modern PyPI wheels; **pure Python** as the portable fallback; legacy **cpp** extension exists but is no longer what `pip install protobuf` ships. You usually do not choose this explicitly; set `PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python` (or `upb`) to force one for debugging or benchmarks.
+At import time the library selects an **implementation backend**:
+
+- **upb** is the default in modern PyPI wheels.  
+- **pure Python** is the portable fallback.  
+- A legacy **cpp** extension exists, but it is no longer what `pip install protobuf` ships for ordinary use.
+
+You usually do not choose this explicitly. Set `PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python` (or `upb`) to force one backend for debugging or reproducible benchmarks.
 
 ### S2 — Field walk (descriptor-driven)
 
-`SerializeToString()` iterates the message's **present fields** using descriptor metadata (field numbers, types, labels) baked in at codegen time. For each field it emits a **key** (field number + wire type) followed by the payload.
+`SerializeToString()` iterates the message’s **present fields** using descriptor metadata (field numbers, types, labels). For each field it emits a **key** (field number plus wire type) followed by the payload.
 
 ### S3 — Emit tag + payload
 
-Each field becomes exactly the tag + payload pair from the [wire format article](protobuf-wire-format.md):
+Each field becomes exactly the tag-plus-payload pair described in the [wire format article](protobuf-wire-format.md):
 
-- Varint types (int, bool, enum) → key + varint encoding.
-- Fixed32/64 → key + 4/8 little-endian bytes.
-- String/bytes → key + length varint + raw data.
-- Nested message → key + length varint + recursive serialize of the submessage.
+- Varint types (integers, bool, enum) → key plus varint encoding.  
+- Fixed32/64 → key plus 4 or 8 little-endian bytes.  
+- String/bytes → key plus length varint plus raw data.  
+- Nested message → key plus length varint plus a recursive serialize of the submessage.
 
 ### S4 — Produce output bytes
 
-The result is a new **immutable `bytes` object** — the caller owns it. No reference to the original message is retained in the output.
+The result is a new **immutable `bytes` object**. The **caller owns it**. No reference to the original message is retained inside that output.
 
 ```text
   Message fields
@@ -137,10 +145,10 @@ The result is a new **immutable `bytes` object** — the caller owns it. No refe
 
 | Situation | Practical note |
 |-----------|----------------|
-| You care about speed in hot paths | upb (default) is usually best |
+| You care about speed in hot paths | upb (the default) is usually best |
 | You need zero-copy sharing with C++ | Legacy cpp extension (rare now) |
 | You must run without any native extension | `PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python` |
-| Benchmarking or debugging | Pin backend via env var for reproducibility |
+| Benchmarking or debugging | Pin the backend via the environment variable for reproducibility |
 
 ## How the package implements deserialization (step-by-step)
 
@@ -149,20 +157,20 @@ The result is a new **immutable `bytes` object** — the caller owns it. No refe
 | API | Behavior |
 |-----|----------|
 | **`ParseFromString(data)`** | **Replace:** clears `self`, then parses `data` into it |
-| **`MergeFromString(data)`** | **Merge:** does not clear; merges fields into existing state |
-| **`FromString(data)`** | Constructs a **new** message, then parse (replace into empty) |
+| **`MergeFromString(data)`** | **Merge:** does not clear; merges fields into the existing state |
+| **`FromString(data)`** | Constructs a **new** message, then parses (replace into empty) |
 
-1. Backend receives a pointer/view of the input buffer (zero-copy into C for upb when possible for the raw read; Python objects for field values are still allocated as needed).  
-2. Prefer `FromString` or a fresh instance + `ParseFromString` when you want replace semantics; use `MergeFromString` only when merge is intentional.
+1. The backend receives a pointer or view of the input buffer (zero-copy into C for upb when possible for the raw read; Python objects for field values are still allocated as needed).  
+2. Prefer `FromString` or a fresh instance plus `ParseFromString` when you want replace semantics. Use `MergeFromString` only when merge is intentional.
 
 ### D2 — Tag loop
 
 While input remains:
 
-1. Read **key** varint → `field_number`, `wire_type`.  
+1. Read the **key** varint and split it into `field_number` and `wire_type`.  
 2. Look up `field_number` in the message **descriptor**.  
-3. If **known**: decode payload for that field’s type and **set/merge** into the message.  
-4. If **unknown**: **skip** the payload using `wire_type` (and often retain unknown fields for round-trip, depending on backend/version).
+3. If the field is **known**, decode the payload for that field’s type and set or merge it into the message.  
+4. If the field is **unknown**, **skip** the payload using `wire_type` (and often retain unknown fields for round-trip, depending on backend and version).
 
 This matches the decode loop in the wire article.
 
@@ -170,21 +178,21 @@ This matches the decode loop in the wire article.
 
 | Wire/content | Action |
 |--------------|--------|
-| Varint field | Decode varint → store as int/bool/enum |
-| Fixed32/64 | Read 4/8 little-endian bytes |
-| String | Read len + UTF-8 → Python `str` |
-| Bytes | Read len + raw → `bytes` |
-| Nested message | Read len-delimited slice → recursive parse into submessage |
-| Repeated | Append element (or unpack packed block into multiple elements) |
+| Varint field | Decode varint → store as int, bool, or enum |
+| Fixed32/64 | Read 4 or 8 little-endian bytes |
+| String | Read length plus UTF-8 → Python `str` |
+| Bytes | Read length plus raw data → `bytes` |
+| Nested message | Read a length-delimited slice → recursive parse into a submessage |
+| Repeated | Append an element (or unpack a packed block into multiple elements) |
 | Map | Decode as repeated entry messages → Python map |
 
 ### D4 — Merge semantics (when merging)
 
-When using **`MergeFromString`** (or merge paths inside nested updates): repeated fields append; singulars overwrite; submessages merge field-by-field. That is why “parse into an already-filled message” with merge APIs can surprise you—use `ParseFromString` / fresh instance when you want replace.
+When you use **`MergeFromString`** (or merge paths inside nested updates), repeated fields append, singular scalars overwrite, and submessages merge field-by-field. That is why “parse into an already-filled message” with merge APIs can surprise you. Use `ParseFromString` or a fresh instance when you want replace.
 
 ### D5 — Allocate Python-visible structure
 
-Even with upb, exposing fields to Python often materializes Python objects (`str`, `list` wrappers, submessage proxies). That cost is part of “Python Protobuf,” not pure wire CPU.
+Even with upb, exposing fields to Python often materializes Python objects (`str`, list wrappers, submessage proxies). That cost is part of “Python Protocol Buffers,” not pure wire CPU time.
 
 ### D6 — Errors
 
@@ -199,13 +207,15 @@ Truncated input, illegal varints, or invalid UTF-8 (where checked) raise parse e
 | Stage | Pure Python | upb (default wheel) |
 |-------|-------------|---------------------|
 | Field walk | Python loops in `internal` | Native C |
-| Varint/tag | Python integer ops | Native |
-| Nested | Recursive Python | Native + recursion limit |
+| Varint/tag | Python integer operations | Native |
+| Nested | Recursive Python | Native plus a recursion limit |
 | API | Same `Message` methods | Same |
 
-Functionally interchangeable for ordinary use; performance and some edge behaviors differ. Pin via `PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python` (or `upb`) and document the backend for benchmarks.
+The two backends are functionally interchangeable for ordinary use. Performance and some edge behaviors differ. Pin via `PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python` (or `upb`) and document the backend when you publish benchmarks.
 
-## Buffers & ownership (simple diagram)
+## Buffers and ownership (simple diagram)
+
+**Ownership** here means: who allocated this object, who is responsible for freeing it (or letting the garbage collector take it), and how long a buffer must stay valid.
 
 ```text
 Python Message object
@@ -219,43 +229,43 @@ input bytes (or memoryview — underlying buffer must remain valid for the call)
 
 | Object | Owner |
 |--------|--------|
-| Generated Message | Python GC |
+| Generated Message | Python garbage collector |
 | `bytes` from serialize | Immutable; caller-owned |
 | Parse input | Caller; ordinary `bytes` are fine; if you pass a view into a mutable buffer, keep that buffer alive for the call |
-| Unknown fields | Held on message when the backend retains them |
+| Unknown fields | Held on the message when the backend retains them |
 
 ## In this suite
 
 | Location | Role |
 |----------|------|
-| `python/src/benchmark/serializers/schema_protobuf.py` | `prepare_data` → Message; `serialize_bytes` → `SerializeToString` |
+| `python/src/benchmark/serializers/schema_protobuf.py` | `prepare_data` builds a Message; `serialize_bytes` calls `SerializeToString` |
 | suite generated `*_pb2.py` modules | Generated suite messages—not MiniUser |
 | Log name | `protobuf` |
 | Pin | `protobuf>=7.34.1,<8` |
 | [Python Results](../../python/results.md) | Cost under whatever backend the environment selected |
 
-Harness keeps conversion **out** of the timed path so Results compare codec work, not model mapping. Do not rank Python vs Rust/C from Results alone ([cross-language fidelity](protobuf-cross-language-fidelity.md)).
+The harness keeps domain-to-Message conversion **out** of the timed path so Results compare codec work, not model mapping. Do not rank Python against Rust or C from Results alone ([cross-language fidelity](protobuf-cross-language-fidelity.md)).
 
 ## Common mistakes
 
-- Timing `prepare_data` + serialize together.  
+- Timing `prepare_data` and serialize together.  
 - Assuming pure-Python behavior while upb is active (or the reverse).  
-- Using `MergeFromString` when you meant replace (`ParseFromString` / fresh message).  
+- Using `MergeFromString` when you meant replace (`ParseFromString` or a fresh message).  
 - Mutating a message while another thread serializes it.  
 - Parsing untrusted bytes without size limits.  
 - Hand-editing `*_pb2.py`.  
-- Expecting `MiniUser` in suite generated modules (teaching schema only).
+- Expecting `MiniUser` in suite-generated modules (it is a teaching schema only).
 
 ## What this article is not
 
-- Line-by-line tour of upb C sources.  
+- A line-by-line tour of the upb C sources.  
 - gRPC Python stubs.  
-- From-scratch encoder ([lab](lab-mini-protobuf-encoder.md)).
+- A from-scratch encoder (see the [lab](lab-mini-protobuf-encoder.md)).
 
 ## Key takeaways
 
-- Client API: **codegen → Message → SerializeToString / ParseFromString**.  
-- **ParseFromString** replaces (clear + parse); **MergeFromString** merges.  
-- Implementation: **backend** + **descriptor-driven** field walk = wire tags.  
-- Default backend is **upb**; pure Python remains the portable fallback.  
-- Parallel: [Rust prost](protobuf-rust-prost.md), [C protobuf-c](protobuf-c-protobuf-c.md).
+- Client API path: **codegen → Message → SerializeToString / ParseFromString**.  
+- **ParseFromString** replaces (clear, then parse); **MergeFromString** merges.  
+- Implementation: a **backend** plus a **descriptor-driven** field walk produces wire tags.  
+- The default backend is **upb**; pure Python remains the portable fallback.  
+- Parallel articles: [Rust prost](protobuf-rust-prost.md), [C protobuf-c](protobuf-c-protobuf-c.md).

--- a/docs/theory/401/protobuf-rust-prost.md
+++ b/docs/theory/401/protobuf-rust-prost.md
@@ -2,20 +2,22 @@
 
 ## Problem
 
-Rust Protobuf stacks differ (`prost`, `protobuf` crate, …). Client use of `encode` / `decode` is short; serializer developers need how **`prost::Message`**, **codegen**, and **encoding modules** actually turn structs into wire bytes and back.
+Rust has more than one Protocol Buffers stack (`prost`, the `protobuf` crate, and others). Client use of `encode` and `decode` looks short. Serializer developers need a deeper picture: how **`prost::Message`**, **code generation**, and the **encoding modules** actually turn structs into wire bytes and back.
 
 ## Short answer
 
-`prost-build` emits Rust structs with a derived/`impl Message` that implements **`encode_raw`**, **`encoded_len`**, **`merge_field`**, and **`clear`**. Public `encode` / `encode_to_vec` / `decode` are thin wrappers: compute length, ensure capacity, call `encode_raw`; or `Default` + **`merge`** tag loop. Low-level primitives live in `prost::encoding` (varint, wire type, length-delimited) per the [Protobuf encoding guide](https://protobuf.dev/programming-guides/encoding/). Suite `prepare` builds messages untimed; timed path is encode/decode.
+**`prost-build`** runs at compile time and emits Rust structs with an `impl Message` (or a derived equivalent). That implementation provides **`encode_raw`**, **`encoded_len`**, **`merge_field`**, and **`clear`**. The public methods `encode`, `encode_to_vec`, and `decode` are thin wrappers: they compute length, ensure capacity, and call `encode_raw`; or they start from `Default` and run a **`merge`** tag loop. Low-level primitives live in `prost::encoding` (varint, wire type, length-delimited helpers) and follow the [Protobuf encoding guide](https://protobuf.dev/programming-guides/encoding/).
 
-Assumes [wire format](protobuf-wire-format.md). Crate: [tokio-rs/prost](https://github.com/tokio-rs/prost) (`Message` in `prost/src/message.rs`).
+In this suite, **`prepare`** builds messages outside the timed path. Timed work is encode and decode.
+
+This article assumes the [wire format](protobuf-wire-format.md) article. Crate: [tokio-rs/prost](https://github.com/tokio-rs/prost) (`Message` lives in `prost/src/message.rs`).
 
 **Suite pin (this monorepo):** `prost` / `prost-build` **0.13** in `rust/Cargo.toml`.
 
 ## Prerequisites
 
-- Intermediate Rust (ownership, `Vec<u8>`, traits).  
-- 201 schema-dependent encoding.  
+- Intermediate Rust: ownership, `Vec<u8>`, traits.  
+- Serialization 201: schema-dependent encoding.  
 - Soft: [301 untrusted input](../301/untrusted-input.md) (recursion limits and hostile nesting).
 
 ## Mental model
@@ -39,7 +41,7 @@ prost_build::Config::new()
     )?;
 ```
 
-Often set `PROTOC` via `protoc-bin-vendored` (as in this suite’s `rust/build.rs`).
+Projects often set `PROTOC` through `protoc-bin-vendored` (as this suite does in `rust/build.rs`).
 
 ### 2. Include generated code
 
@@ -64,27 +66,27 @@ let buf = person.encode_to_vec();
 let parsed = pb::MiniUser::decode(&buf[..])?;
 ```
 
-Field names are Rust-ified; **tags** still come from `.proto` numbers. For the teaching [MiniUser](lab-mini-protobuf-encoder.md) message, compile a separate tiny `mini.proto`—it is not part of suite `benchmark_data.proto`.
+Field names are Rust-ified (snake_case and similar conventions). **Tags on the wire still come from the field numbers in the `.proto` file.** For the teaching [MiniUser](lab-mini-protobuf-encoder.md) message, compile a separate tiny `mini.proto`—it is not part of the suite `benchmark_data.proto`.
 
 ## How prost implements serialization (step-by-step)
 
-prost turns a Rust struct into wire bytes using **compile-time knowledge** of the schema. There is no runtime descriptor table — the hot path is monomorphized per message type.
+prost turns a Rust struct into wire bytes using **compile-time knowledge** of the schema. There is no runtime descriptor table on the hot path. Instead, the code is **monomorphized**: the compiler specializes encode and decode for each concrete message type.
 
 ### S1 — Codegen bakes the schema into Rust code
 
-`prost-build` runs at `cargo build` time: it invokes `protoc`, reads the descriptor, and emits a Rust struct plus `impl Message` with per-field `encode_raw` / `merge_field` bodies. After this step, field numbers and wire types are compile-time constants — no descriptor table is consulted at encode time.
+`prost-build` runs at `cargo build` time. It invokes `protoc`, reads the descriptor, and emits a Rust struct plus `impl Message` with per-field `encode_raw` and `merge_field` bodies. After this step, field numbers and wire types are compile-time constants. No descriptor table is consulted at encode time.
 
 ### S2 — `encoded_len` (dry-run size)
 
-`encoded_len()` walks the struct's fields and sums `tag_len + payload_len` for every present field. Nested messages recurse. The result tells the caller (or `encode`) how many bytes to reserve.
+`encoded_len()` walks the struct’s fields and sums `tag_len + payload_len` for every present field. Nested messages recurse. The result tells the caller (or `encode`) how many bytes to reserve.
 
 ### S3 — `encode_raw` (write tags + payloads)
 
-`encode_raw(&self, buf: &mut impl BufMut)` emits one tag + payload pair per present field into the output buffer, using helpers from `prost::encoding` (varint, fixed, length-delimited). Nested messages call their own `encode_raw` inside a length-delimited frame.
+`encode_raw(&self, buf: &mut impl BufMut)` emits one tag-plus-payload pair per present field into the output buffer, using helpers from `prost::encoding` (varint, fixed, length-delimited). Nested messages call their own `encode_raw` inside a length-delimited frame.
 
 ### S4 — Public wrappers
 
-`encode(&self, buf: &mut impl BufMut)` calls `encoded_len` for a capacity check, then `encode_raw`. `encode_to_vec(&self)` allocates a `Vec<u8>` of exactly the right size, then `encode_raw` into it. `encode_length_delimited` prepends the message's length varint (used by streaming / gRPC framing).
+`encode(&self, buf: &mut impl BufMut)` calls `encoded_len` for a capacity check, then `encode_raw`. `encode_to_vec(&self)` allocates a `Vec<u8>` of exactly the right size, then runs `encode_raw` into it. `encode_length_delimited` prepends the message’s length as a varint (used by streaming and gRPC framing).
 
 ```text
   Rust struct
@@ -104,7 +106,7 @@ prost turns a Rust struct into wire bytes using **compile-time knowledge** of th
 
 ### When prost fits
 
-Use prost when you want typed, monomorphized encode/decode in a Rust binary with build-time codegen. Prefer other crates if you need fully dynamic messages at runtime or a different codegen style—this page does not rank alternatives.
+Use prost when you want typed, monomorphized encode and decode in a Rust binary with build-time code generation. Prefer other crates if you need fully dynamic messages at runtime or a different codegen style. This page does not rank the alternatives.
 
 ## How prost implements deserialization (step-by-step)
 
@@ -116,18 +118,18 @@ Use prost when you want typed, monomorphized encode/decode in a Rust binary with
 
 `merge` reads the input buffer in a loop:
 
-1. Call `decode_key(buf)` → `(field_number, wire_type)`.
-2. Pass both plus the remaining buffer to `merge_field`.
+1. Call `decode_key(buf)` to get `(field_number, wire_type)`.  
+2. Pass both plus the remaining buffer to `merge_field`.  
 3. Repeat until the buffer is exhausted.
 
-A `DecodeContext` tracks **recursion depth** to protect against malicious nesting (configurable limit). Bound untrusted input size as well ([301 untrusted input](../301/untrusted-input.md)).
+A `DecodeContext` tracks **recursion depth** to protect against malicious nesting (the limit is configurable). Bound untrusted input size as well ([301 untrusted input](../301/untrusted-input.md)).
 
 ### D3 — `merge_field` dispatch (generated)
 
 `merge_field` is generated per message type. It contains a `match` on `field_number`:
 
-- **Known tag** → call the type-appropriate decoder from `prost::encoding` (e.g. `uint32::merge`, `string::merge`, `message::merge`).
-- **Unknown tag** → skip the payload by wire type (consume varint, fixed bytes, or length-delimited blob) so the loop can continue.
+- **Known tag** → call the type-appropriate decoder from `prost::encoding` (for example `uint32::merge`, `string::merge`, `message::merge`).  
+- **Unknown tag** → skip the payload by wire type (consume a varint, fixed bytes, or a length-delimited blob) so the loop can continue.
 
 Because `merge_field` is monomorphized code (not a runtime descriptor lookup), the compiler can inline and optimize each branch.
 
@@ -135,19 +137,19 @@ Because `merge_field` is monomorphized code (not a runtime descriptor lookup), t
 
 | Field kind | Behavior |
 |------------|----------|
-| Singular scalar | Overwrite with decoded value |
-| Singular message | Decode length-delimited; merge into nested struct |
-| Repeated | Decode one element and `push` (or expand packed) |
-| String | Validate UTF-8; store `String` |
-| `oneof` | Match variant tag; decode into the enum arm |
+| Singular scalar | Overwrite with the decoded value |
+| Singular message | Decode length-delimited; merge into the nested struct |
+| Repeated | Decode one element and `push` (or expand a packed block) |
+| String | Validate UTF-8; store a `String` |
+| `oneof` | Match the variant tag; decode into the enum arm |
 
 ### D5 — Length-delimited messages
 
-`decode_length_delimited` / nested decode read a length prefix, then merge only that many bytes — same as LEN wire payloads in the encoding guide. This is how nested messages are bounded: the outer decoder slices the buffer before recursing.
+`decode_length_delimited` and nested decode read a length prefix, then merge only that many bytes—the same idea as LEN wire payloads in the encoding guide. That is how nested messages stay bounded: the outer decoder slices the buffer before it recurses.
 
 ### D6 — Errors
 
-Insufficient data, invalid varint, recursion limit, bad UTF-8 → `DecodeError`. The entire `decode` buffer is expected to be consumed (no trailing garbage); length-delimited variants stop at the declared length.
+Insufficient data, an invalid varint, a recursion-limit hit, or bad UTF-8 all become `DecodeError`. The entire `decode` buffer is expected to be consumed (no trailing garbage). Length-delimited variants stop at the declared length.
 
 ```text
   Buf
@@ -169,14 +171,16 @@ Insufficient data, invalid varint, recursion limit, bad UTF-8 → `DecodeError`.
 
 | Piece | Role |
 |-------|------|
-| **prost** | `Message` trait, varint/wire helpers, errors |
-| **prost-build** | Invoke protoc plugins / emit Rust at build time |
-| **prost-derive** | Derive support for custom/annotated types |
-| **Generated module** | Per-schema structs + `encode_raw` / `merge_field` bodies |
+| **prost** | `Message` trait, varint and wire helpers, errors |
+| **prost-build** | Invoke protoc plugins and emit Rust at build time |
+| **prost-derive** | Derive support for custom or annotated types |
+| **Generated module** | Per-schema structs plus `encode_raw` / `merge_field` bodies |
 
-Hot path = **monomorphized** encode/decode per type, not a single reflective interpreter.
+The hot path is **monomorphized** encode and decode per type, not a single reflective interpreter that walks a descriptor table at runtime.
 
-## Buffers & ownership (simple diagram)
+## Buffers and ownership (simple diagram)
+
+In Rust, **ownership** is explicit: each value has one owner, and borrows must not outlive that owner.
 
 ```text
 Your struct (owned fields)
@@ -190,16 +194,16 @@ Vec<u8>  (you own the output)
 
 | Value | Owner / Lifetime |
 |-------|------------------|
-| Generated struct | You (owned `String`/`Vec`) |
+| Generated struct | You (owned `String` / `Vec` fields) |
 | `encode_to_vec()` result | You own the `Vec<u8>` |
-| Decode input slice | Must outlive the call |
+| Decode input slice | Must remain valid for the duration of the call |
 
 ## In this suite
 
 | Location | Role |
 |----------|------|
-| `rust/build.rs` | `prost-build` on shared proto |
-| `rust/src/serializers.rs` (`ProstSer`) | `prepare` → message; `serialize_bytes` → `encode` |
+| `rust/build.rs` | `prost-build` on the shared proto |
+| `rust/src/serializers.rs` (`ProstSer`) | `prepare` builds a message; `serialize_bytes` calls `encode` |
 | Log name | `prost` |
 | Pin | `prost` / `prost-build` 0.13 |
 | [Rust Results](../../rust/results.md) | Schema-driven comparisons |
@@ -208,20 +212,20 @@ Do not cross-rank language Results without controlling for language ([cross-lang
 
 ## Common mistakes
 
-- Hand-editing `OUT_DIR` generated files.  
+- Hand-editing files under `OUT_DIR`.  
 - Ignoring recursion limits on deep hostile input.  
 - Cross-language Results comparisons without controlling for language.  
 - Assuming field emission order is part of the contract (decoders must accept any order).
 
 ## What this article is not
 
-- `tonic`/gRPC.  
-- Full prost vs `protobuf` crate comparison.  
-- Manual subset codec ([lab](lab-mini-protobuf-encoder.md)).
+- `tonic` / gRPC.  
+- A full prost versus `protobuf` crate comparison.  
+- A manual subset codec (see the [lab](lab-mini-protobuf-encoder.md)).
 
 ## Key takeaways
 
-- **Trait split:** `encoded_len` + `encode_raw` (write); `merge` + `merge_field` (read).  
-- **Codegen** bakes field tags into Rust code—no descriptor table on the hot path.  
-- **decode** = `Default` + tag loop—same wire model as other languages.  
-- Parallel: [Python](protobuf-python.md), [C protobuf-c](protobuf-c-protobuf-c.md).
+- **Trait split:** `encoded_len` plus `encode_raw` for writing; `merge` plus `merge_field` for reading.  
+- **Codegen** bakes field tags into Rust code—there is no descriptor table on the hot path.  
+- **decode** is `Default` plus a tag loop—the same wire model as other languages.  
+- Parallel articles: [Python](protobuf-python.md), [C protobuf-c](protobuf-c-protobuf-c.md).

--- a/docs/theory/401/protobuf-wire-format.md
+++ b/docs/theory/401/protobuf-wire-format.md
@@ -5,40 +5,48 @@
 
 ## Problem
 
-Schema-driven formats are often described as “binary with field numbers.” That slogan does not teach you how to **read or emit bytes**, debug a hex dump, or implement a subset codec. Without the wire rules, language tutorials stay API-deep and 201’s “schema-dependent” concept never becomes operational.
+Schema-driven formats are often described as “binary with field numbers.” That slogan does not teach you how to **read or write the actual bytes**, how to debug a hexadecimal dump, or how to implement even a small subset codec. Without the wire rules, language tutorials stay at the API surface, and the idea from Serialization 201 that Protocol Buffers is **schema-dependent** never becomes something you can operate on.
 
 ## Short answer
 
-Protocol Buffers (proto3 binary encoding) write a sequence of **keyed fields**. Each field is a **tag** (field number + wire type) followed by a **payload** whose shape depends on the wire type: varint, fixed 32/64-bit, or length-delimited (strings, bytes, embedded messages, packed repeated). Field **names do not appear** on the wire; readers need the schema (or equivalent) to interpret numbers. Unknown fields are typically **skipped** by field number, which is why additive evolution works when numbers are never reused.
+Protocol Buffers (proto3 binary encoding) write a message as a **sequence of keyed fields**. Each field begins with a **tag** (also called a **key**): a small integer that packs the **field number** (which field this is in the schema) together with the **wire type** (how the following bytes are shaped). After the tag comes a **payload**. The payload shape depends on the wire type: a **varint** (variable-length integer), a fixed 32-bit or 64-bit value, or a **length-delimited** blob (often abbreviated **LEN**)—used for strings, raw bytes, nested messages, and packed repeated numbers.
 
-Assumes 201: [self-describing vs schema](../201/self-describing-vs-schema-dependent.md), [schema evolution](../201/schema-evolution.md).
+Field **names never appear** on the wire. A reader needs the schema (or equivalent knowledge of field numbers and types) to turn those numbers back into meaningful fields. Unknown field numbers are usually **skipped** by looking at the wire type and consuming the right number of bytes. That skip rule is why additive schema evolution works, as long as field numbers are never reused for a different meaning.
+
+This article assumes the 201 ideas in [self-describing vs schema](../201/self-describing-vs-schema-dependent.md) and [schema evolution](../201/schema-evolution.md).
 
 Official encoding reference: [Protocol Buffers encoding](https://protobuf.dev/programming-guides/encoding/).
 
 ## Prerequisites
 
-- Comfort with hex and unsigned integers.  
-- 201 vocabulary: schema-dependent wire, additive field numbers.  
-- Optional: skim shared suite schema `schemas/v2/protobuf/benchmark_v2.proto` for real field numbers (this page uses a **teaching mini-message**, not a full suite fixture).
+- Comfort with hexadecimal notation and unsigned integers.  
+- 201 vocabulary: schema-dependent wire formats and additive field numbers.  
+- Optional: skim the suite schema `schemas/v2/protobuf/benchmark_v2.proto` for realistic field numbers. This page uses a **teaching mini-message**, not a full suite fixture.
 
 ## Mental model
 
-A message is a sequence of **fields**. Each field is:
+A message is a sequence of **fields**. Each field looks like this on the wire:
 
 ```
 [key varint] [payload...]
 ```
 
-Where `key = (field_number << 3) | wire_type`.
+The key is computed as:
+
+```text
+key = (field_number << 3) | wire_type
+```
+
+In plain language: shift the field number three bits left, then put the wire-type code in the low three bits. That integer is itself written as a varint.
 
 | Wire type | Value | Payload |
 |-----------|------:|---------|
-| VARINT | 0 | unsigned varint |
+| VARINT | 0 | unsigned varint (variable-length integer) |
 | I64    | 1 | exactly 8 bytes, little-endian |
-| LEN    | 2 | varint length `n` + `n` bytes |
+| LEN    | 2 | a length (as a varint) `n`, then exactly `n` bytes |
 | I32    | 5 | exactly 4 bytes, little-endian |
 
-Example tag strip for `id = 1` (field 1, varint):
+Example tag strip for `id = 1` (field 1, varint payload):
 
 ```
 08 01
@@ -47,7 +55,7 @@ Example tag strip for `id = 1` (field 1, varint):
 key = (1<<3) | 0
 ```
 
-Nested message example (field 3 = manager with `id=2`):
+Nested message example (field 3 is a manager whose only content is `id = 2`):
 
 ```
 1a       02       08       02
@@ -58,9 +66,9 @@ Nested message example (field 3 = manager with `id=2`):
 outer key = (3<<3)|2 = 0x1a (field 3, LEN)
 ```
 
-(Wire types 3/4 are legacy group markers — avoid.)
+Wire types 3 and 4 are legacy “group” markers. Avoid them in new designs.
 
-**Teaching mini-message** (not a full suite fixture / `benchmark_data.proto`):
+**Teaching mini-message** (not a full suite fixture and not `benchmark_data.proto`):
 
 ```protobuf
 syntax = "proto3";
@@ -84,7 +92,7 @@ Example: field `1`, wire type VARINT (0) → key = `(1 << 3) | 0` = `8` = `0x08`
 
 Field `2`, LEN (2) → key = `(2 << 3) | 2` = `18` = `0x12`.
 
-The key is itself a **varint**. For field numbers **1–15**, a single-byte key is common (the low 4 bits of the field number fit with the 3-bit wire type). For field number **≥ 16**, the key needs more than one byte:
+The key is itself a **varint**. For field numbers **1–15**, a single-byte key is common, because the low four bits of the field number fit beside the three-bit wire type. For field number **16 or higher**, the key needs more than one byte:
 
 | Field | Wire type | key value | Hex (key only) |
 |------:|----------:|----------:|----------------|
@@ -94,8 +102,12 @@ The key is itself a **varint**. For field numbers **1–15**, a single-byte key 
 
 ### 2. Encode a varint (unsigned base-128)
 
-While value ≥ 128: emit `(value & 0x7f) | 0x80`, then `value >>= 7`.  
-Finally emit the last 7-bit group with high bit clear.
+A **varint** (variable-length integer) stores an unsigned integer in base-128 groups. Each byte carries seven data bits. The high bit of a byte means “more bytes follow.”
+
+Algorithm:
+
+1. While the value is at least 128: emit `(value & 0x7f) | 0x80`, then shift the value right by seven bits.  
+2. Finally emit the last seven-bit group with the high bit cleared.
 
 | Decimal | Hex bytes (illustrative) |
 |--------:|--------------------------|
@@ -104,68 +116,68 @@ Finally emit the last 7-bit group with high bit clear.
 | 128 | `80 01` |
 | 300 | `ac 02` |
 
-Signed **int32/int64** in proto3 use ordinary varints of their two’s-complement bit pattern (large magnitudes for negatives). **sint32/sint64** use zigzag; this course’s mini subset avoids sint unless you extend the lab.
+Signed **int32** / **int64** in proto3 use ordinary varints of their two’s-complement bit pattern. Negative values therefore expand to many bytes. **sint32** / **sint64** use **zigzag** encoding so that small negatives become small varints. This course’s mini subset avoids `sint` unless you extend the lab yourself.
 
 | Type | Logical −1 (illustrative) | Idea |
 |------|---------------------------|------|
-| `int32` / `int64` | many `ff` bytes as unsigned varint of two’s complement | Expensive for negatives |
-| `sint32` / `sint64` | zigzag → small varint (e.g. `01` for −1) | Prefer when negatives are common |
+| `int32` / `int64` | many `ff` bytes as the unsigned varint of two’s complement | Expensive when negatives are common |
+| `sint32` / `sint64` | zigzag maps −1 to a small varint (for example `01`) | Prefer when negatives are common |
 
-**bool:** `false` → often omitted in proto3 (default); `true` → tag + varint `01`.  
-**enum:** encoded as varint of the numeric value.
+**bool:** `false` is often omitted in proto3 (it is the default); `true` is a tag plus the varint `01`.  
+**enum:** encoded as the varint of the numeric enum value.
 
 #### Varint failure modes (codec concerns)
 
-A correct decoder must not assume “integers are small” or “the buffer is well-formed”:
+A correct decoder must not assume that “integers are small” or that “the buffer is well-formed”:
 
 | Failure | What goes wrong |
 |---------|-----------------|
-| **Truncated mid-varint** | High bit set on last available byte; need more input |
-| **Overlong encoding** | Value that fits in fewer bytes encoded with extra continuation bytes; reject or define policy |
-| **Too many continuation bytes** | Cap (e.g. 10 bytes for 64-bit); otherwise DoS via endless `0x80` stream |
-| **Truncated fixed / LEN** | Not enough bytes for 4/8 or for `n` payload bytes after length |
+| **Truncated mid-varint** | The high bit is set on the last available byte, so more input is required but the stream ended |
+| **Overlong encoding** | A value that fits in fewer bytes is written with extra continuation bytes; reject it or define a clear policy |
+| **Too many continuation bytes** | Cap the length (for example ten bytes for a 64-bit value); otherwise a hostile stream of `0x80` bytes can become a denial-of-service |
+| **Truncated fixed or LEN** | Not enough bytes remain for 4/8 fixed bytes, or for `n` payload bytes after a length prefix |
 
-Hostile payloads are an operational topic in [301 untrusted input](../301/untrusted-input.md); bounds belong in the decoder itself.
+Hostile payloads as an operational problem are covered in [301 untrusted input](../301/untrusted-input.md). Bounds checks still belong inside the decoder itself.
 
-### 3. Length-delimited (wire type 2)
+### 3. Length-delimited fields (wire type 2, often called LEN)
 
-**On the wire** the field is always:
+**On the wire** a length-delimited field is always:
 
 ```text
   [ key ][ len ][ payload bytes… ]
 ```
 
-**When encoding**, you usually stage the payload first so you know `len`:
+**When encoding**, you usually stage the payload first so you know `len` before you write it:
 
-1. Build payload bytes (UTF-8 string, raw bytes, or nested message encoding) in a temporary buffer.  
-2. Emit key with wire type 2.  
-3. Emit varint **length** of that payload.  
+1. Build the payload bytes (UTF-8 for a string, raw bytes, or a nested message encoding) in a temporary buffer.  
+2. Emit the key with wire type 2.  
+3. Emit the **length** of that payload as a varint.  
 4. Emit the payload bytes.
 
-Do not emit length *after* the payload on the wire—only after you have computed it.
+Do not emit the length *after* the payload on the wire. Staging the payload in memory first is fine; the on-wire order is always key, then length, then payload.
 
 ### 4. Nested message
 
-A nested message is **just another length-delimited blob** whose payload is itself a valid message encoding (concatenation of its fields). There is no special “nest” wire type.
+A nested message is **just another length-delimited blob**. Its payload is itself a valid message encoding—the concatenation of that nested message’s fields. There is no special “nest” wire type.
 
 ### 5. Repeated fields
 
-**Unpacked** (lab default): for `repeated uint32 tags = 4`, emit **one complete field** (key + varint) **per element**. Same key may appear multiple times.
+**Unpacked** (the lab default): for `repeated uint32 tags = 4`, emit **one complete field** (key plus varint value) **per element**. The same key may appear multiple times in one message.
 
-Example `tags = [1, 2]` only:
+Example for `tags = [1, 2]` only:
 
 ```
 20 01 20 02
 ^^ ^^ ^^ ^^
 |  |  |  value 2
-|  |  key field 4 VARINT again
+|  |  key for field 4, VARINT, again
 |  value 1
 key (4<<3)|0 = 0x20
 ```
 
-**Packed** (proto3 default for many generators on primitive numeric repeated): a **single** length-delimited field whose payload is the concatenation of element encodings—no per-element tags inside.
+**Packed** (the proto3 default that many code generators use for primitive numeric repeated fields): a **single** length-delimited field whose payload is the concatenation of element encodings. There are no per-element tags inside the packed block.
 
-Example same logical `tags = [1, 2]` as packed (field 4, LEN):
+Example for the same logical `tags = [1, 2]` as packed (field 4, LEN):
 
 ```
 22       02       01 02
@@ -194,7 +206,7 @@ while bytes remain:
   else: assign to schema field
 ```
 
-Skipping unknown fields requires understanding the wire type so you consume the correct number of bytes—**do not** assume fixed sizes. Always check that the buffer has enough remaining bytes before reading.
+Skipping unknown fields requires understanding the wire type so you consume the correct number of bytes. **Do not** assume every unknown field has a fixed size. Always check that the buffer has enough remaining bytes before you read.
 
 ### 7. Worked examples
 
@@ -221,39 +233,39 @@ Skipping unknown fields requires understanding the wire type so you consume the 
 
 **Full message:** `1a 02 08 02`
 
-Verify with any official parser that loads an equivalent `.proto` (see [lab](lab-mini-protobuf-encoder.md)).
+Verify these with any official parser that loads an equivalent `.proto` (see the [lab](lab-mini-protobuf-encoder.md)).
 
 ## In this suite
 
 | Asset | Role |
 |-------|------|
-| `schemas/v2/protobuf/benchmark_v2.proto` | Real multi-message suite schema—larger than MiniUser |
+| `schemas/v2/protobuf/benchmark_v2.proto` | Real multi-message suite schema—much larger than MiniUser |
 | [Python](protobuf-python.md) / [Rust](protobuf-rust-prost.md) / [C](protobuf-c-protobuf-c.md) | Language runtime implementations of **this** wire format |
-| [301 using this suite](../301/using-this-suite.md) | How not to misuse Results when comparing libs |
+| [301 using this suite](../301/using-this-suite.md) | How not to misuse Results when comparing libraries |
 
-Wire layout is language-agnostic; buffer ownership is covered in each language path article.
+Wire layout is language-agnostic. Buffer ownership (who allocates and who frees) is covered in each language-path article.
 
 ## Common mistakes
 
-- Putting field **names** on the wire (that is not classic Protobuf binary).  
-- Reusing field numbers after deletion without `reserved`.  
-- Forgetting length prefix on strings.  
-- Emitting length after payload on the wire (staging vs wire order).  
+- Putting field **names** on the wire (classic Protocol Buffers binary does not do that).  
+- Reusing field numbers after deletion without marking them `reserved`.  
+- Forgetting the length prefix on strings.  
+- Emitting the length after the payload on the wire (confusing staging order with wire order).  
 - Treating message field order as semantically required (encoders may differ; decoders must accept any order).  
 - Decoding without a skip path for unknown tags.  
-- Reading LEN/`n` or fixed widths without checking remaining buffer length.
+- Reading a LEN length `n` or a fixed width without checking remaining buffer length.
 
 ## What this article is not
 
 - A full proto3 language guide (maps, oneofs, extensions, editions, JSON mapping).  
-- gRPC framing (length-prefixed HTTP/2 messages **wrap** Protobuf payloads).  
-- Buffer ownership per language (see language path articles).  
-- A security playbook—see [301 untrusted input](../301/untrusted-input.md) for hostile operational controls; varint/LEN bounds above are the codec side.
+- gRPC framing (length-prefixed HTTP/2 messages **wrap** Protocol Buffers payloads; they are not the payload itself).  
+- Buffer ownership per language (see the language-path articles).  
+- A security playbook—see [301 untrusted input](../301/untrusted-input.md) for hostile operational controls. The varint and LEN bounds above are the codec-side half of that story.
 
 ## Key takeaways
 
-- Protobuf binary = **tagged fields**; key = `(number << 3) | wire_type` (key is a varint; large field numbers multi-byte).  
-- Payloads are varint, fixed 32/64, or length-delimited (`key | len | payload` on the wire).  
-- Nested messages are length-delimited messages; repeated unpacked = repeated tags; packed = one LEN of concatenated elements.  
-- Unknown fields are skipped by wire type—foundation of evolution.  
-- Language paths apply these bytes via codegen runtimes; the lab builds a subset by hand.
+- Protocol Buffers binary is a stream of **tagged fields**. The key is `(number << 3) | wire_type`, written as a varint; large field numbers need more than one key byte.  
+- Payloads are varints, fixed 32/64-bit values, or length-delimited blobs (`key | len | payload` on the wire).  
+- Nested messages are length-delimited messages. Unpacked repeated fields repeat tags; packed repeated fields use one LEN of concatenated elements.  
+- Unknown fields are skipped by wire type—that rule is the foundation of additive evolution.  
+- Language-path articles show how code-generated runtimes apply these bytes; the lab builds a small subset by hand.


### PR DESCRIPTION
## Summary
- Rewrite all Serialization **101–401** theory articles in clear, complete sentences for students seeing the material a second or third time (not telegraphic expert shorthand)
- Expand jargon lightly on first use; keep technical accuracy, section structure, links, Colab badges, 301 Experiments/Metrics, and 401 golden hex / algorithms
- Fix engineering perspective: Colab badge no longer nested inside a Python code fence

## Validation
- Tests: analysis (55 pass), python (29 pass), javascript (9 pass), rust (6 pass); Java/Maven not on host (warn only)
- Benchmarks: **skipped** — no harness language changes (`detect-changed-langs` → none); docs-only
- Error CSVs: n/a (no re-bench)
- Analysis: n/a (no re-bench)
- Dashboard: `sync-data.py` ran; identical-size gzip recompress churn not committed

## Notes
- 43 markdown files under `docs/theory/{101,201,301,401}/`
- Honesty rules unchanged: prose numbers are illustrative; suite Results remain harness truth