### PR TITLE
docs: map README audiences to Serialization 101–401

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Scientific, multi-language suite for **measuring and comparing serialization libraries**.
 
-- [Serialization 101](https://leo-gan.github.io/GLD.SerializerBenchmark/theory/101/) — a starting point for anyone who wants to understand data serialization—students, data scientists, backend engineers, and systems architects.
+- [Serialization 101-401](https://leo-gan.github.io/GLD.SerializerBenchmark/theory/101/) — a starting point for anyone who wants to understand data serialization—students, data scientists, backend engineers, and systems architects.
 - [Benchmarks](https://leo-gan.github.io/GLD.SerializerBenchmark/analysis/)
 - [📊 Dashboard](https://leo-gan.github.io/GLD.SerializerBenchmark/dashboard/)
 
@@ -10,12 +10,12 @@ Scientific, multi-language suite for **measuring and comparing serialization lib
 
 ## Who it is for
 
-| Audience | Use case |
-|----------|----------|
-| **Computer Science Students** | Theory, history, examples |
-| **Researchers** | Reproducible methods, CIs, configurable payloads, metrics |
-| **Serializer authors** | Measure, compare, and improve |
-| **System integrators** | Find serializers that fit custom payloads and environments |
+| Audience | Use case | Course |
+|----------|----------|--------|
+| **Computer Science Students** | Theory, history, examples | [101](https://leo-gan.github.io/GLD.SerializerBenchmark/theory/101/),  [201](https://leo-gan.github.io/GLD.SerializerBenchmark/theory/201/) |
+| **System integrators** | Find serializers that fit payloads and environments | [301](https://leo-gan.github.io/GLD.SerializerBenchmark/theory/301/) |
+| **Researchers** | Research, measure, invent | [301](https://leo-gan.github.io/GLD.SerializerBenchmark/theory/301/) |
+| **Serializer authors** | Measure, compare, and improve | [401](https://leo-gan.github.io/GLD.SerializerBenchmark/theory/401/) |
 
 ---
 


### PR DESCRIPTION
## Summary
- Rename the Serialization 101 link to **101–401** on the root README.
- Add a **Course** column on the audience table with links to the matching theory tracks (101/201, 301, 401).

## Validation
- Tests: analysis (57), python (29), js (8), rust (10) — pass
- Benchmarks: skipped (README-only; no harness changes)
- Error CSVs: n/a
- Dashboard: `sync-data.py` (no churn expected for docs-only)