### PR TITLE
docs: theory diagrams and dashboard UX polish

### DIFF
--- a/dashboard/index.css
+++ b/dashboard/index.css
@@ -419,7 +419,26 @@ select:focus {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
+  justify-content: flex-start;
   gap: 0.6rem;
+}
+
+/* Keep language + serializer + Add as a tight group (do not stretch the
+   serializer wrapper — a flex:1 wrapper left the custom ::after chevron
+   stranded at the far right of the row). */
+.cross-lang-add-row .select-wrapper {
+  flex: 0 0 auto;
+}
+
+.cross-lang-add-row .xl-add-ser-wrap select {
+  min-width: 12rem;
+  max-width: 22rem;
+}
+
+.cross-lang-add-row .xl-add-btn {
+  flex: 0 0 auto;
+  font-size: 0.85rem;
+  border: 1px solid var(--border-color);
 }
 
 .xl-chips {

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -4,7 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Interactive dashboard presenting performance analytics, trade-offs, and comparisons for serialization libraries.">
-  <title>Serializer Benchmark Analytics Dashboard</title>
+  <title>Serializer Analytics dashboard</title>
+  <link rel="icon" href="./favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="./index.css">
   <!-- Chart.js from CDN -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
@@ -14,7 +15,7 @@
   <header>
     <div class="logo">
       <div class="logo-icon">📊</div>
-      <h1>Serializer Analytics</h1>
+      <h1>Serializer Analytics dashboard</h1>
     </div>
     <ul class="nav-links">
       <li><a href="../" id="nav-docs-link" style="margin-right: 0.75rem; border: 1px solid var(--border-color); font-weight: 500;">← Back to Docs</a></li>
@@ -232,10 +233,10 @@
         <div class="select-wrapper">
           <select id="xl-add-lang" aria-label="Language to add"></select>
         </div>
-        <div class="select-wrapper" style="min-width: 12rem; flex: 1;">
+        <div class="select-wrapper xl-add-ser-wrap">
           <select id="xl-add-serializer" aria-label="Serializer to add"></select>
         </div>
-        <button type="button" id="xl-add-btn" class="tab-btn" style="font-size: 0.85rem; border: 1px solid var(--border-color);">
+        <button type="button" id="xl-add-btn" class="tab-btn xl-add-btn">
           Add
         </button>
       </div>

--- a/dashboard/public/favicon.svg
+++ b/dashboard/public/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="Serializer Analytics">
+  <!-- Compact bar-chart mark; indigo matches dashboard accent -->
+  <rect width="32" height="32" rx="6" fill="#1a73e8"/>
+  <rect x="6" y="18" width="4.5" height="8" rx="1" fill="#ffffff"/>
+  <rect x="13.75" y="11" width="4.5" height="15" rx="1" fill="#ffffff"/>
+  <rect x="21.5" y="7" width="4.5" height="19" rx="1" fill="#e8f0fe"/>
+</svg>

--- a/docs/theory/101/index.md
+++ b/docs/theory/101/index.md
@@ -19,6 +19,9 @@ Theory alone does not decide production choices. Use this course to build vocabu
 
 Memory is a web of pointers and types. The network and the disk only understand bytes. Every format is a **contract** between a writer and a reader about how that collapse and rebuild work.
 
+![Serialization as a contract: in memory, on the wire, rebuilt](../assets/diagrams/101-serialize-contract.svg#only-light)
+![Serialization as a contract: in memory, on the wire, rebuilt](../assets/diagrams/101-serialize-contract-dark.svg#only-dark)
+
 ---
 
 ## Three lenses

--- a/docs/theory/201/memory-layout.md
+++ b/docs/theory/201/memory-layout.md
@@ -98,6 +98,9 @@ Consider three logical fields:
 
 **Layout 1 — order `flag`, `id`, `score` (typical 64-bit C-like padding):**
 
+![In-memory layout with padding: flag, pad, id, score](../assets/diagrams/201-memory-padding.svg#only-light)
+![In-memory layout with padding: flag, pad, id, score](../assets/diagrams/201-memory-padding-dark.svg#only-dark)
+
 ```text
   offset  0:  flag          [1 byte]
   offset  1:  pad pad pad   [3 bytes]   ← so that id begins at a multiple of 4
@@ -199,12 +202,8 @@ A multi-byte integer is stored as **several bytes in a defined order**. Two comm
 
 **Example:** 32-bit value `0x12345678` (decimal 305 419 896):
 
-```text
-  Increasing addresses →
-
-  Big-endian:     12  34  56  78
-  Little-endian:  78  56  34  12
-```
+![Endianness: big-endian vs little-endian byte order for 0x12345678](../assets/diagrams/201-endianness.svg#only-light)
+![Endianness: big-endian vs little-endian byte order for 0x12345678](../assets/diagrams/201-endianness-dark.svg#only-dark)
 
 If a little-endian writer emits those four bytes and a big-endian reader loads them as a native integer **without conversion**, the reader obtains a different numeric value. Network protocols historically adopted a **network byte order**; classical Internet Protocol stacks used big-endian. Every serialization format must **document** endianness—or avoid host integers as the interchange unit (for example by using decimal text in JSON). See also the [historical perspective](../101/historical_perspective.md).
 

--- a/docs/theory/201/self-describing-vs-schema-dependent.md
+++ b/docs/theory/201/self-describing-vs-schema-dependent.md
@@ -24,21 +24,8 @@ Self-describing formats typically trade larger size and extra parsing work for i
 
 ## Mental model
 
-```text
-  Self-describing (illustrative JSON)     Schema-dependent (illustrative)
-  ┌──────────────────────────┐           ┌──────────────────────────┐
-  │ {"user_id": 42,          │           │ Shared schema / IDL      │
-  │  "name": "Ada"}          │           │   1 → user_id (integer)  │
-  │  names and values        │           │   2 → name (string)      │
-  │  travel together         │           └────────────┬─────────────┘
-  └──────────────────────────┘                        │
-                                                      ▼
-                                         ┌──────────────────────────┐
-                                         │ Compact bytes using      │
-                                         │ field numbers / layout   │
-                                         │ (names not repeated)     │
-                                         └──────────────────────────┘
-```
+![Self-describing payload versus schema-dependent encoding](../assets/diagrams/201-self-describing-vs-schema.svg#only-light)
+![Self-describing payload versus schema-dependent encoding](../assets/diagrams/201-self-describing-vs-schema-dark.svg#only-dark)
 
 “Self-describing” is a spectrum, not a single switch. JSON prioritizes human inspection. MessagePack remains machine-oriented yet still carries tags and often keys. Operational deployments that ship descriptor sets alongside Protocol Buffers are hybrid arrangements; they are not the minimal on-the-wire encoding.
 

--- a/docs/theory/201/zero-copy.md
+++ b/docs/theory/201/zero-copy.md
@@ -18,18 +18,8 @@ Encoding still requires work to **construct** that layout. **Validation** of unt
 
 ## Mental model
 
-```text
-  Classical path                      Zero-copy style path
-  ──────────────                      ────────────────────
-  network buffer                      network buffer
-       │                                   │
-       ▼                                   │ structural verification
-  parse and allocate                       │ (required for untrusted data)
-       │                                   ▼
-       ▼                              accessors / views
-  object graph  ←── application ──   (read fields at offsets
-  (independent copy)     reads        into the same buffer)
-```
+![Classical deserialize path versus zero-copy accessors](../assets/diagrams/201-zero-copy.svg#only-light)
+![Classical deserialize path versus zero-copy accessors](../assets/diagrams/201-zero-copy-dark.svg#only-dark)
 
 **Information versus materialization.** Interpreting bytes as typed fields *is* deserialization in the information-theoretic sense. What zero-copy designs avoid is the classical step of **allocating a full data-transfer object graph** that mirrors the message.
 

--- a/docs/theory/301/trust-boundaries.md
+++ b/docs/theory/301/trust-boundaries.md
@@ -34,18 +34,8 @@ This page assumes the 201 article on [self-describing vs schema](../201/self-des
 
 Ask one primary question first: **do these bytes leave this process or trust domain?**
 
-```text
-  Do bytes leave this process / trust domain?
-        │
-   no   │   yes
-        │    │
-        ▼    ▼
-   Native    Portable format required
-   may be    (choose the family with 101/201
-   OK if      knowledge and the category guide)
-   peers are
-   trusted
-```
+![Trust boundaries: process, service estate, public untrusted](../assets/diagrams/301-trust-boundaries.svg#only-light)
+![Trust boundaries: process, service estate, public untrusted](../assets/diagrams/301-trust-boundaries-dark.svg#only-dark)
 
 If the answer is yes, a portable format is required. If the answer is no, a native format may still be acceptable—only when every peer is trusted and the lock-in is documented.
 

--- a/docs/theory/401/protobuf-wire-format.md
+++ b/docs/theory/401/protobuf-wire-format.md
@@ -57,6 +57,9 @@ key = (1<<3) | 0
 
 Nested message example (field 3 is a manager whose only content is `id = 2`):
 
+![Annotated MiniUser nested wire strip](../assets/diagrams/401-miniuser-wire.svg#only-light)
+![Annotated MiniUser nested wire strip](../assets/diagrams/401-miniuser-wire-dark.svg#only-dark)
+
 ```
 1a       02       08       02
 ^^       ^^       ^^       ^^
@@ -103,6 +106,9 @@ The key is itself a **varint**. For field numbers **1–15**, a single-byte key 
 ### 2. Encode a varint (unsigned base-128)
 
 A **varint** (variable-length integer) stores an unsigned integer in base-128 groups. Each byte carries seven data bits. The high bit of a byte means “more bytes follow.”
+
+![Varint bit layout for decimal 300](../assets/diagrams/401-varint.svg#only-light)
+![Varint bit layout for decimal 300](../assets/diagrams/401-varint-dark.svg#only-dark)
 
 Algorithm:
 

--- a/docs/theory/assets/diagrams/101-serialize-contract-dark.svg
+++ b/docs/theory/assets/diagrams/101-serialize-contract-dark.svg
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 360" width="1000" height="360" role="img" aria-labelledby="title desc">
+  <title id="title">Serialization as a contract</title>
+  <desc id="desc">In-memory structure becomes a linear byte sequence; deserialization rebuilds a local structure under an agreed format contract. Dark-mode palette.</desc>
+
+  <!--
+    Dark palette (Material slate + indigo). Same geometry as 101-serialize-contract.svg.
+    No gradients, no shadows. Keep in sync with the light twin when editing layout.
+  -->
+  <defs>
+    <style type="text/css"><![CDATA[
+      .bg { fill: #1a1a1a; }
+      .panel { fill: #242424; stroke: #5c6bc0; stroke-width: 1.5; stroke-opacity: 0.55; }
+      .label { font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; fill: #e0e0e0; }
+      .title { font-size: 15px; font-weight: 600; letter-spacing: 0.02em; }
+      .caption { font-size: 12px; fill: #90a4ae; }
+      .node { fill: #2c2c2c; stroke: #9fa8da; stroke-width: 1.75; }
+      .node-fill { fill: #303f9f; stroke: #9fa8da; stroke-width: 1.75; fill-opacity: 0.45; }
+      .edge { stroke: #9fa8da; stroke-width: 1.5; fill: none; }
+      .byte { fill: #303f9f; stroke: #9fa8da; stroke-width: 1.25; fill-opacity: 0.4; }
+      .byte-text { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 11px; fill: #c5cae9; text-anchor: middle; }
+      .arrow { stroke: #b0bec5; stroke-width: 1.75; fill: none; marker-end: url(#arrowhead); }
+      /*
+       * Action verbs (diagram display labels).
+       * Same type treatment as light twin; light fill for dark surface.
+       */
+      .arrow-label {
+        font-family: "Liberation Sans", "DejaVu Sans", "Helvetica Neue", Arial, sans-serif;
+        font-size: 15px;
+        font-weight: 400;
+        letter-spacing: 0.05em;
+        fill: #eceff1;
+        text-anchor: middle;
+      }
+      .contract { font-size: 11px; fill: #78909c; text-anchor: middle; letter-spacing: 0.04em; }
+    ]]></style>
+    <marker id="arrowhead" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#b0bec5"/>
+    </marker>
+  </defs>
+
+  <rect class="bg" width="1000" height="360"/>
+
+  <!-- Panel 1: in memory -->
+  <rect class="panel" x="28" y="48" width="250" height="260" rx="10"/>
+  <text class="label title" x="48" y="78">In memory</text>
+  <text class="label caption" x="48" y="98">pointers · types · padding</text>
+
+  <!-- simple object graph: root + two children -->
+  <rect class="node-fill" x="113" y="120" width="80" height="36" rx="6"/>
+  <text class="label" x="153" y="143" text-anchor="middle" font-size="13">Record</text>
+
+  <line class="edge" x1="135" y1="156" x2="90" y2="190"/>
+  <line class="edge" x1="171" y1="156" x2="215" y2="190"/>
+
+  <rect class="node" x="50" y="190" width="80" height="36" rx="6"/>
+  <text class="label" x="90" y="213" text-anchor="middle" font-size="13">Field A</text>
+
+  <rect class="node" x="175" y="190" width="80" height="36" rx="6"/>
+  <text class="label" x="215" y="213" text-anchor="middle" font-size="13">Field B</text>
+
+  <text class="label caption" x="153" y="270" text-anchor="middle">one process image</text>
+
+  <!-- Arrow serialize (~80px, matches shorter label) -->
+  <line class="arrow" x1="292" y1="178" x2="372" y2="178"/>
+  <text class="arrow-label" x="332" y="164">serialize</text>
+
+  <!-- Panel 2: on the wire -->
+  <rect class="panel" x="386" y="48" width="250" height="260" rx="10"/>
+  <text class="label title" x="406" y="78">On the wire</text>
+  <text class="label caption" x="406" y="98">linear bytes · agreed order</text>
+
+  <!-- byte strip -->
+  <g transform="translate(413, 168)">
+    <rect class="byte" x="0" y="0" width="36" height="36" rx="4"/>
+    <rect class="byte" x="40" y="0" width="36" height="36" rx="4"/>
+    <rect class="byte" x="80" y="0" width="36" height="36" rx="4"/>
+    <rect class="byte" x="120" y="0" width="36" height="36" rx="4"/>
+    <rect class="byte" x="160" y="0" width="36" height="36" rx="4"/>
+    <text class="byte-text" x="18" y="23">a1</text>
+    <text class="byte-text" x="58" y="23">b2</text>
+    <text class="byte-text" x="98" y="23">c3</text>
+    <text class="byte-text" x="138" y="23">d4</text>
+    <text class="byte-text" x="178" y="23">…</text>
+  </g>
+
+  <text class="label caption" x="511" y="240" text-anchor="middle">network · disk · cache</text>
+  <text class="contract" x="511" y="275">FORMAT CONTRACT</text>
+
+  <!-- Arrow deserialize (~112px, matches longer label) -->
+  <line class="arrow" x1="650" y1="178" x2="762" y2="178"/>
+  <text class="arrow-label" x="706" y="164">deserialize</text>
+
+  <!-- Panel 3: rebuilt -->
+  <rect class="panel" x="776" y="48" width="200" height="260" rx="10"/>
+  <text class="label title" x="792" y="78">Rebuilt</text>
+  <text class="label caption" x="792" y="98">local objects or views</text>
+
+  <rect class="node-fill" x="836" y="120" width="80" height="36" rx="6"/>
+  <text class="label" x="876" y="143" text-anchor="middle" font-size="13">Record</text>
+
+  <line class="edge" x1="856" y1="156" x2="822" y2="190"/>
+  <line class="edge" x1="896" y1="156" x2="930" y2="190"/>
+
+  <rect class="node" x="782" y="190" width="80" height="36" rx="6"/>
+  <text class="label" x="822" y="213" text-anchor="middle" font-size="13">Field A</text>
+
+  <rect class="node" x="890" y="190" width="80" height="36" rx="6"/>
+  <text class="label" x="930" y="213" text-anchor="middle" font-size="13">Field B</text>
+
+  <text class="label caption" x="876" y="270" text-anchor="middle">maybe another language</text>
+</svg>

--- a/docs/theory/assets/diagrams/101-serialize-contract.svg
+++ b/docs/theory/assets/diagrams/101-serialize-contract.svg
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 360" width="1000" height="360" role="img" aria-labelledby="title desc">
+  <title id="title">Serialization as a contract</title>
+  <desc id="desc">In-memory structure becomes a linear byte sequence; deserialization rebuilds a local structure under an agreed format contract.</desc>
+
+  <!--
+    Light palette (slate + indigo). Twin: 101-serialize-contract-dark.svg
+    Same geometry — keep layout in sync when editing. No gradients, no shadows.
+  -->
+  <defs>
+    <style type="text/css"><![CDATA[
+      .bg { fill: #fafafa; }
+      .panel { fill: #ffffff; stroke: #c5cae9; stroke-width: 1.5; }
+      .label { font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; fill: #37474f; }
+      .title { font-size: 15px; font-weight: 600; letter-spacing: 0.02em; }
+      .caption { font-size: 12px; fill: #607d8b; }
+      .node { fill: #ffffff; stroke: #5c6bc0; stroke-width: 1.75; }
+      .node-fill { fill: #e8eaf6; stroke: #5c6bc0; stroke-width: 1.75; }
+      .edge { stroke: #5c6bc0; stroke-width: 1.5; fill: none; }
+      .byte { fill: #e8eaf6; stroke: #5c6bc0; stroke-width: 1.25; }
+      .byte-text { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 11px; fill: #283593; text-anchor: middle; }
+      .arrow { stroke: #455a64; stroke-width: 1.75; fill: none; marker-end: url(#arrowhead); }
+      /*
+       * Action verbs (diagram display labels).
+       * Avoid system-ui + heavy weight at enlarged size (looks blocky).
+       * Liberation/DejaVu render cleanly; open tracking suits long words.
+       */
+      .arrow-label {
+        font-family: "Liberation Sans", "DejaVu Sans", "Helvetica Neue", Arial, sans-serif;
+        font-size: 15px;
+        font-weight: 400;
+        letter-spacing: 0.05em;
+        fill: #263238;
+        text-anchor: middle;
+      }
+      .contract { font-size: 11px; fill: #78909c; text-anchor: middle; letter-spacing: 0.04em; }
+    ]]></style>
+    <marker id="arrowhead" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#455a64"/>
+    </marker>
+  </defs>
+
+  <rect class="bg" width="1000" height="360"/>
+
+  <!-- Panel 1: in memory -->
+  <rect class="panel" x="28" y="48" width="250" height="260" rx="10"/>
+  <text class="label title" x="48" y="78">In memory</text>
+  <text class="label caption" x="48" y="98">pointers · types · padding</text>
+
+  <!-- simple object graph: root + two children -->
+  <rect class="node-fill" x="113" y="120" width="80" height="36" rx="6"/>
+  <text class="label" x="153" y="143" text-anchor="middle" font-size="13">Record</text>
+
+  <line class="edge" x1="135" y1="156" x2="90" y2="190"/>
+  <line class="edge" x1="171" y1="156" x2="215" y2="190"/>
+
+  <rect class="node" x="50" y="190" width="80" height="36" rx="6"/>
+  <text class="label" x="90" y="213" text-anchor="middle" font-size="13">Field A</text>
+
+  <rect class="node" x="175" y="190" width="80" height="36" rx="6"/>
+  <text class="label" x="215" y="213" text-anchor="middle" font-size="13">Field B</text>
+
+  <text class="label caption" x="153" y="270" text-anchor="middle">one process image</text>
+
+  <!-- Arrow serialize (~80px, matches shorter label) -->
+  <line class="arrow" x1="292" y1="178" x2="372" y2="178"/>
+  <text class="arrow-label" x="332" y="164">serialize</text>
+
+  <!-- Panel 2: on the wire -->
+  <rect class="panel" x="386" y="48" width="250" height="260" rx="10"/>
+  <text class="label title" x="406" y="78">On the wire</text>
+  <text class="label caption" x="406" y="98">linear bytes · agreed order</text>
+
+  <!-- byte strip -->
+  <g transform="translate(413, 168)">
+    <rect class="byte" x="0" y="0" width="36" height="36" rx="4"/>
+    <rect class="byte" x="40" y="0" width="36" height="36" rx="4"/>
+    <rect class="byte" x="80" y="0" width="36" height="36" rx="4"/>
+    <rect class="byte" x="120" y="0" width="36" height="36" rx="4"/>
+    <rect class="byte" x="160" y="0" width="36" height="36" rx="4"/>
+    <text class="byte-text" x="18" y="23">a1</text>
+    <text class="byte-text" x="58" y="23">b2</text>
+    <text class="byte-text" x="98" y="23">c3</text>
+    <text class="byte-text" x="138" y="23">d4</text>
+    <text class="byte-text" x="178" y="23">…</text>
+  </g>
+
+  <text class="label caption" x="511" y="240" text-anchor="middle">network · disk · cache</text>
+  <text class="contract" x="511" y="275">FORMAT CONTRACT</text>
+
+  <!-- Arrow deserialize (~112px, matches longer label) -->
+  <line class="arrow" x1="650" y1="178" x2="762" y2="178"/>
+  <text class="arrow-label" x="706" y="164">deserialize</text>
+
+  <!-- Panel 3: rebuilt -->
+  <rect class="panel" x="776" y="48" width="200" height="260" rx="10"/>
+  <text class="label title" x="792" y="78">Rebuilt</text>
+  <text class="label caption" x="792" y="98">local objects or views</text>
+
+  <rect class="node-fill" x="836" y="120" width="80" height="36" rx="6"/>
+  <text class="label" x="876" y="143" text-anchor="middle" font-size="13">Record</text>
+
+  <line class="edge" x1="856" y1="156" x2="822" y2="190"/>
+  <line class="edge" x1="896" y1="156" x2="930" y2="190"/>
+
+  <rect class="node" x="782" y="190" width="80" height="36" rx="6"/>
+  <text class="label" x="822" y="213" text-anchor="middle" font-size="13">Field A</text>
+
+  <rect class="node" x="890" y="190" width="80" height="36" rx="6"/>
+  <text class="label" x="930" y="213" text-anchor="middle" font-size="13">Field B</text>
+
+  <text class="label caption" x="876" y="270" text-anchor="middle">maybe another language</text>
+</svg>

--- a/docs/theory/assets/diagrams/201-endianness-dark.svg
+++ b/docs/theory/assets/diagrams/201-endianness-dark.svg
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 360" width="1000" height="360" role="img" aria-labelledby="title desc">
+  <title id="title">Endianness: big-endian vs little-endian</title>
+  <desc id="desc">The 32-bit value 0x12345678 shown as four bytes in big-endian and little-endian order with addresses increasing left to right.</desc>
+  <defs>
+    <style type="text/css"><![CDATA[
+      .label { font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; fill: #e0e0e0; }
+      .title { font-size: 15px; font-weight: 600; letter-spacing: 0.02em; }
+      .caption { font-size: 12px; fill: #90a4ae; }
+      .small { font-size: 11px; fill: #90a4ae; }
+      .row { font-size: 13px; font-weight: 600; }
+      .mono-lg { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 15px; fill: #c5cae9; }
+      .tag { font-size: 10px; fill: #90a4ae; }
+    ]]></style>
+    <marker id="arrowhead" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#b0bec5"/>
+    </marker>
+  </defs>
+  <rect width="1000" height="360" fill="#1a1a1a"/>
+  <rect x="40" y="28" width="920" height="304" rx="10" fill="#242424" stroke="#5c6bc0" stroke-width="1.5" stroke-opacity="0.55"/>
+  <text class="label title" x="60" y="60">Endianness — byte order of a multi-byte integer</text>
+  <text class="label caption" x="60" y="80">Same value 0x12345678 · addresses increase left → right</text>
+  <text class="label row" x="60" y="118" fill="#e0e0e0">Big-endian (BE)</text>
+  <text class="label caption" x="60" y="138">most significant byte</text>
+  <text class="label caption" x="60" y="154">at lowest address</text>
+  <text class="tag" x="315.0" y="100" text-anchor="middle">addr +0</text>
+  <rect x="280" y="110" width="70" height="52" rx="6" fill="#1565c0" stroke="#9fa8da" stroke-width="1.5" fill-opacity="0.45"/>
+  <text class="mono-lg" x="315.0" y="134" text-anchor="middle">12</text>
+  <text class="tag" x="315.0" y="152" text-anchor="middle">MSB</text>
+  <text class="tag" x="397.0" y="100" text-anchor="middle">addr +1</text>
+  <rect x="362" y="110" width="70" height="52" rx="6" fill="#303f9f" stroke="#9fa8da" stroke-width="1.5" fill-opacity="0.45"/>
+  <text class="mono-lg" x="397.0" y="134" text-anchor="middle">34</text>
+  <text class="tag" x="479.0" y="100" text-anchor="middle">addr +2</text>
+  <rect x="444" y="110" width="70" height="52" rx="6" fill="#4527a0" stroke="#9fa8da" stroke-width="1.5" fill-opacity="0.45"/>
+  <text class="mono-lg" x="479.0" y="134" text-anchor="middle">56</text>
+  <text class="tag" x="561.0" y="100" text-anchor="middle">addr +3</text>
+  <rect x="526" y="110" width="70" height="52" rx="6" fill="#6a1b9a" stroke="#9fa8da" stroke-width="1.5" fill-opacity="0.45"/>
+  <text class="mono-lg" x="561.0" y="134" text-anchor="middle">78</text>
+  <text class="tag" x="561.0" y="152" text-anchor="middle">LSB</text>
+  <line x1="280" y1="180" x2="596" y2="180" stroke="#b0bec5" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <text class="tag" x="438.0" y="196" text-anchor="middle">increasing addresses</text>
+  <text class="label row" x="60" y="238" fill="#e0e0e0">Little-endian (LE)</text>
+  <text class="label caption" x="60" y="258">least significant byte</text>
+  <text class="label caption" x="60" y="274">at lowest address</text>
+  <text class="tag" x="315.0" y="220" text-anchor="middle">addr +0</text>
+  <rect x="280" y="230" width="70" height="52" rx="6" fill="#6a1b9a" stroke="#9fa8da" stroke-width="1.5" fill-opacity="0.45"/>
+  <text class="mono-lg" x="315.0" y="254" text-anchor="middle">78</text>
+  <text class="tag" x="315.0" y="272" text-anchor="middle">LSB</text>
+  <text class="tag" x="397.0" y="220" text-anchor="middle">addr +1</text>
+  <rect x="362" y="230" width="70" height="52" rx="6" fill="#4527a0" stroke="#9fa8da" stroke-width="1.5" fill-opacity="0.45"/>
+  <text class="mono-lg" x="397.0" y="254" text-anchor="middle">56</text>
+  <text class="tag" x="479.0" y="220" text-anchor="middle">addr +2</text>
+  <rect x="444" y="230" width="70" height="52" rx="6" fill="#303f9f" stroke="#9fa8da" stroke-width="1.5" fill-opacity="0.45"/>
+  <text class="mono-lg" x="479.0" y="254" text-anchor="middle">34</text>
+  <text class="tag" x="561.0" y="220" text-anchor="middle">addr +3</text>
+  <rect x="526" y="230" width="70" height="52" rx="6" fill="#1565c0" stroke="#9fa8da" stroke-width="1.5" fill-opacity="0.45"/>
+  <text class="mono-lg" x="561.0" y="254" text-anchor="middle">12</text>
+  <text class="tag" x="561.0" y="272" text-anchor="middle">MSB</text>
+  <line x1="280" y1="300" x2="596" y2="300" stroke="#b0bec5" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <text class="tag" x="438.0" y="316" text-anchor="middle">increasing addresses</text>
+  <rect x="720" y="110" width="210" height="172" rx="8" fill="#2c2c2c" stroke="#9fa8da" stroke-width="1.5"/>
+  <text class="label small" x="740" y="140" fill="#e0e0e0">Without conversion:</text>
+  <text class="label small" x="740" y="166" fill="#e0e0e0">LE writer → BE reader</text>
+  <text class="label small" x="740" y="190" fill="#e0e0e0">reads a different number.</text>
+  <text class="label caption" x="740" y="226">Formats must document</text>
+  <text class="label caption" x="740" y="244">byte order — or use</text>
+  <text class="label caption" x="740" y="262">text / self-describing tags.</text>
+</svg>

--- a/docs/theory/assets/diagrams/201-endianness.svg
+++ b/docs/theory/assets/diagrams/201-endianness.svg
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 360" width="1000" height="360" role="img" aria-labelledby="title desc">
+  <title id="title">Endianness: big-endian vs little-endian</title>
+  <desc id="desc">The 32-bit value 0x12345678 shown as four bytes in big-endian and little-endian order with addresses increasing left to right.</desc>
+  <defs>
+    <style type="text/css"><![CDATA[
+      .label { font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; fill: #37474f; }
+      .title { font-size: 15px; font-weight: 600; letter-spacing: 0.02em; }
+      .caption { font-size: 12px; fill: #607d8b; }
+      .small { font-size: 11px; fill: #607d8b; }
+      .row { font-size: 13px; font-weight: 600; }
+      .mono-lg { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 15px; fill: #283593; }
+      .tag { font-size: 10px; fill: #607d8b; }
+    ]]></style>
+    <marker id="arrowhead" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#455a64"/>
+    </marker>
+  </defs>
+  <rect width="1000" height="360" fill="#fafafa"/>
+  <rect x="40" y="28" width="920" height="304" rx="10" fill="#ffffff" stroke="#c5cae9" stroke-width="1.5"/>
+  <text class="label title" x="60" y="60">Endianness — byte order of a multi-byte integer</text>
+  <text class="label caption" x="60" y="80">Same value 0x12345678 · addresses increase left → right</text>
+  <text class="label row" x="60" y="118" fill="#37474f">Big-endian (BE)</text>
+  <text class="label caption" x="60" y="138">most significant byte</text>
+  <text class="label caption" x="60" y="154">at lowest address</text>
+  <text class="tag" x="315.0" y="100" text-anchor="middle">addr +0</text>
+  <rect x="280" y="110" width="70" height="52" rx="6" fill="#e3f2fd" stroke="#5c6bc0" stroke-width="1.5"/>
+  <text class="mono-lg" x="315.0" y="134" text-anchor="middle">12</text>
+  <text class="tag" x="315.0" y="152" text-anchor="middle">MSB</text>
+  <text class="tag" x="397.0" y="100" text-anchor="middle">addr +1</text>
+  <rect x="362" y="110" width="70" height="52" rx="6" fill="#e8eaf6" stroke="#5c6bc0" stroke-width="1.5"/>
+  <text class="mono-lg" x="397.0" y="134" text-anchor="middle">34</text>
+  <text class="tag" x="479.0" y="100" text-anchor="middle">addr +2</text>
+  <rect x="444" y="110" width="70" height="52" rx="6" fill="#ede7f6" stroke="#5c6bc0" stroke-width="1.5"/>
+  <text class="mono-lg" x="479.0" y="134" text-anchor="middle">56</text>
+  <text class="tag" x="561.0" y="100" text-anchor="middle">addr +3</text>
+  <rect x="526" y="110" width="70" height="52" rx="6" fill="#f3e5f5" stroke="#5c6bc0" stroke-width="1.5"/>
+  <text class="mono-lg" x="561.0" y="134" text-anchor="middle">78</text>
+  <text class="tag" x="561.0" y="152" text-anchor="middle">LSB</text>
+  <line x1="280" y1="180" x2="596" y2="180" stroke="#455a64" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <text class="tag" x="438.0" y="196" text-anchor="middle">increasing addresses</text>
+  <text class="label row" x="60" y="238" fill="#37474f">Little-endian (LE)</text>
+  <text class="label caption" x="60" y="258">least significant byte</text>
+  <text class="label caption" x="60" y="274">at lowest address</text>
+  <text class="tag" x="315.0" y="220" text-anchor="middle">addr +0</text>
+  <rect x="280" y="230" width="70" height="52" rx="6" fill="#f3e5f5" stroke="#5c6bc0" stroke-width="1.5"/>
+  <text class="mono-lg" x="315.0" y="254" text-anchor="middle">78</text>
+  <text class="tag" x="315.0" y="272" text-anchor="middle">LSB</text>
+  <text class="tag" x="397.0" y="220" text-anchor="middle">addr +1</text>
+  <rect x="362" y="230" width="70" height="52" rx="6" fill="#ede7f6" stroke="#5c6bc0" stroke-width="1.5"/>
+  <text class="mono-lg" x="397.0" y="254" text-anchor="middle">56</text>
+  <text class="tag" x="479.0" y="220" text-anchor="middle">addr +2</text>
+  <rect x="444" y="230" width="70" height="52" rx="6" fill="#e8eaf6" stroke="#5c6bc0" stroke-width="1.5"/>
+  <text class="mono-lg" x="479.0" y="254" text-anchor="middle">34</text>
+  <text class="tag" x="561.0" y="220" text-anchor="middle">addr +3</text>
+  <rect x="526" y="230" width="70" height="52" rx="6" fill="#e3f2fd" stroke="#5c6bc0" stroke-width="1.5"/>
+  <text class="mono-lg" x="561.0" y="254" text-anchor="middle">12</text>
+  <text class="tag" x="561.0" y="272" text-anchor="middle">MSB</text>
+  <line x1="280" y1="300" x2="596" y2="300" stroke="#455a64" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <text class="tag" x="438.0" y="316" text-anchor="middle">increasing addresses</text>
+  <rect x="720" y="110" width="210" height="172" rx="8" fill="#ffffff" stroke="#5c6bc0" stroke-width="1.5"/>
+  <text class="label small" x="740" y="140" fill="#37474f">Without conversion:</text>
+  <text class="label small" x="740" y="166" fill="#37474f">LE writer → BE reader</text>
+  <text class="label small" x="740" y="190" fill="#37474f">reads a different number.</text>
+  <text class="label caption" x="740" y="226">Formats must document</text>
+  <text class="label caption" x="740" y="244">byte order — or use</text>
+  <text class="label caption" x="740" y="262">text / self-describing tags.</text>
+</svg>

--- a/docs/theory/assets/diagrams/201-memory-padding-dark.svg
+++ b/docs/theory/assets/diagrams/201-memory-padding-dark.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 360" width="1000" height="360" role="img" aria-labelledby="title desc">
+  <title id="title">Memory layout with padding</title>
+  <desc id="desc">A 16-byte structure layout showing flag, padding, id, and score fields with example little-endian bytes.</desc>
+  <defs>
+    <style type="text/css"><![CDATA[
+      .label { font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; fill: #e0e0e0; }
+      .title { font-size: 15px; font-weight: 600; letter-spacing: 0.02em; }
+      .caption { font-size: 12px; fill: #90a4ae; }
+      .small { font-size: 11px; fill: #90a4ae; }
+      .mono { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 11px; fill: #c5cae9; }
+      .mono-lg { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 13px; fill: #c5cae9; }
+      .arrow-label {
+        font-family: "Liberation Sans", "DejaVu Sans", "Helvetica Neue", Arial, sans-serif;
+        font-size: 15px;
+        font-weight: 400;
+        letter-spacing: 0.05em;
+        fill: #eceff1;
+        text-anchor: middle;
+      }
+      .panel-title { font-size: 14px; font-weight: 600; }
+    ]]></style>
+    <marker id="arrowhead" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#b0bec5"/>
+    </marker>
+  </defs>
+  <rect width="1000" height="360" fill="#1a1a1a"/>
+  <rect x="40" y="40" width="920" height="280" rx="10" fill="#242424" stroke="#5c6bc0" stroke-width="1.5" stroke-opacity="0.55"/>
+  <text class="label title" x="60" y="72">In-memory layout with padding</text>
+  <text class="label caption" x="60" y="94">flag · id · score on a typical 64-bit C-like layout (little-endian example)</text>
+  <rect x="80" y="120" width="46" height="44" rx="4" fill="#1565c0" stroke="#9fa8da" stroke-width="1.25" fill-opacity="0.45"/>
+  <text class="mono" x="103.0" y="138" text-anchor="middle">01</text>
+  <text class="label small" x="103.0" y="156" text-anchor="middle" fill="#e0e0e0">F</text>
+  <text class="label small" x="103.0" y="112" text-anchor="middle">00</text>
+  <rect x="128" y="120" width="46" height="44" rx="4" fill="#37474f" stroke="#78909c" stroke-width="1.25"/>
+  <text class="mono" x="151.0" y="138" text-anchor="middle">00</text>
+  <text class="label small" x="151.0" y="156" text-anchor="middle" fill="#e0e0e0">p</text>
+  <text class="label small" x="151.0" y="112" text-anchor="middle">01</text>
+  <rect x="176" y="120" width="46" height="44" rx="4" fill="#37474f" stroke="#78909c" stroke-width="1.25"/>
+  <text class="mono" x="199.0" y="138" text-anchor="middle">00</text>
+  <text class="label small" x="199.0" y="156" text-anchor="middle" fill="#e0e0e0">p</text>
+  <text class="label small" x="199.0" y="112" text-anchor="middle">02</text>
+  <rect x="224" y="120" width="46" height="44" rx="4" fill="#37474f" stroke="#78909c" stroke-width="1.25"/>
+  <text class="mono" x="247.0" y="138" text-anchor="middle">00</text>
+  <text class="label small" x="247.0" y="156" text-anchor="middle" fill="#e0e0e0">p</text>
+  <text class="label small" x="247.0" y="112" text-anchor="middle">03</text>
+  <rect x="272" y="120" width="46" height="44" rx="4" fill="#303f9f" stroke="#9fa8da" stroke-width="1.25" fill-opacity="0.45"/>
+  <text class="mono" x="295.0" y="138" text-anchor="middle">2a</text>
+  <text class="label small" x="295.0" y="156" text-anchor="middle" fill="#e0e0e0">I</text>
+  <text class="label small" x="295.0" y="112" text-anchor="middle">04</text>
+  <rect x="320" y="120" width="46" height="44" rx="4" fill="#303f9f" stroke="#9fa8da" stroke-width="1.25" fill-opacity="0.45"/>
+  <text class="mono" x="343.0" y="138" text-anchor="middle">00</text>
+  <text class="label small" x="343.0" y="156" text-anchor="middle" fill="#e0e0e0">I</text>
+  <text class="label small" x="343.0" y="112" text-anchor="middle">05</text>
+  <rect x="368" y="120" width="46" height="44" rx="4" fill="#303f9f" stroke="#9fa8da" stroke-width="1.25" fill-opacity="0.45"/>
+  <text class="mono" x="391.0" y="138" text-anchor="middle">00</text>
+  <text class="label small" x="391.0" y="156" text-anchor="middle" fill="#e0e0e0">I</text>
+  <text class="label small" x="391.0" y="112" text-anchor="middle">06</text>
+  <rect x="416" y="120" width="46" height="44" rx="4" fill="#303f9f" stroke="#9fa8da" stroke-width="1.25" fill-opacity="0.45"/>
+  <text class="mono" x="439.0" y="138" text-anchor="middle">00</text>
+  <text class="label small" x="439.0" y="156" text-anchor="middle" fill="#e0e0e0">I</text>
+  <text class="label small" x="439.0" y="112" text-anchor="middle">07</text>
+  <rect x="464" y="120" width="46" height="44" rx="4" fill="#6a1b9a" stroke="#9fa8da" stroke-width="1.25" fill-opacity="0.45"/>
+  <text class="mono" x="487.0" y="138" text-anchor="middle">07</text>
+  <text class="label small" x="487.0" y="156" text-anchor="middle" fill="#e0e0e0">S</text>
+  <text class="label small" x="487.0" y="112" text-anchor="middle">08</text>
+  <rect x="512" y="120" width="46" height="44" rx="4" fill="#6a1b9a" stroke="#9fa8da" stroke-width="1.25" fill-opacity="0.45"/>
+  <text class="mono" x="535.0" y="138" text-anchor="middle">00</text>
+  <text class="label small" x="535.0" y="156" text-anchor="middle" fill="#e0e0e0">S</text>
+  <text class="label small" x="535.0" y="112" text-anchor="middle">09</text>
+  <rect x="560" y="120" width="46" height="44" rx="4" fill="#6a1b9a" stroke="#9fa8da" stroke-width="1.25" fill-opacity="0.45"/>
+  <text class="mono" x="583.0" y="138" text-anchor="middle">00</text>
+  <text class="label small" x="583.0" y="156" text-anchor="middle" fill="#e0e0e0">S</text>
+  <text class="label small" x="583.0" y="112" text-anchor="middle">10</text>
+  <rect x="608" y="120" width="46" height="44" rx="4" fill="#6a1b9a" stroke="#9fa8da" stroke-width="1.25" fill-opacity="0.45"/>
+  <text class="mono" x="631.0" y="138" text-anchor="middle">00</text>
+  <text class="label small" x="631.0" y="156" text-anchor="middle" fill="#e0e0e0">S</text>
+  <text class="label small" x="631.0" y="112" text-anchor="middle">11</text>
+  <rect x="656" y="120" width="46" height="44" rx="4" fill="#6a1b9a" stroke="#9fa8da" stroke-width="1.25" fill-opacity="0.45"/>
+  <text class="mono" x="679.0" y="138" text-anchor="middle">00</text>
+  <text class="label small" x="679.0" y="156" text-anchor="middle" fill="#e0e0e0">S</text>
+  <text class="label small" x="679.0" y="112" text-anchor="middle">12</text>
+  <rect x="704" y="120" width="46" height="44" rx="4" fill="#6a1b9a" stroke="#9fa8da" stroke-width="1.25" fill-opacity="0.45"/>
+  <text class="mono" x="727.0" y="138" text-anchor="middle">00</text>
+  <text class="label small" x="727.0" y="156" text-anchor="middle" fill="#e0e0e0">S</text>
+  <text class="label small" x="727.0" y="112" text-anchor="middle">13</text>
+  <rect x="752" y="120" width="46" height="44" rx="4" fill="#6a1b9a" stroke="#9fa8da" stroke-width="1.25" fill-opacity="0.45"/>
+  <text class="mono" x="775.0" y="138" text-anchor="middle">00</text>
+  <text class="label small" x="775.0" y="156" text-anchor="middle" fill="#e0e0e0">S</text>
+  <text class="label small" x="775.0" y="112" text-anchor="middle">14</text>
+  <rect x="800" y="120" width="46" height="44" rx="4" fill="#6a1b9a" stroke="#9fa8da" stroke-width="1.25" fill-opacity="0.45"/>
+  <text class="mono" x="823.0" y="138" text-anchor="middle">00</text>
+  <text class="label small" x="823.0" y="156" text-anchor="middle" fill="#e0e0e0">S</text>
+  <text class="label small" x="823.0" y="112" text-anchor="middle">15</text>
+  <text class="label caption" x="60" y="200">offsets</text>
+  <text class="label caption" x="60" y="248">F = flag (1) · p = padding · I = id (42) · S = score (7) — 13 data bytes + 3 pad → often 16 total</text>
+  <text class="label small" x="60" y="280">Padding exists for alignment, not for domain meaning. Another machine cannot assume these gaps.</text>
+</svg>

--- a/docs/theory/assets/diagrams/201-memory-padding.svg
+++ b/docs/theory/assets/diagrams/201-memory-padding.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 360" width="1000" height="360" role="img" aria-labelledby="title desc">
+  <title id="title">Memory layout with padding</title>
+  <desc id="desc">A 16-byte structure layout showing flag, padding, id, and score fields with example little-endian bytes.</desc>
+  <defs>
+    <style type="text/css"><![CDATA[
+      .label { font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; fill: #37474f; }
+      .title { font-size: 15px; font-weight: 600; letter-spacing: 0.02em; }
+      .caption { font-size: 12px; fill: #607d8b; }
+      .small { font-size: 11px; fill: #607d8b; }
+      .mono { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 11px; fill: #283593; }
+      .mono-lg { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 13px; fill: #283593; }
+      .arrow-label {
+        font-family: "Liberation Sans", "DejaVu Sans", "Helvetica Neue", Arial, sans-serif;
+        font-size: 15px;
+        font-weight: 400;
+        letter-spacing: 0.05em;
+        fill: #263238;
+        text-anchor: middle;
+      }
+      .panel-title { font-size: 14px; font-weight: 600; }
+    ]]></style>
+    <marker id="arrowhead" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#455a64"/>
+    </marker>
+  </defs>
+  <rect width="1000" height="360" fill="#fafafa"/>
+  <rect x="40" y="40" width="920" height="280" rx="10" fill="#ffffff" stroke="#c5cae9" stroke-width="1.5"/>
+  <text class="label title" x="60" y="72">In-memory layout with padding</text>
+  <text class="label caption" x="60" y="94">flag · id · score on a typical 64-bit C-like layout (little-endian example)</text>
+  <rect x="80" y="120" width="46" height="44" rx="4" fill="#e3f2fd" stroke="#5c6bc0" stroke-width="1.25"/>
+  <text class="mono" x="103.0" y="138" text-anchor="middle">01</text>
+  <text class="label small" x="103.0" y="156" text-anchor="middle" fill="#37474f">F</text>
+  <text class="label small" x="103.0" y="112" text-anchor="middle">00</text>
+  <rect x="128" y="120" width="46" height="44" rx="4" fill="#eceff1" stroke="#90a4ae" stroke-width="1.25"/>
+  <text class="mono" x="151.0" y="138" text-anchor="middle">00</text>
+  <text class="label small" x="151.0" y="156" text-anchor="middle" fill="#37474f">p</text>
+  <text class="label small" x="151.0" y="112" text-anchor="middle">01</text>
+  <rect x="176" y="120" width="46" height="44" rx="4" fill="#eceff1" stroke="#90a4ae" stroke-width="1.25"/>
+  <text class="mono" x="199.0" y="138" text-anchor="middle">00</text>
+  <text class="label small" x="199.0" y="156" text-anchor="middle" fill="#37474f">p</text>
+  <text class="label small" x="199.0" y="112" text-anchor="middle">02</text>
+  <rect x="224" y="120" width="46" height="44" rx="4" fill="#eceff1" stroke="#90a4ae" stroke-width="1.25"/>
+  <text class="mono" x="247.0" y="138" text-anchor="middle">00</text>
+  <text class="label small" x="247.0" y="156" text-anchor="middle" fill="#37474f">p</text>
+  <text class="label small" x="247.0" y="112" text-anchor="middle">03</text>
+  <rect x="272" y="120" width="46" height="44" rx="4" fill="#e8eaf6" stroke="#5c6bc0" stroke-width="1.25"/>
+  <text class="mono" x="295.0" y="138" text-anchor="middle">2a</text>
+  <text class="label small" x="295.0" y="156" text-anchor="middle" fill="#37474f">I</text>
+  <text class="label small" x="295.0" y="112" text-anchor="middle">04</text>
+  <rect x="320" y="120" width="46" height="44" rx="4" fill="#e8eaf6" stroke="#5c6bc0" stroke-width="1.25"/>
+  <text class="mono" x="343.0" y="138" text-anchor="middle">00</text>
+  <text class="label small" x="343.0" y="156" text-anchor="middle" fill="#37474f">I</text>
+  <text class="label small" x="343.0" y="112" text-anchor="middle">05</text>
+  <rect x="368" y="120" width="46" height="44" rx="4" fill="#e8eaf6" stroke="#5c6bc0" stroke-width="1.25"/>
+  <text class="mono" x="391.0" y="138" text-anchor="middle">00</text>
+  <text class="label small" x="391.0" y="156" text-anchor="middle" fill="#37474f">I</text>
+  <text class="label small" x="391.0" y="112" text-anchor="middle">06</text>
+  <rect x="416" y="120" width="46" height="44" rx="4" fill="#e8eaf6" stroke="#5c6bc0" stroke-width="1.25"/>
+  <text class="mono" x="439.0" y="138" text-anchor="middle">00</text>
+  <text class="label small" x="439.0" y="156" text-anchor="middle" fill="#37474f">I</text>
+  <text class="label small" x="439.0" y="112" text-anchor="middle">07</text>
+  <rect x="464" y="120" width="46" height="44" rx="4" fill="#f3e5f5" stroke="#5c6bc0" stroke-width="1.25"/>
+  <text class="mono" x="487.0" y="138" text-anchor="middle">07</text>
+  <text class="label small" x="487.0" y="156" text-anchor="middle" fill="#37474f">S</text>
+  <text class="label small" x="487.0" y="112" text-anchor="middle">08</text>
+  <rect x="512" y="120" width="46" height="44" rx="4" fill="#f3e5f5" stroke="#5c6bc0" stroke-width="1.25"/>
+  <text class="mono" x="535.0" y="138" text-anchor="middle">00</text>
+  <text class="label small" x="535.0" y="156" text-anchor="middle" fill="#37474f">S</text>
+  <text class="label small" x="535.0" y="112" text-anchor="middle">09</text>
+  <rect x="560" y="120" width="46" height="44" rx="4" fill="#f3e5f5" stroke="#5c6bc0" stroke-width="1.25"/>
+  <text class="mono" x="583.0" y="138" text-anchor="middle">00</text>
+  <text class="label small" x="583.0" y="156" text-anchor="middle" fill="#37474f">S</text>
+  <text class="label small" x="583.0" y="112" text-anchor="middle">10</text>
+  <rect x="608" y="120" width="46" height="44" rx="4" fill="#f3e5f5" stroke="#5c6bc0" stroke-width="1.25"/>
+  <text class="mono" x="631.0" y="138" text-anchor="middle">00</text>
+  <text class="label small" x="631.0" y="156" text-anchor="middle" fill="#37474f">S</text>
+  <text class="label small" x="631.0" y="112" text-anchor="middle">11</text>
+  <rect x="656" y="120" width="46" height="44" rx="4" fill="#f3e5f5" stroke="#5c6bc0" stroke-width="1.25"/>
+  <text class="mono" x="679.0" y="138" text-anchor="middle">00</text>
+  <text class="label small" x="679.0" y="156" text-anchor="middle" fill="#37474f">S</text>
+  <text class="label small" x="679.0" y="112" text-anchor="middle">12</text>
+  <rect x="704" y="120" width="46" height="44" rx="4" fill="#f3e5f5" stroke="#5c6bc0" stroke-width="1.25"/>
+  <text class="mono" x="727.0" y="138" text-anchor="middle">00</text>
+  <text class="label small" x="727.0" y="156" text-anchor="middle" fill="#37474f">S</text>
+  <text class="label small" x="727.0" y="112" text-anchor="middle">13</text>
+  <rect x="752" y="120" width="46" height="44" rx="4" fill="#f3e5f5" stroke="#5c6bc0" stroke-width="1.25"/>
+  <text class="mono" x="775.0" y="138" text-anchor="middle">00</text>
+  <text class="label small" x="775.0" y="156" text-anchor="middle" fill="#37474f">S</text>
+  <text class="label small" x="775.0" y="112" text-anchor="middle">14</text>
+  <rect x="800" y="120" width="46" height="44" rx="4" fill="#f3e5f5" stroke="#5c6bc0" stroke-width="1.25"/>
+  <text class="mono" x="823.0" y="138" text-anchor="middle">00</text>
+  <text class="label small" x="823.0" y="156" text-anchor="middle" fill="#37474f">S</text>
+  <text class="label small" x="823.0" y="112" text-anchor="middle">15</text>
+  <text class="label caption" x="60" y="200">offsets</text>
+  <text class="label caption" x="60" y="248">F = flag (1) · p = padding · I = id (42) · S = score (7) — 13 data bytes + 3 pad → often 16 total</text>
+  <text class="label small" x="60" y="280">Padding exists for alignment, not for domain meaning. Another machine cannot assume these gaps.</text>
+</svg>

--- a/docs/theory/assets/diagrams/201-self-describing-vs-schema-dark.svg
+++ b/docs/theory/assets/diagrams/201-self-describing-vs-schema-dark.svg
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 360" width="1000" height="360" role="img" aria-labelledby="title desc">
+  <title id="title">Self-describing vs schema-dependent</title>
+  <desc id="desc">Comparison of a self-describing JSON payload versus a schema-dependent compact binary encoding.</desc>
+  <defs>
+    <style type="text/css"><![CDATA[
+      .label { font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; fill: #e0e0e0; }
+      .title { font-size: 15px; font-weight: 600; letter-spacing: 0.02em; }
+      .caption { font-size: 12px; fill: #90a4ae; }
+      .small { font-size: 11px; fill: #90a4ae; }
+      .mono { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 11px; fill: #c5cae9; }
+      .mono-lg { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 13px; fill: #c5cae9; }
+      .arrow-label {
+        font-family: "Liberation Sans", "DejaVu Sans", "Helvetica Neue", Arial, sans-serif;
+        font-size: 15px;
+        font-weight: 400;
+        letter-spacing: 0.05em;
+        fill: #eceff1;
+        text-anchor: middle;
+      }
+      .panel-title { font-size: 14px; font-weight: 600; }
+    ]]></style>
+    <marker id="arrowhead" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#b0bec5"/>
+    </marker>
+  </defs>
+  <rect width="1000" height="360" fill="#1a1a1a"/>
+  <rect x="28" y="40" width="450" height="280" rx="10" fill="#242424" stroke="#5c6bc0" stroke-width="1.5" stroke-opacity="0.55"/>
+  <rect x="522" y="40" width="450" height="280" rx="10" fill="#242424" stroke="#5c6bc0" stroke-width="1.5" stroke-opacity="0.55"/>
+  <text class="label panel-title" x="48" y="72" fill="#e0e0e0">Self-describing</text>
+  <text class="label caption" x="48" y="94">names travel with values</text>
+  <text class="label panel-title" x="542" y="72" fill="#e0e0e0">Schema-dependent</text>
+  <text class="label caption" x="542" y="94">names live in the shared contract</text>
+  <rect x="60" y="120" width="386" height="90" rx="8" fill="#303f9f" stroke="#9fa8da" stroke-width="1.5" fill-opacity="0.45"/>
+  <text class="mono-lg" x="80" y="155">{&quot;user_id&quot;: 42,</text>
+  <text class="mono-lg" x="80" y="180">  &quot;name&quot;: &quot;Ada&quot; }</text>
+  <text class="label caption" x="60" y="240">Every message repeats field names.</text>
+  <text class="label caption" x="60" y="262">Generic tools can inspect without a schema file.</text>
+  <text class="label caption" x="60" y="284">Cost: size + parse work.</text>
+  <rect x="554" y="118" width="386" height="70" rx="8" fill="#303f9f" stroke="#9fa8da" stroke-width="1.5" fill-opacity="0.45"/>
+  <text class="label small" x="574" y="142" fill="#e0e0e0">Shared schema / IDL</text>
+  <text class="mono" x="574" y="164">1 → user_id (int)    2 → name (string)</text>
+  <line x1="747" y1="196" x2="747" y2="220" stroke="#b0bec5" stroke-width="1.75" marker-end="url(#arrowhead)"/>
+  <rect x="554" y="232" width="386" height="50" rx="8" fill="#2c2c2c" stroke="#9fa8da" stroke-width="1.5"/>
+  <text class="mono-lg" x="574" y="262">08 2a  12 03 41 64 61</text>
+  <text class="label caption" x="554" y="304">Compact tags + values — field names not on the wire.</text>
+</svg>

--- a/docs/theory/assets/diagrams/201-self-describing-vs-schema.svg
+++ b/docs/theory/assets/diagrams/201-self-describing-vs-schema.svg
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 360" width="1000" height="360" role="img" aria-labelledby="title desc">
+  <title id="title">Self-describing vs schema-dependent</title>
+  <desc id="desc">Comparison of a self-describing JSON payload versus a schema-dependent compact binary encoding.</desc>
+  <defs>
+    <style type="text/css"><![CDATA[
+      .label { font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; fill: #37474f; }
+      .title { font-size: 15px; font-weight: 600; letter-spacing: 0.02em; }
+      .caption { font-size: 12px; fill: #607d8b; }
+      .small { font-size: 11px; fill: #607d8b; }
+      .mono { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 11px; fill: #283593; }
+      .mono-lg { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 13px; fill: #283593; }
+      .arrow-label {
+        font-family: "Liberation Sans", "DejaVu Sans", "Helvetica Neue", Arial, sans-serif;
+        font-size: 15px;
+        font-weight: 400;
+        letter-spacing: 0.05em;
+        fill: #263238;
+        text-anchor: middle;
+      }
+      .panel-title { font-size: 14px; font-weight: 600; }
+    ]]></style>
+    <marker id="arrowhead" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#455a64"/>
+    </marker>
+  </defs>
+  <rect width="1000" height="360" fill="#fafafa"/>
+  <rect x="28" y="40" width="450" height="280" rx="10" fill="#ffffff" stroke="#c5cae9" stroke-width="1.5"/>
+  <rect x="522" y="40" width="450" height="280" rx="10" fill="#ffffff" stroke="#c5cae9" stroke-width="1.5"/>
+  <text class="label panel-title" x="48" y="72" fill="#37474f">Self-describing</text>
+  <text class="label caption" x="48" y="94">names travel with values</text>
+  <text class="label panel-title" x="542" y="72" fill="#37474f">Schema-dependent</text>
+  <text class="label caption" x="542" y="94">names live in the shared contract</text>
+  <rect x="60" y="120" width="386" height="90" rx="8" fill="#e8eaf6" stroke="#5c6bc0" stroke-width="1.5"/>
+  <text class="mono-lg" x="80" y="155">{&quot;user_id&quot;: 42,</text>
+  <text class="mono-lg" x="80" y="180">  &quot;name&quot;: &quot;Ada&quot; }</text>
+  <text class="label caption" x="60" y="240">Every message repeats field names.</text>
+  <text class="label caption" x="60" y="262">Generic tools can inspect without a schema file.</text>
+  <text class="label caption" x="60" y="284">Cost: size + parse work.</text>
+  <rect x="554" y="118" width="386" height="70" rx="8" fill="#e8eaf6" stroke="#5c6bc0" stroke-width="1.5"/>
+  <text class="label small" x="574" y="142" fill="#37474f">Shared schema / IDL</text>
+  <text class="mono" x="574" y="164">1 → user_id (int)    2 → name (string)</text>
+  <line x1="747" y1="196" x2="747" y2="220" stroke="#455a64" stroke-width="1.75" marker-end="url(#arrowhead)"/>
+  <rect x="554" y="232" width="386" height="50" rx="8" fill="#ffffff" stroke="#5c6bc0" stroke-width="1.5"/>
+  <text class="mono-lg" x="574" y="262">08 2a  12 03 41 64 61</text>
+  <text class="label caption" x="554" y="304">Compact tags + values — field names not on the wire.</text>
+</svg>

--- a/docs/theory/assets/diagrams/201-zero-copy-dark.svg
+++ b/docs/theory/assets/diagrams/201-zero-copy-dark.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 360" width="1000" height="360" role="img" aria-labelledby="title desc">
+  <title id="title">Classical deserialize vs zero-copy</title>
+  <desc id="desc">Classical path materializes an object graph; zero-copy verifies then reads fields in place from the buffer.</desc>
+  <defs>
+    <style type="text/css"><![CDATA[
+      .label { font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; fill: #e0e0e0; }
+      .title { font-size: 15px; font-weight: 600; letter-spacing: 0.02em; }
+      .caption { font-size: 12px; fill: #90a4ae; }
+      .small { font-size: 11px; fill: #90a4ae; }
+      .mono { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 11px; fill: #c5cae9; }
+      .mono-lg { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 13px; fill: #c5cae9; }
+      .arrow-label {
+        font-family: "Liberation Sans", "DejaVu Sans", "Helvetica Neue", Arial, sans-serif;
+        font-size: 15px;
+        font-weight: 400;
+        letter-spacing: 0.05em;
+        fill: #eceff1;
+        text-anchor: middle;
+      }
+      .panel-title { font-size: 14px; font-weight: 600; }
+    ]]></style>
+    <marker id="arrowhead" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#b0bec5"/>
+    </marker>
+  </defs>
+  <rect width="1000" height="360" fill="#1a1a1a"/>
+  <rect x="28" y="40" width="450" height="280" rx="10" fill="#242424" stroke="#5c6bc0" stroke-width="1.5" stroke-opacity="0.55"/>
+  <rect x="522" y="40" width="450" height="280" rx="10" fill="#242424" stroke="#5c6bc0" stroke-width="1.5" stroke-opacity="0.55"/>
+  <text class="label panel-title" x="48" y="72" fill="#e0e0e0">Classical path</text>
+  <text class="label caption" x="48" y="94">parse → allocate object graph</text>
+  <text class="label panel-title" x="542" y="72" fill="#e0e0e0">Zero-copy path</text>
+  <text class="label caption" x="542" y="94">verify → read in place</text>
+  <rect x="120" y="118" width="260" height="36" rx="6" fill="#2c2c2c" stroke="#9fa8da" stroke-width="1.5"/>
+  <text class="label" x="250" y="141" text-anchor="middle" font-size="13" fill="#e0e0e0">network buffer</text>
+  <line x1="250" y1="154" x2="250" y2="176" stroke="#b0bec5" stroke-width="1.75" marker-end="url(#arrowhead)"/>
+  <rect x="120" y="180" width="260" height="36" rx="6" fill="#303f9f" stroke="#9fa8da" stroke-width="1.5" fill-opacity="0.45"/>
+  <text class="label" x="250" y="203" text-anchor="middle" font-size="13" fill="#e0e0e0">parse and allocate</text>
+  <line x1="250" y1="216" x2="250" y2="238" stroke="#b0bec5" stroke-width="1.75" marker-end="url(#arrowhead)"/>
+  <rect x="120" y="242" width="260" height="36" rx="6" fill="#303f9f" stroke="#9fa8da" stroke-width="1.5" fill-opacity="0.45"/>
+  <text class="label" x="250" y="265" text-anchor="middle" font-size="13" fill="#e0e0e0">object graph (copy)</text>
+  <rect x="614" y="118" width="260" height="36" rx="6" fill="#2c2c2c" stroke="#9fa8da" stroke-width="1.5"/>
+  <text class="label" x="744" y="141" text-anchor="middle" font-size="13" fill="#e0e0e0">network buffer</text>
+  <line x1="744" y1="154" x2="744" y2="176" stroke="#b0bec5" stroke-width="1.75" marker-end="url(#arrowhead)"/>
+  <rect x="614" y="180" width="260" height="36" rx="6" fill="#4e342e" stroke="#ffab91" stroke-width="1.5"/>
+  <text class="label" x="744" y="203" text-anchor="middle" font-size="13" fill="#e0e0e0">structural verification</text>
+  <line x1="744" y1="216" x2="744" y2="238" stroke="#b0bec5" stroke-width="1.75" marker-end="url(#arrowhead)"/>
+  <rect x="614" y="242" width="260" height="36" rx="6" fill="#1b5e20" stroke="#81c784" stroke-width="1.5"/>
+  <text class="label" x="744" y="265" text-anchor="middle" font-size="13" fill="#e0e0e0">accessors / views</text>
+  <text class="label small" x="48" y="302">Application reads a full object tree.</text>
+  <text class="label small" x="542" y="302">Application reads fields at offsets in the same buffer.</text>
+</svg>

--- a/docs/theory/assets/diagrams/201-zero-copy.svg
+++ b/docs/theory/assets/diagrams/201-zero-copy.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 360" width="1000" height="360" role="img" aria-labelledby="title desc">
+  <title id="title">Classical deserialize vs zero-copy</title>
+  <desc id="desc">Classical path materializes an object graph; zero-copy verifies then reads fields in place from the buffer.</desc>
+  <defs>
+    <style type="text/css"><![CDATA[
+      .label { font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; fill: #37474f; }
+      .title { font-size: 15px; font-weight: 600; letter-spacing: 0.02em; }
+      .caption { font-size: 12px; fill: #607d8b; }
+      .small { font-size: 11px; fill: #607d8b; }
+      .mono { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 11px; fill: #283593; }
+      .mono-lg { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 13px; fill: #283593; }
+      .arrow-label {
+        font-family: "Liberation Sans", "DejaVu Sans", "Helvetica Neue", Arial, sans-serif;
+        font-size: 15px;
+        font-weight: 400;
+        letter-spacing: 0.05em;
+        fill: #263238;
+        text-anchor: middle;
+      }
+      .panel-title { font-size: 14px; font-weight: 600; }
+    ]]></style>
+    <marker id="arrowhead" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#455a64"/>
+    </marker>
+  </defs>
+  <rect width="1000" height="360" fill="#fafafa"/>
+  <rect x="28" y="40" width="450" height="280" rx="10" fill="#ffffff" stroke="#c5cae9" stroke-width="1.5"/>
+  <rect x="522" y="40" width="450" height="280" rx="10" fill="#ffffff" stroke="#c5cae9" stroke-width="1.5"/>
+  <text class="label panel-title" x="48" y="72" fill="#37474f">Classical path</text>
+  <text class="label caption" x="48" y="94">parse → allocate object graph</text>
+  <text class="label panel-title" x="542" y="72" fill="#37474f">Zero-copy path</text>
+  <text class="label caption" x="542" y="94">verify → read in place</text>
+  <rect x="120" y="118" width="260" height="36" rx="6" fill="#ffffff" stroke="#5c6bc0" stroke-width="1.5"/>
+  <text class="label" x="250" y="141" text-anchor="middle" font-size="13" fill="#37474f">network buffer</text>
+  <line x1="250" y1="154" x2="250" y2="176" stroke="#455a64" stroke-width="1.75" marker-end="url(#arrowhead)"/>
+  <rect x="120" y="180" width="260" height="36" rx="6" fill="#e8eaf6" stroke="#5c6bc0" stroke-width="1.5"/>
+  <text class="label" x="250" y="203" text-anchor="middle" font-size="13" fill="#37474f">parse and allocate</text>
+  <line x1="250" y1="216" x2="250" y2="238" stroke="#455a64" stroke-width="1.75" marker-end="url(#arrowhead)"/>
+  <rect x="120" y="242" width="260" height="36" rx="6" fill="#e8eaf6" stroke="#5c6bc0" stroke-width="1.5"/>
+  <text class="label" x="250" y="265" text-anchor="middle" font-size="13" fill="#37474f">object graph (copy)</text>
+  <rect x="614" y="118" width="260" height="36" rx="6" fill="#ffffff" stroke="#5c6bc0" stroke-width="1.5"/>
+  <text class="label" x="744" y="141" text-anchor="middle" font-size="13" fill="#37474f">network buffer</text>
+  <line x1="744" y1="154" x2="744" y2="176" stroke="#455a64" stroke-width="1.75" marker-end="url(#arrowhead)"/>
+  <rect x="614" y="180" width="260" height="36" rx="6" fill="#fff3e0" stroke="#ffb74d" stroke-width="1.5"/>
+  <text class="label" x="744" y="203" text-anchor="middle" font-size="13" fill="#37474f">structural verification</text>
+  <line x1="744" y1="216" x2="744" y2="238" stroke="#455a64" stroke-width="1.75" marker-end="url(#arrowhead)"/>
+  <rect x="614" y="242" width="260" height="36" rx="6" fill="#e8f5e9" stroke="#66bb6a" stroke-width="1.5"/>
+  <text class="label" x="744" y="265" text-anchor="middle" font-size="13" fill="#37474f">accessors / views</text>
+  <text class="label small" x="48" y="302">Application reads a full object tree.</text>
+  <text class="label small" x="542" y="302">Application reads fields at offsets in the same buffer.</text>
+</svg>

--- a/docs/theory/assets/diagrams/301-trust-boundaries-dark.svg
+++ b/docs/theory/assets/diagrams/301-trust-boundaries-dark.svg
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 360" width="1000" height="360" role="img" aria-labelledby="title desc">
+  <title id="title">Trust boundaries and format choice</title>
+  <desc id="desc">Three trust domains: process, service estate, and public untrusted input, with format recommendations.</desc>
+  <defs>
+    <style type="text/css"><![CDATA[
+      .label { font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; fill: #e0e0e0; }
+      .title { font-size: 15px; font-weight: 600; letter-spacing: 0.02em; }
+      .caption { font-size: 12px; fill: #90a4ae; }
+      .small { font-size: 11px; fill: #90a4ae; }
+      .mono { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 11px; fill: #c5cae9; }
+      .mono-lg { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 13px; fill: #c5cae9; }
+      .arrow-label {
+        font-family: "Liberation Sans", "DejaVu Sans", "Helvetica Neue", Arial, sans-serif;
+        font-size: 15px;
+        font-weight: 400;
+        letter-spacing: 0.05em;
+        fill: #eceff1;
+        text-anchor: middle;
+      }
+      .panel-title { font-size: 14px; font-weight: 600; }
+    ]]></style>
+    <marker id="arrowhead" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#b0bec5"/>
+    </marker>
+  </defs>
+  <rect width="1000" height="360" fill="#1a1a1a"/>
+  <rect x="40" y="40" width="920" height="280" rx="10" fill="#242424" stroke="#5c6bc0" stroke-width="1.5" stroke-opacity="0.55"/>
+  <text class="label title" x="60" y="72">Trust boundaries and format choice</text>
+  <text class="label caption" x="60" y="94">Do these bytes leave this process or trust domain?</text>
+  <rect x="80" y="120" width="240" height="150" rx="10" fill="#1b5e20" stroke="#81c784" stroke-width="1.75"/>
+  <text class="label panel-title" x="200" y="150" text-anchor="middle" fill="#e0e0e0">Process</text>
+  <text class="label caption" x="200" y="178" text-anchor="middle">same runtime</text>
+  <text class="label small" x="200" y="210" text-anchor="middle" fill="#e0e0e0">native formats</text>
+  <text class="label small" x="200" y="230" text-anchor="middle" fill="#e0e0e0">may be OK if peers trusted</text>
+  <rect x="360" y="120" width="240" height="150" rx="10" fill="#303f9f" stroke="#9fa8da" stroke-width="1.75" fill-opacity="0.35"/>
+  <text class="label panel-title" x="480" y="150" text-anchor="middle" fill="#e0e0e0">Service / estate</text>
+  <text class="label caption" x="480" y="178" text-anchor="middle">queues · cache · RPC</text>
+  <text class="label small" x="480" y="210" text-anchor="middle" fill="#e0e0e0">portable format</text>
+  <text class="label small" x="480" y="230" text-anchor="middle" fill="#e0e0e0">required</text>
+  <rect x="640" y="120" width="280" height="150" rx="10" fill="#4e342e" stroke="#ffab91" stroke-width="1.75"/>
+  <text class="label panel-title" x="780" y="150" text-anchor="middle" fill="#e0e0e0">Public / untrusted</text>
+  <text class="label caption" x="780" y="178" text-anchor="middle">clients · partners · multi-tenant</text>
+  <text class="label small" x="780" y="210" text-anchor="middle" fill="#e0e0e0">portable + validation</text>
+  <text class="label small" x="780" y="230" text-anchor="middle" fill="#e0e0e0">never language-native</text>
+  <text class="label caption" x="60" y="298">Crossing a boundary changes the decision more than raw speed numbers.</text>
+</svg>

--- a/docs/theory/assets/diagrams/301-trust-boundaries.svg
+++ b/docs/theory/assets/diagrams/301-trust-boundaries.svg
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 360" width="1000" height="360" role="img" aria-labelledby="title desc">
+  <title id="title">Trust boundaries and format choice</title>
+  <desc id="desc">Three trust domains: process, service estate, and public untrusted input, with format recommendations.</desc>
+  <defs>
+    <style type="text/css"><![CDATA[
+      .label { font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; fill: #37474f; }
+      .title { font-size: 15px; font-weight: 600; letter-spacing: 0.02em; }
+      .caption { font-size: 12px; fill: #607d8b; }
+      .small { font-size: 11px; fill: #607d8b; }
+      .mono { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 11px; fill: #283593; }
+      .mono-lg { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 13px; fill: #283593; }
+      .arrow-label {
+        font-family: "Liberation Sans", "DejaVu Sans", "Helvetica Neue", Arial, sans-serif;
+        font-size: 15px;
+        font-weight: 400;
+        letter-spacing: 0.05em;
+        fill: #263238;
+        text-anchor: middle;
+      }
+      .panel-title { font-size: 14px; font-weight: 600; }
+    ]]></style>
+    <marker id="arrowhead" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#455a64"/>
+    </marker>
+  </defs>
+  <rect width="1000" height="360" fill="#fafafa"/>
+  <rect x="40" y="40" width="920" height="280" rx="10" fill="#ffffff" stroke="#c5cae9" stroke-width="1.5"/>
+  <text class="label title" x="60" y="72">Trust boundaries and format choice</text>
+  <text class="label caption" x="60" y="94">Do these bytes leave this process or trust domain?</text>
+  <rect x="80" y="120" width="240" height="150" rx="10" fill="#e8f5e9" stroke="#66bb6a" stroke-width="1.75"/>
+  <text class="label panel-title" x="200" y="150" text-anchor="middle" fill="#37474f">Process</text>
+  <text class="label caption" x="200" y="178" text-anchor="middle">same runtime</text>
+  <text class="label small" x="200" y="210" text-anchor="middle" fill="#37474f">native formats</text>
+  <text class="label small" x="200" y="230" text-anchor="middle" fill="#37474f">may be OK if peers trusted</text>
+  <rect x="360" y="120" width="240" height="150" rx="10" fill="#e8eaf6" stroke="#5c6bc0" stroke-width="1.75"/>
+  <text class="label panel-title" x="480" y="150" text-anchor="middle" fill="#37474f">Service / estate</text>
+  <text class="label caption" x="480" y="178" text-anchor="middle">queues · cache · RPC</text>
+  <text class="label small" x="480" y="210" text-anchor="middle" fill="#37474f">portable format</text>
+  <text class="label small" x="480" y="230" text-anchor="middle" fill="#37474f">required</text>
+  <rect x="640" y="120" width="280" height="150" rx="10" fill="#fff3e0" stroke="#ffb74d" stroke-width="1.75"/>
+  <text class="label panel-title" x="780" y="150" text-anchor="middle" fill="#37474f">Public / untrusted</text>
+  <text class="label caption" x="780" y="178" text-anchor="middle">clients · partners · multi-tenant</text>
+  <text class="label small" x="780" y="210" text-anchor="middle" fill="#37474f">portable + validation</text>
+  <text class="label small" x="780" y="230" text-anchor="middle" fill="#37474f">never language-native</text>
+  <text class="label caption" x="60" y="298">Crossing a boundary changes the decision more than raw speed numbers.</text>
+</svg>

--- a/docs/theory/assets/diagrams/401-miniuser-wire-dark.svg
+++ b/docs/theory/assets/diagrams/401-miniuser-wire-dark.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 360" width="1000" height="360" role="img" aria-labelledby="title desc">
+  <title id="title">Annotated Protobuf wire strip</title>
+  <desc id="desc">Nested MiniUser manager field encoded as tag, length, inner tag, and varint value.</desc>
+  <defs>
+    <style type="text/css"><![CDATA[
+      .label { font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; fill: #e0e0e0; }
+      .title { font-size: 15px; font-weight: 600; letter-spacing: 0.02em; }
+      .caption { font-size: 12px; fill: #90a4ae; }
+      .small { font-size: 11px; fill: #90a4ae; }
+      .mono { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 11px; fill: #c5cae9; }
+      .mono-lg { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 13px; fill: #c5cae9; }
+      .arrow-label {
+        font-family: "Liberation Sans", "DejaVu Sans", "Helvetica Neue", Arial, sans-serif;
+        font-size: 15px;
+        font-weight: 400;
+        letter-spacing: 0.05em;
+        fill: #eceff1;
+        text-anchor: middle;
+      }
+      .panel-title { font-size: 14px; font-weight: 600; }
+    ]]></style>
+    <marker id="arrowhead" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#b0bec5"/>
+    </marker>
+  </defs>
+  <rect width="1000" height="360" fill="#1a1a1a"/>
+  <rect x="40" y="40" width="920" height="280" rx="10" fill="#242424" stroke="#5c6bc0" stroke-width="1.5" stroke-opacity="0.55"/>
+  <text class="label title" x="60" y="72">Annotated wire strip — nested MiniUser</text>
+  <text class="label caption" x="60" y="94">manager (field 3) whose only content is id = 2</text>
+  <rect x="120" y="130" width="90" height="56" rx="6" fill="#303f9f" stroke="#9fa8da" stroke-width="1.5" fill-opacity="0.45"/>
+  <text class="mono-lg" x="165.0" y="154" text-anchor="middle">1a</text>
+  <text class="label small" x="165.0" y="174" text-anchor="middle" fill="#e0e0e0">tag</text>
+  <text class="label caption" x="165.0" y="208" text-anchor="middle">field 3 · LEN</text>
+  <line x1="214" y1="158.0" x2="230" y2="158.0" stroke="#b0bec5" stroke-width="1.5"/>
+  <rect x="234" y="130" width="90" height="56" rx="6" fill="#37474f" stroke="#9fa8da" stroke-width="1.5" fill-opacity="0.45"/>
+  <text class="mono-lg" x="279.0" y="154" text-anchor="middle">02</text>
+  <text class="label small" x="279.0" y="174" text-anchor="middle" fill="#e0e0e0">len</text>
+  <text class="label caption" x="279.0" y="208" text-anchor="middle">2 bytes</text>
+  <line x1="328" y1="158.0" x2="344" y2="158.0" stroke="#b0bec5" stroke-width="1.5"/>
+  <rect x="348" y="130" width="90" height="56" rx="6" fill="#1565c0" stroke="#9fa8da" stroke-width="1.5" fill-opacity="0.45"/>
+  <text class="mono-lg" x="393.0" y="154" text-anchor="middle">08</text>
+  <text class="label small" x="393.0" y="174" text-anchor="middle" fill="#e0e0e0">tag</text>
+  <text class="label caption" x="393.0" y="208" text-anchor="middle">field 1 · VARINT</text>
+  <line x1="442" y1="158.0" x2="458" y2="158.0" stroke="#b0bec5" stroke-width="1.5"/>
+  <rect x="462" y="130" width="90" height="56" rx="6" fill="#6a1b9a" stroke="#9fa8da" stroke-width="1.5" fill-opacity="0.45"/>
+  <text class="mono-lg" x="507.0" y="154" text-anchor="middle">02</text>
+  <text class="label small" x="507.0" y="174" text-anchor="middle" fill="#e0e0e0">val</text>
+  <text class="label caption" x="507.0" y="208" text-anchor="middle">id = 2</text>
+  <text class="label small" x="60" y="250" fill="#e0e0e0">outer key = (3&lt;&lt;3)|2 = 0x1a · inner key = (1&lt;&lt;3)|0 = 0x08</text>
+  <text class="label caption" x="60" y="280">Field names never appear on the wire — only field numbers, wire types, and payloads.</text>
+</svg>

--- a/docs/theory/assets/diagrams/401-miniuser-wire.svg
+++ b/docs/theory/assets/diagrams/401-miniuser-wire.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 360" width="1000" height="360" role="img" aria-labelledby="title desc">
+  <title id="title">Annotated Protobuf wire strip</title>
+  <desc id="desc">Nested MiniUser manager field encoded as tag, length, inner tag, and varint value.</desc>
+  <defs>
+    <style type="text/css"><![CDATA[
+      .label { font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; fill: #37474f; }
+      .title { font-size: 15px; font-weight: 600; letter-spacing: 0.02em; }
+      .caption { font-size: 12px; fill: #607d8b; }
+      .small { font-size: 11px; fill: #607d8b; }
+      .mono { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 11px; fill: #283593; }
+      .mono-lg { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 13px; fill: #283593; }
+      .arrow-label {
+        font-family: "Liberation Sans", "DejaVu Sans", "Helvetica Neue", Arial, sans-serif;
+        font-size: 15px;
+        font-weight: 400;
+        letter-spacing: 0.05em;
+        fill: #263238;
+        text-anchor: middle;
+      }
+      .panel-title { font-size: 14px; font-weight: 600; }
+    ]]></style>
+    <marker id="arrowhead" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#455a64"/>
+    </marker>
+  </defs>
+  <rect width="1000" height="360" fill="#fafafa"/>
+  <rect x="40" y="40" width="920" height="280" rx="10" fill="#ffffff" stroke="#c5cae9" stroke-width="1.5"/>
+  <text class="label title" x="60" y="72">Annotated wire strip — nested MiniUser</text>
+  <text class="label caption" x="60" y="94">manager (field 3) whose only content is id = 2</text>
+  <rect x="120" y="130" width="90" height="56" rx="6" fill="#e8eaf6" stroke="#5c6bc0" stroke-width="1.5"/>
+  <text class="mono-lg" x="165.0" y="154" text-anchor="middle">1a</text>
+  <text class="label small" x="165.0" y="174" text-anchor="middle" fill="#37474f">tag</text>
+  <text class="label caption" x="165.0" y="208" text-anchor="middle">field 3 · LEN</text>
+  <line x1="214" y1="158.0" x2="230" y2="158.0" stroke="#455a64" stroke-width="1.5"/>
+  <rect x="234" y="130" width="90" height="56" rx="6" fill="#eceff1" stroke="#5c6bc0" stroke-width="1.5"/>
+  <text class="mono-lg" x="279.0" y="154" text-anchor="middle">02</text>
+  <text class="label small" x="279.0" y="174" text-anchor="middle" fill="#37474f">len</text>
+  <text class="label caption" x="279.0" y="208" text-anchor="middle">2 bytes</text>
+  <line x1="328" y1="158.0" x2="344" y2="158.0" stroke="#455a64" stroke-width="1.5"/>
+  <rect x="348" y="130" width="90" height="56" rx="6" fill="#e3f2fd" stroke="#5c6bc0" stroke-width="1.5"/>
+  <text class="mono-lg" x="393.0" y="154" text-anchor="middle">08</text>
+  <text class="label small" x="393.0" y="174" text-anchor="middle" fill="#37474f">tag</text>
+  <text class="label caption" x="393.0" y="208" text-anchor="middle">field 1 · VARINT</text>
+  <line x1="442" y1="158.0" x2="458" y2="158.0" stroke="#455a64" stroke-width="1.5"/>
+  <rect x="462" y="130" width="90" height="56" rx="6" fill="#f3e5f5" stroke="#5c6bc0" stroke-width="1.5"/>
+  <text class="mono-lg" x="507.0" y="154" text-anchor="middle">02</text>
+  <text class="label small" x="507.0" y="174" text-anchor="middle" fill="#37474f">val</text>
+  <text class="label caption" x="507.0" y="208" text-anchor="middle">id = 2</text>
+  <text class="label small" x="60" y="250" fill="#37474f">outer key = (3&lt;&lt;3)|2 = 0x1a · inner key = (1&lt;&lt;3)|0 = 0x08</text>
+  <text class="label caption" x="60" y="280">Field names never appear on the wire — only field numbers, wire types, and payloads.</text>
+</svg>

--- a/docs/theory/assets/diagrams/401-varint-dark.svg
+++ b/docs/theory/assets/diagrams/401-varint-dark.svg
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 360" width="1000" height="360" role="img" aria-labelledby="title desc">
+  <title id="title">Varint bit layout for value 300</title>
+  <desc id="desc">Two-byte varint for decimal 300 showing continuation bits and seven data bits per byte.</desc>
+  <defs>
+    <style type="text/css"><![CDATA[
+      .label { font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; fill: #e0e0e0; }
+      .title { font-size: 15px; font-weight: 600; letter-spacing: 0.02em; }
+      .caption { font-size: 12px; fill: #90a4ae; }
+      .small { font-size: 11px; fill: #90a4ae; }
+      .mono { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 11px; fill: #c5cae9; }
+      .mono-lg { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 13px; fill: #c5cae9; }
+      .arrow-label {
+        font-family: "Liberation Sans", "DejaVu Sans", "Helvetica Neue", Arial, sans-serif;
+        font-size: 15px;
+        font-weight: 400;
+        letter-spacing: 0.05em;
+        fill: #eceff1;
+        text-anchor: middle;
+      }
+      .panel-title { font-size: 14px; font-weight: 600; }
+    ]]></style>
+    <marker id="arrowhead" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#b0bec5"/>
+    </marker>
+  </defs>
+  <rect width="1000" height="360" fill="#1a1a1a"/>
+  <rect x="40" y="40" width="920" height="280" rx="10" fill="#242424" stroke="#5c6bc0" stroke-width="1.5" stroke-opacity="0.55"/>
+  <text class="label title" x="60" y="72">Varint encoding — value 300</text>
+  <text class="label caption" x="60" y="94">each byte: 1 continuation bit + 7 data bits (base-128 groups)</text>
+  <text class="label panel-title" x="200" y="130" text-anchor="middle" fill="#e0e0e0">byte 0 · 0xac</text>
+  <text class="label panel-title" x="520" y="130" text-anchor="middle" fill="#e0e0e0">byte 1 · 0x02</text>
+  <rect x="60" y="150" width="32" height="40" rx="4" fill="#bf360c" stroke="#9fa8da" stroke-width="1.25" fill-opacity="0.45"/>
+  <text class="mono-lg" x="76" y="176" text-anchor="middle">1</text>
+  <rect x="96" y="150" width="32" height="40" rx="4" fill="#303f9f" stroke="#9fa8da" stroke-width="1.25" fill-opacity="0.45"/>
+  <text class="mono-lg" x="112" y="176" text-anchor="middle">0</text>
+  <rect x="132" y="150" width="32" height="40" rx="4" fill="#303f9f" stroke="#9fa8da" stroke-width="1.25" fill-opacity="0.45"/>
+  <text class="mono-lg" x="148" y="176" text-anchor="middle">1</text>
+  <rect x="168" y="150" width="32" height="40" rx="4" fill="#303f9f" stroke="#9fa8da" stroke-width="1.25" fill-opacity="0.45"/>
+  <text class="mono-lg" x="184" y="176" text-anchor="middle">0</text>
+  <rect x="204" y="150" width="32" height="40" rx="4" fill="#303f9f" stroke="#9fa8da" stroke-width="1.25" fill-opacity="0.45"/>
+  <text class="mono-lg" x="220" y="176" text-anchor="middle">1</text>
+  <rect x="240" y="150" width="32" height="40" rx="4" fill="#303f9f" stroke="#9fa8da" stroke-width="1.25" fill-opacity="0.45"/>
+  <text class="mono-lg" x="256" y="176" text-anchor="middle">1</text>
+  <rect x="276" y="150" width="32" height="40" rx="4" fill="#303f9f" stroke="#9fa8da" stroke-width="1.25" fill-opacity="0.45"/>
+  <text class="mono-lg" x="292" y="176" text-anchor="middle">0</text>
+  <rect x="312" y="150" width="32" height="40" rx="4" fill="#303f9f" stroke="#9fa8da" stroke-width="1.25" fill-opacity="0.45"/>
+  <text class="mono-lg" x="328" y="176" text-anchor="middle">0</text>
+  <rect x="380" y="150" width="32" height="40" rx="4" fill="#bf360c" stroke="#9fa8da" stroke-width="1.25" fill-opacity="0.45"/>
+  <text class="mono-lg" x="396" y="176" text-anchor="middle">0</text>
+  <rect x="416" y="150" width="32" height="40" rx="4" fill="#303f9f" stroke="#9fa8da" stroke-width="1.25" fill-opacity="0.45"/>
+  <text class="mono-lg" x="432" y="176" text-anchor="middle">0</text>
+  <rect x="452" y="150" width="32" height="40" rx="4" fill="#303f9f" stroke="#9fa8da" stroke-width="1.25" fill-opacity="0.45"/>
+  <text class="mono-lg" x="468" y="176" text-anchor="middle">0</text>
+  <rect x="488" y="150" width="32" height="40" rx="4" fill="#303f9f" stroke="#9fa8da" stroke-width="1.25" fill-opacity="0.45"/>
+  <text class="mono-lg" x="504" y="176" text-anchor="middle">0</text>
+  <rect x="524" y="150" width="32" height="40" rx="4" fill="#303f9f" stroke="#9fa8da" stroke-width="1.25" fill-opacity="0.45"/>
+  <text class="mono-lg" x="540" y="176" text-anchor="middle">0</text>
+  <rect x="560" y="150" width="32" height="40" rx="4" fill="#303f9f" stroke="#9fa8da" stroke-width="1.25" fill-opacity="0.45"/>
+  <text class="mono-lg" x="576" y="176" text-anchor="middle">0</text>
+  <rect x="596" y="150" width="32" height="40" rx="4" fill="#303f9f" stroke="#9fa8da" stroke-width="1.25" fill-opacity="0.45"/>
+  <text class="mono-lg" x="612" y="176" text-anchor="middle">1</text>
+  <rect x="632" y="150" width="32" height="40" rx="4" fill="#303f9f" stroke="#9fa8da" stroke-width="1.25" fill-opacity="0.45"/>
+  <text class="mono-lg" x="648" y="176" text-anchor="middle">0</text>
+  <text class="label small" x="76" y="210" text-anchor="middle" fill="#e0e0e0">C</text>
+  <text class="label small" x="220" y="210" text-anchor="middle">7 data bits → 44</text>
+  <text class="label small" x="396" y="210" text-anchor="middle" fill="#e0e0e0">C</text>
+  <text class="label small" x="540" y="210" text-anchor="middle">7 data bits → 2</text>
+  <text class="label caption" x="60" y="248">C = continuation (1 = more bytes follow). Cleared on the last byte.</text>
+  <text class="label small" x="60" y="278" fill="#e0e0e0">value = 44 + (2 × 128) = 300 · wire bytes: ac 02</text>
+  <rect x="720" y="150" width="18" height="18" rx="3" fill="#bf360c" stroke="#9fa8da" stroke-width="1" fill-opacity="0.45"/>
+  <text class="label small" x="748" y="164" fill="#e0e0e0">continuation</text>
+  <rect x="720" y="180" width="18" height="18" rx="3" fill="#303f9f" stroke="#9fa8da" stroke-width="1" fill-opacity="0.45"/>
+  <text class="label small" x="748" y="194" fill="#e0e0e0">data bits</text>
+</svg>

--- a/docs/theory/assets/diagrams/401-varint.svg
+++ b/docs/theory/assets/diagrams/401-varint.svg
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 360" width="1000" height="360" role="img" aria-labelledby="title desc">
+  <title id="title">Varint bit layout for value 300</title>
+  <desc id="desc">Two-byte varint for decimal 300 showing continuation bits and seven data bits per byte.</desc>
+  <defs>
+    <style type="text/css"><![CDATA[
+      .label { font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; fill: #37474f; }
+      .title { font-size: 15px; font-weight: 600; letter-spacing: 0.02em; }
+      .caption { font-size: 12px; fill: #607d8b; }
+      .small { font-size: 11px; fill: #607d8b; }
+      .mono { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 11px; fill: #283593; }
+      .mono-lg { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 13px; fill: #283593; }
+      .arrow-label {
+        font-family: "Liberation Sans", "DejaVu Sans", "Helvetica Neue", Arial, sans-serif;
+        font-size: 15px;
+        font-weight: 400;
+        letter-spacing: 0.05em;
+        fill: #263238;
+        text-anchor: middle;
+      }
+      .panel-title { font-size: 14px; font-weight: 600; }
+    ]]></style>
+    <marker id="arrowhead" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#455a64"/>
+    </marker>
+  </defs>
+  <rect width="1000" height="360" fill="#fafafa"/>
+  <rect x="40" y="40" width="920" height="280" rx="10" fill="#ffffff" stroke="#c5cae9" stroke-width="1.5"/>
+  <text class="label title" x="60" y="72">Varint encoding — value 300</text>
+  <text class="label caption" x="60" y="94">each byte: 1 continuation bit + 7 data bits (base-128 groups)</text>
+  <text class="label panel-title" x="200" y="130" text-anchor="middle" fill="#37474f">byte 0 · 0xac</text>
+  <text class="label panel-title" x="520" y="130" text-anchor="middle" fill="#37474f">byte 1 · 0x02</text>
+  <rect x="60" y="150" width="32" height="40" rx="4" fill="#ffccbc" stroke="#5c6bc0" stroke-width="1.25"/>
+  <text class="mono-lg" x="76" y="176" text-anchor="middle">1</text>
+  <rect x="96" y="150" width="32" height="40" rx="4" fill="#e8eaf6" stroke="#5c6bc0" stroke-width="1.25"/>
+  <text class="mono-lg" x="112" y="176" text-anchor="middle">0</text>
+  <rect x="132" y="150" width="32" height="40" rx="4" fill="#e8eaf6" stroke="#5c6bc0" stroke-width="1.25"/>
+  <text class="mono-lg" x="148" y="176" text-anchor="middle">1</text>
+  <rect x="168" y="150" width="32" height="40" rx="4" fill="#e8eaf6" stroke="#5c6bc0" stroke-width="1.25"/>
+  <text class="mono-lg" x="184" y="176" text-anchor="middle">0</text>
+  <rect x="204" y="150" width="32" height="40" rx="4" fill="#e8eaf6" stroke="#5c6bc0" stroke-width="1.25"/>
+  <text class="mono-lg" x="220" y="176" text-anchor="middle">1</text>
+  <rect x="240" y="150" width="32" height="40" rx="4" fill="#e8eaf6" stroke="#5c6bc0" stroke-width="1.25"/>
+  <text class="mono-lg" x="256" y="176" text-anchor="middle">1</text>
+  <rect x="276" y="150" width="32" height="40" rx="4" fill="#e8eaf6" stroke="#5c6bc0" stroke-width="1.25"/>
+  <text class="mono-lg" x="292" y="176" text-anchor="middle">0</text>
+  <rect x="312" y="150" width="32" height="40" rx="4" fill="#e8eaf6" stroke="#5c6bc0" stroke-width="1.25"/>
+  <text class="mono-lg" x="328" y="176" text-anchor="middle">0</text>
+  <rect x="380" y="150" width="32" height="40" rx="4" fill="#ffccbc" stroke="#5c6bc0" stroke-width="1.25"/>
+  <text class="mono-lg" x="396" y="176" text-anchor="middle">0</text>
+  <rect x="416" y="150" width="32" height="40" rx="4" fill="#e8eaf6" stroke="#5c6bc0" stroke-width="1.25"/>
+  <text class="mono-lg" x="432" y="176" text-anchor="middle">0</text>
+  <rect x="452" y="150" width="32" height="40" rx="4" fill="#e8eaf6" stroke="#5c6bc0" stroke-width="1.25"/>
+  <text class="mono-lg" x="468" y="176" text-anchor="middle">0</text>
+  <rect x="488" y="150" width="32" height="40" rx="4" fill="#e8eaf6" stroke="#5c6bc0" stroke-width="1.25"/>
+  <text class="mono-lg" x="504" y="176" text-anchor="middle">0</text>
+  <rect x="524" y="150" width="32" height="40" rx="4" fill="#e8eaf6" stroke="#5c6bc0" stroke-width="1.25"/>
+  <text class="mono-lg" x="540" y="176" text-anchor="middle">0</text>
+  <rect x="560" y="150" width="32" height="40" rx="4" fill="#e8eaf6" stroke="#5c6bc0" stroke-width="1.25"/>
+  <text class="mono-lg" x="576" y="176" text-anchor="middle">0</text>
+  <rect x="596" y="150" width="32" height="40" rx="4" fill="#e8eaf6" stroke="#5c6bc0" stroke-width="1.25"/>
+  <text class="mono-lg" x="612" y="176" text-anchor="middle">1</text>
+  <rect x="632" y="150" width="32" height="40" rx="4" fill="#e8eaf6" stroke="#5c6bc0" stroke-width="1.25"/>
+  <text class="mono-lg" x="648" y="176" text-anchor="middle">0</text>
+  <text class="label small" x="76" y="210" text-anchor="middle" fill="#37474f">C</text>
+  <text class="label small" x="220" y="210" text-anchor="middle">7 data bits → 44</text>
+  <text class="label small" x="396" y="210" text-anchor="middle" fill="#37474f">C</text>
+  <text class="label small" x="540" y="210" text-anchor="middle">7 data bits → 2</text>
+  <text class="label caption" x="60" y="248">C = continuation (1 = more bytes follow). Cleared on the last byte.</text>
+  <text class="label small" x="60" y="278" fill="#37474f">value = 44 + (2 × 128) = 300 · wire bytes: ac 02</text>
+  <rect x="720" y="150" width="18" height="18" rx="3" fill="#ffccbc" stroke="#5c6bc0" stroke-width="1"/>
+  <text class="label small" x="748" y="164" fill="#37474f">continuation</text>
+  <rect x="720" y="180" width="18" height="18" rx="3" fill="#e8eaf6" stroke="#5c6bc0" stroke-width="1"/>
+  <text class="label small" x="748" y="194" fill="#37474f">data bits</text>
+</svg>

--- a/docs/theory/assets/diagrams/README.md
+++ b/docs/theory/assets/diagrams/README.md
@@ -1,0 +1,32 @@
+# Theory course diagrams
+
+Simple SVG figures for Serialization 101–401. Light and dark twins share geometry.
+
+## Design rules
+
+- Flat shapes, no gradients or shadows
+- Palette: slate + indigo (Material-friendly)
+- Action labels: Liberation/DejaVu Sans, regular weight, open tracking
+- Light: `*-name.svg` · Dark: `*-name-dark.svg`
+
+## Embedding (Material)
+
+```markdown
+![Alt text](../assets/diagrams/STEM.svg#only-light)
+![Alt text](../assets/diagrams/STEM-dark.svg#only-dark)
+```
+
+Requires `attr_list` (enabled in `mkdocs.yml`).
+
+## Inventory
+
+| Stem | Course page |
+|------|-------------|
+| `101-serialize-contract` | `theory/101/index.md` |
+| `201-memory-padding` | `theory/201/memory-layout.md` |
+| `201-endianness` | `theory/201/memory-layout.md` (Endianness) |
+| `201-self-describing-vs-schema` | `theory/201/self-describing-vs-schema-dependent.md` |
+| `201-zero-copy` | `theory/201/zero-copy.md` |
+| `301-trust-boundaries` | `theory/301/trust-boundaries.md` |
+| `401-miniuser-wire` | `theory/401/protobuf-wire-format.md` |
+| `401-varint` | `theory/401/protobuf-wire-format.md` |


### PR DESCRIPTION
## Summary
- Add simple light/dark SVG diagrams for Serialization 101–401 (serialize contract, padding, endianness, self-describing vs schema, zero-copy, trust boundaries, MiniUser wire strip, varint).
- Embed diagrams with Material `#only-light` / `#only-dark` fragments so theme switching works.
- Dashboard: fix Cross-language **Add** row layout (stray chevron + button far-right), rename title to **Serializer Analytics dashboard**, add favicon.

## Validation
- Tests: analysis (57), python (29), javascript (8), rust (10) — pass
- Benchmarks: skipped (no harness language changes; docs/dashboard only)
- Error CSVs: n/a
- Analysis: n/a (no re-bench)
- Dashboard: `sync-data.py` ran; payload run_ids unchanged (gzip recompression not committed)

## Notes
- Built `docs/dashboard/` remains gitignored; source is `dashboard/` (Vite build for local/docs deploy).
- Diagram inventory and embed rules: `docs/theory/assets/diagrams/README.md`.