### PR TITLE
docs(csharp): envelope and stream-mode honesty

### DIFF
--- a/c-sharp/README.md
+++ b/c-sharp/README.md
@@ -10,7 +10,7 @@ Serializer inventory: [docs/c-sharp/index.md](../docs/c-sharp/index.md).
 
 - **36 serializers** registered in `Program.cs` (Json.NET, protobuf-net, Bond, Jil, SpanJson, Utf8Json, System.Text.Json, MemoryPack, Ceras, FlatSharp, Hyperion, SharpSerializer, and more). **Not** included: MessagePack-CSharp, Wire; Apex.Serialization (net8 crash); FluentSerializer (unsuitable for suite graphs).
 - **Suite data types**: Data Model v2 type ids `message`, `document`, `telemetry`, `strings`, `event` — domain POCOs in `TestData/V2/Models.cs`.
-- **Dual mode**: **string** vs **Stream**. Text codecs use real text on the string path; **binary** codecs usually use **Base64** of bytes on the string path. Stream is **native** when the library writes the stream, or **adapted** when the harness wraps the string path — see [inventory honesty](../docs/c-sharp/index.md#string-mode-vs-stream-mode).
+- **Dual mode**: **string** vs **Stream**. Text codecs use real text on the string path; **binary** codecs usually use **Base64** of bytes on the string path. Stream is **native** when the library writes the stream, or **adapted** when the benchmark runner wraps the string path — see [inventory honesty](../docs/c-sharp/index.md#string-mode-vs-stream-mode).
 - **CSV logs** + optional `*.errors.csv` + `*.configs.json` sidecars.
 - Most codecs use domain types (or codegen forms) on the timed path. **Exceptions:** ExtendedXmlSerializer and Migrant time a **JSON envelope** only — see [envelope codecs](../docs/c-sharp/index.md#envelope-codecs-not-native-domain-wire).
 

--- a/c-sharp/README.md
+++ b/c-sharp/README.md
@@ -9,10 +9,10 @@ Serializer inventory: [docs/c-sharp/index.md](../docs/c-sharp/index.md).
 ## Key Features
 
 - **36 serializers** registered in `Program.cs` (Json.NET, protobuf-net, Bond, Jil, SpanJson, Utf8Json, System.Text.Json, MemoryPack, Ceras, FlatSharp, Hyperion, SharpSerializer, and more). **Not** included: MessagePack-CSharp, Wire; Apex.Serialization (net8 crash); FluentSerializer (unsuitable for suite graphs).
-- **Suite fixtures**: Data Model v2 type ids `message`, `document`, `telemetry`, `strings`, `event` — domain POCOs in `TestData/V2/Models.cs` (no legacy proxies).
-- **Dual mode**: string (base64 buffer) and Stream for every capable serializer.
+- **Suite data types**: Data Model v2 type ids `message`, `document`, `telemetry`, `strings`, `event` — domain POCOs in `TestData/V2/Models.cs`.
+- **Dual mode**: **string** vs **Stream**. Text codecs use real text on the string path; **binary** codecs usually use **Base64** of bytes on the string path. Stream is **native** when the library writes the stream, or **adapted** when the harness wraps the string path — see [inventory honesty](../docs/c-sharp/index.md#string-mode-vs-stream-mode).
 - **CSV logs** + optional `*.errors.csv` + `*.configs.json` sidecars.
-- All registered codecs run on all suite fixtures; some libraries use untimed `PrepareData` for **library wire forms** only (Protobuf `IMessage`, ZeroFormatter `KeyTuple`, envelopes) — see [inventory](../docs/c-sharp/index.md).
+- Most codecs use domain types (or codegen forms) on the timed path. **Exceptions:** ExtendedXmlSerializer and Migrant time a **JSON envelope** only — see [envelope codecs](../docs/c-sharp/index.md#envelope-codecs-not-native-domain-wire).
 
 ---
 

--- a/c-sharp/src/Log.cs
+++ b/c-sharp/src/Log.cs
@@ -78,7 +78,7 @@ namespace GLD.SerializerBenchmark
             get { return (TimeSer + TimeDeser) > 0 ? 1_000_000_000.0 / (TimeSer + TimeDeser) : 0; }
         }
 
-        /// <summary>Harness language id for multi-language CSV schema.</summary>
+        /// <summary>Benchmark-runner language id for multi-language CSV schema.</summary>
         public string Language { get { return "csharp"; } }
 
         /// <summary>Peak memory if measured; 0 when not tracked.</summary>

--- a/c-sharp/src/Report.cs
+++ b/c-sharp/src/Report.cs
@@ -17,7 +17,7 @@ namespace GLD.SerializerBenchmark
             // human-readable average table. The raw CSV written by LogStorage
             // always retains every successful rep (including warmup). Analysis
             // (benchmark_analysis) re-reads the full file and applies its own
-            // exclude_warmup / outlier policy — harnesses must not trim logs.
+            // exclude_warmup / outlier policy — benchmark runners must not trim logs.
             // When repetitions == 1, index 0 is the only data point; keep it here.
             var filteredLogs = repetitions > 1
                 ? logs.Where(w => w.RepetitionIndex != 0)

--- a/c-sharp/src/Serializers/BinaryPackSerializerSer.cs
+++ b/c-sharp/src/Serializers/BinaryPackSerializerSer.cs
@@ -8,7 +8,9 @@ using BinaryPack;
 namespace GLD.SerializerBenchmark.Serializers
 {
     /// <summary>
-    /// BinaryPack: BinaryConverter.Serialize/Deserialize&lt;T&gt; bound from primary type only.
+    /// BinaryPack: BinaryConverter.Serialize/Deserialize&lt;T&gt; bound from primary type only
+    /// (domain types on the timed path — not a JSON envelope).
+    /// String mode is Base64 of the byte payload; stream mode uses BinaryPack's Stream API.
     /// https://github.com/Sergio0694/BinaryPack
     /// </summary>
     internal class BinaryPackSerializerSer : SerDeser

--- a/c-sharp/src/Serializers/CsvHelperSerializerSer.cs
+++ b/c-sharp/src/Serializers/CsvHelperSerializerSer.cs
@@ -12,7 +12,11 @@ namespace GLD.SerializerBenchmark.Serializers
 {
     /// <summary>
     /// CsvHelper on row-list contracts only (CsvFlatRow / CsvEventRow / CsvStringRow).
-    /// Domain projection via <see cref="IDomainNativeMap"/>. Supports message/event/strings.
+    /// Domain projection via <see cref="IDomainNativeMap"/> (untimed). Supports message/event/strings.
+    /// <para>
+    /// Timed path uses real CsvHelper <c>WriteRecords</c> / <c>GetRecords</c> (not a JSON envelope).
+    /// Stream mode is <b>adapted</b>: UTF-8 StreamWriter/Reader around the same CSV text path.
+    /// </para>
     /// https://joshclose.github.io/CsvHelper/
     /// </summary>
     internal class CsvHelperSerializerSer : MappedSerDeser

--- a/c-sharp/src/Serializers/ExtendedXmlSerializerSer.cs
+++ b/c-sharp/src/Serializers/ExtendedXmlSerializerSer.cs
@@ -6,6 +6,24 @@ using Newtonsoft.Json;
 
 namespace GLD.SerializerBenchmark.Serializers
 {
+    /// <summary>
+    /// <b>Honesty — not native domain XML.</b>
+    /// <para>
+    /// Timed work serializes an <see cref="XmlEnvelope"/> whose payload is a
+    /// <b>Newtonsoft.Json</b> string of the suite domain object, not ExtendedXmlSerializer
+    /// mapping of <c>Message</c>/<c>Document</c>/… graphs. ExtendedXmlSerializer only
+    /// round-trips the envelope. Fidelity is restored in <see cref="ToDomain"/> (untimed)
+    /// by deserializing the JSON field.
+    /// </para>
+    /// <para>
+    /// Stream mode is <b>adapted</b>: UTF-8 write/read of the same XML string path
+    /// (not an ExtendedXml streaming API over domain types).
+    /// </para>
+    /// Why: ExtendedXml on net8 does not cleanly host the suite’s nested graphs for
+    /// all fixtures; this keeps the row registered for size/latency of the envelope
+    /// pattern. Do not treat Results as “ExtendedXml of domain POCOs.”
+    /// Docs: https://github.com/ExtendedXmlSerializer/home
+    /// </summary>
     internal class ExtendedXmlSerializerSer : SerDeser
     {
         private readonly IExtendedXmlSerializer _serializer =
@@ -17,19 +35,17 @@ namespace GLD.SerializerBenchmark.Serializers
 
         public override void PrepareData(object data)
         {
-            _native = new XmlEnvelope
-            {
-                TypeName = data.GetType().AssemblyQualifiedName,
-                Json = JsonConvert.SerializeObject(data)
-            };
-            // untimed smoke
+            // Untimed: build JSON+type envelope once per cell (includes N-instance batches).
+            _native = Make(data);
             var xml = _serializer.Serialize(_native);
             var back = _serializer.Deserialize<XmlEnvelope>(xml);
-            if (back?.Json == null) throw new InvalidOperationException("ExtendedXml envelope smoke failed");
+            if (back?.Json == null)
+                throw new InvalidOperationException("ExtendedXml envelope smoke failed");
         }
 
         public override object ToDomain(object decoded)
         {
+            // Untimed: JSON → suite domain (not part of TimeSer/TimeDeser).
             if (decoded is XmlEnvelope env)
                 return JsonConvert.DeserializeObject(env.Json, Type.GetType(env.TypeName));
             return decoded;
@@ -46,6 +62,7 @@ namespace GLD.SerializerBenchmark.Serializers
 
         public override void Serialize(object serializable, Stream outputStream)
         {
+            // Adapted stream: same string path through a StreamWriter.
             using var sw = new StreamWriter(outputStream, System.Text.Encoding.UTF8, 1024, true);
             sw.Write(Serialize(serializable));
             sw.Flush();
@@ -64,6 +81,7 @@ namespace GLD.SerializerBenchmark.Serializers
             Json = JsonConvert.SerializeObject(data)
         };
 
+        /// <summary>Wire type for ExtendedXml only — holds type name + JSON payload.</summary>
         public class XmlEnvelope
         {
             public string TypeName { get; set; }

--- a/c-sharp/src/Serializers/MigrantSerializerSer.cs
+++ b/c-sharp/src/Serializers/MigrantSerializerSer.cs
@@ -6,8 +6,22 @@ using Newtonsoft.Json;
 namespace GLD.SerializerBenchmark.Serializers
 {
     /// <summary>
-    /// Migrant emits Bad IL on net8 for many suite graphs. Timed path serializes a
-    /// plain string envelope; fidelity restored from JSON in ToDomain.
+    /// <b>Honesty — not native domain Migrant graphs.</b>
+    /// <para>
+    /// Timed work serializes a <see cref="MigEnvelope"/> whose payload is a
+    /// <b>Newtonsoft.Json</b> string of the suite domain object. Migrant only
+    /// round-trips that envelope (plain POCOs). Fidelity is restored in
+    /// <see cref="ToDomain"/> (untimed) from the JSON field.
+    /// </para>
+    /// <para>
+    /// <b>String mode</b> wraps Migrant bytes as <b>Base64</b> (not a domain text format).
+    /// <b>Stream mode</b> writes Migrant binary of the envelope directly to the stream
+    /// (native Migrant stream API on the envelope type only).
+    /// </para>
+    /// Why: Migrant emits bad IL / fails on many suite graphs on net8. This keeps a
+    /// registered row for the envelope workaround. Do not treat Results as
+    /// “Migrant of nested suite POCOs.”
+    /// Docs: https://github.com/antmicro/Migrant
     /// </summary>
     internal class MigrantSerializerSer : SerDeser
     {
@@ -25,11 +39,13 @@ namespace GLD.SerializerBenchmark.Serializers
 
         public override void PrepareData(object data)
         {
+            // Untimed: JSON envelope once per cell.
             _native = Make(data);
         }
 
         public override object ToDomain(object decoded)
         {
+            // Untimed: JSON → suite domain.
             if (decoded is MigEnvelope env)
                 return JsonConvert.DeserializeObject(env.Json, Type.GetType(env.TypeName));
             return decoded;
@@ -39,6 +55,7 @@ namespace GLD.SerializerBenchmark.Serializers
         {
             using var ms = new MemoryStream();
             _serializer.Serialize(_native ?? Make(serializable), ms);
+            // String mode: Base64 of Migrant bytes of the envelope (not domain text).
             return Convert.ToBase64String(ms.ToArray());
         }
 
@@ -63,6 +80,7 @@ namespace GLD.SerializerBenchmark.Serializers
             Json = JsonConvert.SerializeObject(data)
         };
 
+        /// <summary>Wire type for Migrant only — holds type name + JSON payload.</summary>
         public class MigEnvelope
         {
             public string TypeName { get; set; }

--- a/c-sharp/src/TestData/V2/Models.cs
+++ b/c-sharp/src/TestData/V2/Models.cs
@@ -1,4 +1,4 @@
-// Data Model v2 domain types — sole suite payload types for the C# harness.
+// Data Model v2 domain types — sole suite payload types for the C# benchmark runner.
 // Shape matches schemas/data_catalog_v2.yaml, python data_v2.models, and benchmark_v2.proto.
 using System;
 using System.Collections.Generic;

--- a/docs/c-sharp/index.md
+++ b/docs/c-sharp/index.md
@@ -11,12 +11,12 @@ This suite registers **36 serializers** in [`c-sharp/src/Program.cs`](../../c-sh
 | Log name | Category | Library / notes |
 |----------|----------|-----------------|
 | System.Text.Json | JSON | System.Text.Json (net8 built-in) |
-| BinaryPack | Binary | BinaryPack (`T : new()` constraints) |
+| BinaryPack | Binary | BinaryPack on domain types (`T : new()`); string mode = Base64 of bytes |
 | Ceras | Binary | Ceras |
-| CsvHelper | CSV | Tabular projection of suite types in `PrepareData` |
-| ExtendedXmlSerializer | XML | ExtendedXmlSerializer |
+| CsvHelper | CSV | Row-list projection (message/event/strings only); real CsvHelper write/read |
+| ExtendedXmlSerializer | XML (**envelope**) | **Not domain XML** — ExtendedXml of `{TypeName, Json}`; see [Envelope codecs](#envelope-codecs-not-native-domain-wire) |
 | fastJson | JSON | FastJson |
-| FlatSharp | Schema / FlatBuffers | FlatSharp (blob table + MemoryPack payload of V2 domain) |
+| FlatSharp | Schema / FlatBuffers | FlatSharp tables via domain map (untimed `PrepareData`) |
 | FsPickler | Binary | FsPickler binary |
 | FsPicklerJson | JSON | FsPickler JSON |
 | Google.Protobuf | Schema | Official Google.Protobuf (`IMessage` / `benchmark_v2.proto`) |
@@ -26,14 +26,14 @@ This suite registers **36 serializers** in [`c-sharp/src/Program.cs`](../../c-sh
 | Json.Net | JSON | Newtonsoft.Json |
 | Json.Net (Helper) | JSON | Newtonsoft.Json helper path |
 | MemoryPack | Binary | MemoryPack (domain types are `[MemoryPackable]`) |
-| Migrant | Binary | Migrant |
+| Migrant | Binary (**envelope**) | **Not domain Migrant graphs** — Migrant of `{TypeName, Json}`; see [Envelope codecs](#envelope-codecs-not-native-domain-wire) |
 | MS Binary | Binary (native) | Legacy `BinaryFormatter` path |
 | MS Bond Compact | Schema / Bond | Bond Compact Binary; V2 domain marked `[Schema]` |
 | MS Bond Fast | Schema / Bond | Bond Fast Binary |
 | MS Bond Json | JSON / Bond | Bond JSON protocol |
 | MS DataContract | XML | `DataContractSerializer` |
 | MS DataContract Json | JSON | `DataContractJsonSerializer` |
-| MS XmlSerializer | XML | Classic `XmlSerializer` |
+| MS XmlSerializer | XML | Classic `XmlSerializer` (real domain XML when attributes allow) |
 | NetJSON | JSON | NetJSON |
 | NetSerializer | Binary | NetSerializer |
 | ProtoBuf | Schema | protobuf-net |
@@ -47,18 +47,50 @@ This suite registers **36 serializers** in [`c-sharp/src/Program.cs`](../../c-sh
 | YAXLib | XML | YAXLib |
 | ZeroFormatter | Binary | ZeroFormatter; **all data types** via `KeyTuple` / list shapes (`PrepareData` untimed) — dynamic `[ZeroFormattable]` IL is broken on .NET 8 |
 
+### Envelope codecs (not native domain wire)
+
+These rows stay in the matrix for history and size noise, but **Results must not be read as “library X serializes suite POCOs directly.”**
+
+| Log name | Timed wire | Untimed fidelity | Stream mode |
+|----------|------------|------------------|-------------|
+| **ExtendedXmlSerializer** | ExtendedXml of `{ TypeName, Json }` where `Json` is Newtonsoft of the domain object | `ToDomain` deserializes JSON | **Adapted** — UTF-8 `StreamWriter` of the XML string |
+| **Migrant** | Migrant of the same JSON envelope POCO | `ToDomain` deserializes JSON | **Native Migrant stream** of the envelope only; **string mode** is Base64 of those bytes |
+
+Source: [`ExtendedXmlSerializerSer.cs`](../../c-sharp/src/Serializers/ExtendedXmlSerializerSer.cs), [`MigrantSerializerSer.cs`](../../c-sharp/src/Serializers/MigrantSerializerSer.cs).
+
+**Compare fairly:** use **MS XmlSerializer** / **YAXLib** / **MS DataContract** for real XML-ish paths; use **Ceras**, **MemoryPack**, **NetSerializer**, etc. for binary domain graphs — not Migrant’s envelope row.
+
+### String mode vs stream mode
+
+CSV column `StringOrStream` is **`string`** or **`Stream`** (Results labels: **bytes mode** often means the non-stream column; for C# that column is the **string** path).
+
+| Path | Meaning on C# |
+|------|----------------|
+| **string** | `Serialize`/`Deserialize` with `string`. **Text** codecs return real text. **Binary** codecs usually return **Base64** of the byte payload (extra encode/decode on the timed path). |
+| **Stream** | `Serialize`/`Deserialize` with `Stream`. |
+
+**Stream honesty**
+
+| Kind | What is timed | Examples |
+|------|----------------|----------|
+| **Native binary stream** | Library writes/reads `Stream` with its binary API | ProtoBuf, Bond, BinaryPack, MemoryPack, NetSerializer, Hyperion, GroBuf, Google.Protobuf, DataContract*, FsPickler, ZeroFormatter, Migrant *(envelope only)*, … |
+| **Text writer on stream** | Library writes to `TextWriter`/`JsonTextWriter` over the stream (real library streaming text API; not “serialize whole string then dump”) | Json.Net, Jil, YamlDotNet, SharpYaml, System.Text.Json (when bound to stream), … |
+| **Adapted stream** | Stream path is “take the full string (or Base64) path and write/read it” via `StreamWriter`/`StreamReader` | **ExtendedXmlSerializer**, CsvHelper (CSV text via StreamWriter), fastJson / NetJSON when they delegate to the string path, some Ceras string-delegate paths |
+
+When stream ≈ string within a few percent on Results, check which kind applies. Prefer **within-mode** comparisons (string vs string, stream vs stream). **String mode for binary codecs** almost always includes Base64; do not compare that string size 1:1 with pure binary stream size without converting.
+
 ### Caveats
 
 - **Domain types:** `Message`, `Document`, `Telemetry`, `Strings`, `Event` (+ batch wrappers) in [`c-sharp/src/TestData/V2/Models.cs`](../../c-sharp/src/TestData/V2/Models.cs).
-- All registered serializers run on all suite data types. Most serialize domain types **directly** (attributes on the V2 models: `[DataContract]`, `[ProtoContract]`, `[Schema]`, `[MemoryPackable]`, …).
-- A few codecs still need untimed `PrepareData` / `ToDomain` for **library wire format** (not old→new type mapping): Google.Protobuf (`IMessage` from `.proto`), ZeroFormatter (`KeyTuple` on net8), FlatSharp (blob + MemoryPack payload), CsvHelper / BinaryPack / ExtendedXml / Migrant (string envelopes where the library cannot hold nested graphs on net8). See serializer source comments.
+- Most codecs serialize domain types **directly** (attributes on V2 models: `[DataContract]`, `[ProtoContract]`, `[Schema]`, `[MemoryPackable]`, …).
+- **Library-native prepare (still real domain or codegen forms):** Google.Protobuf (`IMessage`), ZeroFormatter (`KeyTuple` on net8), FlatSharp (tables via map), CsvHelper (row lists). These are **not** JSON envelopes.
+- **Envelope exceptions:** ExtendedXmlSerializer and Migrant only — see above.
 - **Apex.Serialization** removed (crashes on .NET 8 `FieldInfoModifier`); **FluentSerializer** removed (cannot encode nested graphs / long strings reliably). **System.Text.Json** included.
 - SpanJson / Utf8Json cache closed generic delegates in `Initialize` (no per-call reflection).
 - Jil reuses a single static `Options` instance.
 - Benchmark runner no longer prints per-repetition DEBUG lines (measurement noise).
-
 - Failures: `logs/csharp/<ts>.errors.csv` (per run).
-- Rankings: use generated reports (`analyze-benchmarks`), not this list.
+- Rankings: use generated reports (`analyze-benchmarks`), not this list. Prefer [same category](../analysis/serialization_categories.md) and same I/O mode.
 
 Benchmark runner: [`c-sharp/README.md`](../../c-sharp/README.md). Categories & format trade-offs: [Serialization Categories](../analysis/serialization_categories.md).
 


### PR DESCRIPTION
## Summary
- **Envelope honesty:** ExtendedXmlSerializer and Migrant are documented (Overview + source) as timed **JSON envelopes**, not domain XML / domain Migrant graphs. Fidelity via untimed `ToDomain`.
- **Stream honesty:** Overview table distinguishes native binary stream, text-writer-on-stream (e.g. Json.Net), and fully adapted stream (e.g. ExtendedXml string dump). String mode for binary codecs is Base64.
- CsvHelper / BinaryPack comments corrected (not lumped with envelopes).

## Validation
- `dotnet build` Release — succeed (existing package warnings only)
- No re-bench required (docs + comments; timed paths unchanged)

## Notes
- Log `SerializerName` strings unchanged to preserve history; Results readers should use the new Overview sections when interpreting those two rows.