### PR TITLE
docs: Benchmark modes guide (I/O + run modes)

### DIFF
--- a/analysis/src/benchmark_analysis/reports.py
+++ b/analysis/src/benchmark_analysis/reports.py
@@ -1175,6 +1175,7 @@ def generate_language_results_pages(
             f"| Topic | Where to read |",
             f"|-------|---------------|",
             f"| Which libraries we measure, and caveats | [{title} overview](index.md) |",
+            f"| I/O modes and run modes | [Modes](../analysis/modes.md) |",
             f"| How CSVs become these tables | [Analysis methodology](../analysis/ANALYSIS_METHODOLOGY.md) |",
             f"| What each metric means | [Metrics catalog](../analysis/METRICS.md) |",
             f"| All languages’ result links | [Results summary](../analysis/BENCHMARK_SUMMARY.md) |",
@@ -1183,14 +1184,18 @@ def generate_language_results_pages(
             "",
             "Compare serializers **inside this language**. Prefer the same "
             "[category](../analysis/serialization_categories.md) "
-            "(for example JSON with JSON) so the comparison stays fair.",
+            "(for example JSON with JSON) and the same "
+            "[I/O mode](../analysis/modes.md) "
+            "so the comparison stays fair.",
             "",
             "| Term | Meaning |",
             "|------|---------|",
             "| **data type** | Sample shape: `message`, `document`, `telemetry`, `strings`, or `event` "
             "(CSV `TestDataName`; older text may say “fixture”) |",
-            "| **bytes mode** | In-memory buffer API (encode to bytes / decode from a buffer) |",
-            "| **stream mode** | Stream-style API (write/read through a stream) |",
+            "| **bytes mode** | In-memory buffer API (encode to bytes / decode from a buffer). "
+            "On C# this is often the **string** path — see [Modes](../analysis/modes.md). |",
+            "| **stream mode** | Stream-style API (write/read through a stream). "
+            "May be native or adapted — see [Modes](../analysis/modes.md). |",
             "| **µs** | Microseconds (one microsecond = 1000 nanoseconds). Tables show µs; raw CSVs store nanoseconds. |",
             "| **Ops/s** | Operations per second from mean total time — higher is faster |",
             "| **Bold** | Best value in that column (lowest time/size; highest ops/s). Ties are all bolded. |",

--- a/docs/analysis/ADDING_A_LANGUAGE.md
+++ b/docs/analysis/ADDING_A_LANGUAGE.md
@@ -3,6 +3,7 @@
 This page is a **checklist for implementers**. Follow it when you want a new programming language in the suite without changing the shared analysis core.
 
 Background (layout, timing model, contract): [Benchmark architecture](architecture.md).  
+I/O modes and run modes: [Modes](modes.md).  
 Test data: [Test data](test_data_configuration.md).  
 How CSVs become tables: [Analysis methodology](ANALYSIS_METHODOLOGY.md).
 

--- a/docs/analysis/ANALYSIS_METHODOLOGY.md
+++ b/docs/analysis/ANALYSIS_METHODOLOGY.md
@@ -9,6 +9,7 @@ If architecture is the lab setup, methodology is the **lab notebook**: what we k
 | If you need… | Go here |
 |--------------|---------|
 | What the benchmark runner times / suite layout | [Benchmark architecture](architecture.md) |
+| I/O modes and run modes | [Modes](modes.md) |
 | Data-type meanings | [Test data](test_data_configuration.md) |
 | Paradigms | [Serialization categories](serialization_categories.md) |
 | How to regenerate site snapshots | [Results summary](BENCHMARK_SUMMARY.md#regenerating-language-snapshots) |
@@ -192,7 +193,7 @@ Honest methodology includes what the suite **cannot** claim.
 - **Cross-language absolute times** are directional at best. Garbage collection, allocators, and runtimes differ. Prefer within-language ranks and effect sizes.
 - **C** default builds may use portable stand-ins under real library names—see the [C overview](../c/index.md).
 - **Rust** paths such as `prost`, `rkyv`, and `minicbor` use concrete native codecs; timed `rkyv` deserialize **materializes** owned values for fidelity—see the [Rust overview](../rust/index.md).
-- **Stream** mode is not always a true incremental API (some benchmark runners buffer, then write).
+- **Stream** mode is not always a true incremental API (some benchmark runners buffer, then write). See [Modes — stream honesty](modes.md#three-levels-of-stream-honesty).
 - **Fidelity** is semantic or structural, not bit-identical across formats.
 - Outlier removal and warmup policy affect means; always read `runs`, confidence intervals, and effect sizes together.
 

--- a/docs/analysis/BENCHMARK_SUMMARY.md
+++ b/docs/analysis/BENCHMARK_SUMMARY.md
@@ -22,7 +22,7 @@ Analysis documentation hub: [Benchmarks overview](index.md).
 | C++ | [Results](../cpp/results.md) | [Overview](../cpp/index.md) |
 | Swift | [Results](../swift/results.md) | [Overview](../swift/index.md) |
 
-Related (not numbers): [Serialization categories](serialization_categories.md) · [Analysis methodology](ANALYSIS_METHODOLOGY.md) · [Benchmark architecture](architecture.md)
+Related (not numbers): [Modes](modes.md) · [Serialization categories](serialization_categories.md) · [Analysis methodology](ANALYSIS_METHODOLOGY.md) · [Benchmark architecture](architecture.md)
 
 ---
 

--- a/docs/analysis/METRICS.md
+++ b/docs/analysis/METRICS.md
@@ -35,7 +35,7 @@ These fields are written by each language benchmark runner. Column order (v1.2+)
 | Column | Unit | Importance | Source | Everyday meaning |
 |--------|------|------------|--------|------------------|
 | `Language` | id | high | runner | Which language ran (`python`, `csharp`, …) |
-| `StringOrStream` | enum | high | runner | API mode: `bytes` / `stream` / legacy aliases |
+| `StringOrStream` | enum | high | runner | I/O mode: `bytes` / `stream` (C# often `string`); see [Modes](modes.md) |
 | `TestDataName` | id | high | runner | Data type id (`message`, `document`, …) |
 | `Repetitions` | count | medium | runner | How many times the loop was configured to run |
 | `RepetitionIndex` | index | medium | runner | Which trial this row is; `0` is the warmup row in raw logs |

--- a/docs/analysis/architecture.md
+++ b/docs/analysis/architecture.md
@@ -83,10 +83,12 @@ CSV rows also record how the serializer was called:
 
 | Label on Results pages | Meaning |
 |------------------------|---------|
-| **bytes mode** | Work with in-memory byte arrays (or equivalent) |
+| **bytes mode** | Work with in-memory byte arrays (or equivalent; C# often uses **string**) |
 | **stream mode** | Work through a stream-style API |
 
-These names describe the **programming interface**, not whether the payload is “large” or “small.” Legacy C# rows may use `string` / `stream` with the same idea.
+These names describe the **programming interface**, not whether the payload is “large” or “small.”
+
+**Full explanation** (why both exist, C# string/Base64, native vs adapted stream, fair comparison): **[Modes](modes.md)**.
 
 ---
 
@@ -141,7 +143,7 @@ Defaults live under `statistics:` and `modes:` in `config/benchmark_config.yaml`
 
 ---
 
-## Run modes (how many repetitions)
+## Run modes (how many repetitions) {#run-modes-how-many-repetitions}
 
 Run modes come from `modes:` in `config/benchmark_config.yaml`. Runners should call `bench_mode_reps` rather than hard-coding counts.
 
@@ -152,6 +154,8 @@ Run modes come from `modes:` in `config/benchmark_config.yaml`. Runners should c
 | `full` | 100 | Publication-quality run |
 | `research` | 500 | High-power statistical study |
 
+**When to pick which mode, and how this differs from I/O mode:** **[Modes — run modes](modes.md#part-2--run-modes-how-heavy-the-experiment-is)**.
+
 **Warmup policy:** benchmark runners **always log** every successful repetition, including index 0. Analysis drops `RepetitionIndex == 0` when `statistics.exclude_warmup` is true (the configured warmup count is **1**). Outlier filtering is also analysis-only. Raw files under `logs/<lang>/` are never rewritten by the stats pipeline.
 
 ---
@@ -160,6 +164,6 @@ Run modes come from `modes:` in `config/benchmark_config.yaml`. Runners should c
 
 | Concern | Where it lives |
 |---------|----------------|
-| Run modes, stats, languages, paths | `config/benchmark_config.yaml` |
+| Run modes, stats, languages, paths | `config/benchmark_config.yaml` — [Modes](modes.md) |
 | Payload shapes and seed | `schemas/data_catalog_v2.yaml` + `config/library/` — [Test data](test_data_configuration.md) |
 | Paradigm inventories | [Serialization categories](serialization_categories.md) + each language **Overview** |

--- a/docs/analysis/index.md
+++ b/docs/analysis/index.md
@@ -13,7 +13,7 @@ You do not need to be a performance engineer to read these pages. They are writt
 After reading this section you should be able to:
 
 1. Say what a **benchmark** is measuring here (serialize and deserialize time, size, and correctness).
-2. Find the right page for layout, statistics, metrics, test data, or published results.
+2. Find the right page for layout, modes, statistics, metrics, test data, or published results.
 3. Compare serializers **within one language** (and ideally one category) instead of treating absolute times as a global ranking.
 4. Open a language **Overview** (what libraries we measure) and its **Results** (the measured numbers).
 
@@ -48,9 +48,10 @@ Each programming language has a small program called a **benchmark runner**. The
 | **benchmark runner** | “harness” | Per-language program that times serializers and writes the CSV |
 | **batch size N** | — | How many instances in one serialize call (`1` or `100`) |
 | **category / family** | — | JSON, schemaless binary, schema-driven, language-native |
-| **bytes / stream mode** | — | Which API shape the benchmark runner called (not payload size) |
+| **I/O mode** (bytes / stream) | — | How the library was called (buffer vs stream), **not** payload size |
+| **run mode** (smoke / full / …) | — | How heavy the experiment is (repetitions / intent) |
 
-Full glossary: [Test data — vocabulary](test_data_configuration.md#vocabulary).
+Full mode guide: [Modes](modes.md). Data-type glossary: [Test data — vocabulary](test_data_configuration.md#vocabulary).
 
 ---
 
@@ -59,6 +60,7 @@ Full glossary: [Test data — vocabulary](test_data_configuration.md#vocabulary)
 | Page | What you will learn | Start here if you want… |
 |------|---------------------|-------------------------|
 | **[Architecture](architecture.md)** | How the repository is organized and how timing works | The measurement design |
+| **[Modes](modes.md)** | I/O modes (bytes/stream) and run modes (smoke…research) | Why Results have two mode columns; which run preset to use |
 | **[Categories](serialization_categories.md)** | Four families of serializers (JSON, binary, schema-driven, native) | Fair “apples to apples” groups |
 | **[Test data](test_data_configuration.md)** | The five sample data types and how sizes are chosen | What we serialize |
 | **[Methodology](ANALYSIS_METHODOLOGY.md)** | Warmup, outliers, confidence intervals, effect sizes | How CSVs become published numbers |

--- a/docs/analysis/modes.md
+++ b/docs/analysis/modes.md
@@ -1,0 +1,226 @@
+# Benchmark modes
+
+This page explains the two different meanings of **mode** in this project. Both show up in docs, scripts, and Results tables. Mixing them up is a common source of confusion.
+
+| Name | Question it answers | Example values |
+|------|---------------------|----------------|
+| **I/O mode** | *How* did we call the serializer? | bytes (or string) · stream |
+| **Run mode** | *How long / how heavy* was the experiment? | smoke · all-single · full · research |
+
+A third related idea is **batch size N** (1 vs 100 instances in one call). That is **not** a “mode”; it lives under [Test data](test_data_configuration.md).
+
+---
+
+## Learning goals
+
+After this page you should be able to:
+
+1. Tell I/O mode and run mode apart in one sentence each.
+2. Explain why Results show **bytes mode** and **stream mode** side by side.
+3. Choose a run mode for a quick check vs a publishable snapshot.
+4. Avoid unfair comparisons (different modes, or “adapted” stream vs a real stream API).
+
+---
+
+## Picture: three knobs on one experiment
+
+```text
+  Run mode          → how many times we repeat the timed loop (and which matrix)
+  I/O mode          → buffer/string API  vs  stream API
+  Data type + N     → e.g. message with N=1 or N=100
+
+  One CSV row = one language + one serializer + one data type + one N + one I/O mode + one repetition
+```
+
+You can change any knob independently. Changing run mode does **not** change what “stream” means.
+
+---
+
+## Part 1 — I/O modes (how we call the library)
+
+### Why two paths?
+
+Real programs use serializers in more than one way:
+
+- **In memory:** “Turn this object into a byte array (or string), then later turn those bytes back into an object.” Common for caches, small RPC bodies, tests.
+- **Through a stream:** “Write the encoded form into a stream” / “Read it from a stream.” Common for files, sockets, and large payloads where you do not want one giant string in memory first.
+
+This suite measures **both call shapes** when the language runner supports them, so rankings are not tied to only one API style.
+
+### What the labels mean
+
+On **Results** pages you usually see:
+
+| Label on Results | Everyday meaning | Typical CSV value (`StringOrStream`) |
+|------------------|------------------|--------------------------------------|
+| **bytes mode** | In-memory buffer (or language equivalent) | `bytes`, `buffer`, or C# **`string`** |
+| **stream mode** | Stream-style write/read | `stream` or `Stream` |
+
+**Important:** these names describe the **programming interface**, not the **size** of the data. “Bytes mode” does **not** mean “small payload.” “Stream mode” does **not** mean “large payload.”
+
+### What is timed
+
+For **each** I/O mode, the stopwatch covers:
+
+1. Serialize using that mode’s API  
+2. Deserialize using that mode’s API  
+
+Setup (schemas, maps, buffer pools) stays **outside** the stopwatch. Details: [Architecture — what we measure](architecture.md#measurement-model).
+
+### C# special case: “string” instead of “bytes”
+
+Most languages log the in-memory path as `bytes`. **C#** often logs it as **`string`**, because many .NET libraries expose `Serialize` / `Deserialize` that return or take a `string`.
+
+| Language family | In-memory path in CSV | Results label |
+|-----------------|----------------------|---------------|
+| Python, Rust, Go, Java, C, C++, JS, Swift | `bytes` (or similar) | **bytes mode** |
+| C# | `string` | still shown as **bytes mode** in multi-language tables for consistency |
+
+On C#, for **binary** libraries, that string is often **Base64** text of the real binary payload. So:
+
+- The **string** path times Base64 encode/decode as well as the library.  
+- The **stream** path may write raw binary without Base64.  
+- **Sizes** on the string path can look larger than stream sizes for the same object — that can be Base64, not a different object.
+
+C#-specific notes: [C# overview — string vs stream](../c-sharp/index.md#string-mode-vs-stream-mode).
+
+### Three levels of “stream” honesty
+
+Not every “stream mode” row is a deep, true streaming API.
+
+| Kind | What the runner does | How to read Results |
+|------|----------------------|---------------------|
+| **Native stream** | Calls the library’s real stream (or reader/writer) API | Best evidence for “stream performance” of that library |
+| **Text writer on a stream** | Library writes text through a writer attached to a stream (common for JSON/YAML) | Still a real library path; not the same as binary stream APIs |
+| **Adapted stream** | Builds the full in-memory result first, then dumps it to a stream (or the reverse) | Times often **close to** the in-memory path; do **not** treat as proof of incremental I/O |
+
+If stream and bytes (or string) times are almost the same, check the language **Overview**. Many suites mark adapted paths there. Methodology also notes that stream is not always incremental: [Analysis methodology — limitations](ANALYSIS_METHODOLOGY.md#limitations).
+
+### How I/O mode appears in the pipeline
+
+| Place | What you see |
+|-------|----------------|
+| Raw CSV | Column `StringOrStream` |
+| Analysis groups | Part of the group key: language + serializer + data type + **I/O mode** |
+| Results tables | Columns or labels **bytes mode** / **stream mode** |
+| Fair ranking | Compare serializers in the **same** language, same data type, same **I/O mode** |
+
+### Fair comparison checklist (I/O)
+
+- Same **language**  
+- Same **category** when possible (JSON with JSON, …)  
+- Same **data type** and same **batch size N**  
+- Same **I/O mode** (do not crown a winner from stream vs someone else’s bytes path)  
+- If stream ≈ bytes, prefer the language Overview’s honesty notes before drawing API conclusions  
+
+---
+
+## Part 2 — Run modes (how heavy the experiment is)
+
+### Why several run modes?
+
+A full matrix (many serializers × data types × N × two I/O modes × many repetitions) takes a long time. The suite offers **presets** so you can:
+
+- smoke-test a change in minutes, or  
+- collect publication-quality samples overnight.
+
+Run modes are defined in `config/benchmark_config.yaml` under `modes:`. Scripts should **read** those values (via `bench_mode_reps`), not invent their own counts.
+
+### The four standard run modes
+
+| Run mode | Repetitions (default) | Intent | Typical use |
+|----------|----------------------|--------|-------------|
+| **smoke** | 2 | Smallest useful run | “Does this still work?” CI, local quick check |
+| **all-single** | 10 | Short full matrix | Fast multi-serializer pass before a long run |
+| **full** | 100 | Publication-quality | Numbers you commit to Results / the site |
+| **research** | 500 | High sample count | Statistics papers, tight confidence intervals |
+
+Exact repetition counts live in config; if config changes, this table should be updated to match.
+
+### What a run mode does *not* change
+
+| Unchanged by run mode | Controlled instead by |
+|-----------------------|------------------------|
+| Which serializers exist | Language registration / Overview |
+| Data type shapes | [Test data](test_data_configuration.md) / `config/library/` |
+| Whether both I/O modes run | Language runner design |
+| Warmup policy | Analysis drops repetition index 0; runners still log it |
+| Fairness rules | Same CSV contract for all modes |
+
+So: **smoke** is not “a different I/O mode.” It is “fewer timed repetitions (and often a smaller data matrix if the script’s config says so).”
+
+### Which run mode should I pick?
+
+| Goal | Prefer |
+|------|--------|
+| I changed one serializer and want a quick green light | `smoke` |
+| I want a full matrix without waiting forever | `all-single` |
+| I will publish or commit Results tables | `full` |
+| I need strong statistical power | `research` |
+
+Example:
+
+```bash
+./scripts/run-all-benchmarks.sh --mode smoke --lang python
+./scripts/run-all-benchmarks.sh --mode full --lang rust
+```
+
+### Warmup and repetitions
+
+- The runner logs **every** successful repetition, including the first (`RepetitionIndex = 0`).  
+- Analysis treats the first as **warmup** and drops it from averages by default.  
+- So `full` with 100 logged reps yields about **99** samples in summaries when warmup exclusion is on.
+
+Details: [Architecture — run modes](architecture.md#run-modes-how-many-repetitions) · [Methodology — warmup](ANALYSIS_METHODOLOGY.md).
+
+---
+
+## Part 3 — How modes show up together
+
+### One example CSV row (idea)
+
+```text
+Language=python, StringOrStream=bytes, TestDataName=message,
+DataTypeInstanceCount=100, SerializerName=orjson, RepetitionIndex=3, ...
+```
+
+Read as: Python, **bytes** I/O mode, data type **message**, batch **N=100**, library **orjson**, 4th timed try (index 3).
+
+### Results tables
+
+- **Summary** rows often average across data types; they still prefer one I/O mode when both exist (usually the in-memory path).  
+- **Total time** pivots often show bytes and stream columns side by side.  
+- **Ops/s** tables break out data types (and N) so you can see which workload matters.
+
+If two columns look almost equal, open [stream honesty](#three-levels-of-stream-honesty) before concluding the library’s stream API is “free.”
+
+### Dashboard and regenerate
+
+- Published tables come from a chosen run (often `full`).  
+- Regenerating: [Results summary](BENCHMARK_SUMMARY.md).  
+- Metrics names: [Metrics catalog](METRICS.md) (`StringOrStream`).
+
+---
+
+## Quick reference
+
+| If you hear… | It means… |
+|--------------|-----------|
+| “bytes mode” / “string mode” | In-memory API path (C# uses string) |
+| “stream mode” | Stream API path (native, text-on-stream, or adapted) |
+| “smoke / full / research” | How heavy the **run** is (repetitions / matrix intent) |
+| “message @ n=100” | Data type + batch size — **not** an I/O mode |
+| “modes in config” | Usually **run** modes under `modes:` in YAML |
+
+---
+
+## Related pages
+
+| Topic | Page |
+|-------|------|
+| Suite layout and timing rules | [Architecture](architecture.md) |
+| How CSVs become numbers | [Methodology](ANALYSIS_METHODOLOGY.md) |
+| Column dictionary | [Metrics](METRICS.md) |
+| Data types and batch size N | [Test data](test_data_configuration.md) |
+| C# string / Base64 / envelopes | [C# overview](../c-sharp/index.md) |
+| Fair format families | [Categories](serialization_categories.md) |

--- a/docs/c-sharp/results.md
+++ b/docs/c-sharp/results.md
@@ -7,19 +7,20 @@ This page is a **snapshot of measured numbers** for C# (.NET) on one machine. Co
 | Topic | Where to read |
 |-------|---------------|
 | Which libraries we measure, and caveats | [C# (.NET) overview](index.md) |
+| I/O modes and run modes | [Modes](../analysis/modes.md) |
 | How CSVs become these tables | [Analysis methodology](../analysis/ANALYSIS_METHODOLOGY.md) |
 | What each metric means | [Metrics catalog](../analysis/METRICS.md) |
 | All languages’ result links | [Results summary](../analysis/BENCHMARK_SUMMARY.md) |
 
 ## How to read these tables
 
-Compare serializers **inside this language**. Prefer the same [category](../analysis/serialization_categories.md) (for example JSON with JSON) so the comparison stays fair.
+Compare serializers **inside this language**. Prefer the same [category](../analysis/serialization_categories.md) (for example JSON with JSON) and the same [I/O mode](../analysis/modes.md) so the comparison stays fair.
 
 | Term | Meaning |
 |------|---------|
 | **data type** | Sample shape: `message`, `document`, `telemetry`, `strings`, or `event` (CSV `TestDataName`; older text may say “fixture”) |
-| **bytes mode** | In-memory buffer API (encode to bytes / decode from a buffer) |
-| **stream mode** | Stream-style API (write/read through a stream) |
+| **bytes mode** | In-memory buffer API (encode to bytes / decode from a buffer). On C# this is often the **string** path — see [Modes](../analysis/modes.md). |
+| **stream mode** | Stream-style API (write/read through a stream). May be native or adapted — see [Modes](../analysis/modes.md). |
 | **µs** | Microseconds (one microsecond = 1000 nanoseconds). Tables show µs; raw CSVs store nanoseconds. |
 | **Ops/s** | Operations per second from mean total time — higher is faster |
 | **Bold** | Best value in that column (lowest time/size; highest ops/s). Ties are all bolded. |

--- a/docs/c/results.md
+++ b/docs/c/results.md
@@ -7,19 +7,20 @@ This page is a **snapshot of measured numbers** for C on one machine. Continuous
 | Topic | Where to read |
 |-------|---------------|
 | Which libraries we measure, and caveats | [C overview](index.md) |
+| I/O modes and run modes | [Modes](../analysis/modes.md) |
 | How CSVs become these tables | [Analysis methodology](../analysis/ANALYSIS_METHODOLOGY.md) |
 | What each metric means | [Metrics catalog](../analysis/METRICS.md) |
 | All languages’ result links | [Results summary](../analysis/BENCHMARK_SUMMARY.md) |
 
 ## How to read these tables
 
-Compare serializers **inside this language**. Prefer the same [category](../analysis/serialization_categories.md) (for example JSON with JSON) so the comparison stays fair.
+Compare serializers **inside this language**. Prefer the same [category](../analysis/serialization_categories.md) (for example JSON with JSON) and the same [I/O mode](../analysis/modes.md) so the comparison stays fair.
 
 | Term | Meaning |
 |------|---------|
 | **data type** | Sample shape: `message`, `document`, `telemetry`, `strings`, or `event` (CSV `TestDataName`; older text may say “fixture”) |
-| **bytes mode** | In-memory buffer API (encode to bytes / decode from a buffer) |
-| **stream mode** | Stream-style API (write/read through a stream) |
+| **bytes mode** | In-memory buffer API (encode to bytes / decode from a buffer). On C# this is often the **string** path — see [Modes](../analysis/modes.md). |
+| **stream mode** | Stream-style API (write/read through a stream). May be native or adapted — see [Modes](../analysis/modes.md). |
 | **µs** | Microseconds (one microsecond = 1000 nanoseconds). Tables show µs; raw CSVs store nanoseconds. |
 | **Ops/s** | Operations per second from mean total time — higher is faster |
 | **Bold** | Best value in that column (lowest time/size; highest ops/s). Ties are all bolded. |

--- a/docs/cpp/results.md
+++ b/docs/cpp/results.md
@@ -7,19 +7,20 @@ This page is a **snapshot of measured numbers** for C++ on one machine. Continuo
 | Topic | Where to read |
 |-------|---------------|
 | Which libraries we measure, and caveats | [C++ overview](index.md) |
+| I/O modes and run modes | [Modes](../analysis/modes.md) |
 | How CSVs become these tables | [Analysis methodology](../analysis/ANALYSIS_METHODOLOGY.md) |
 | What each metric means | [Metrics catalog](../analysis/METRICS.md) |
 | All languages’ result links | [Results summary](../analysis/BENCHMARK_SUMMARY.md) |
 
 ## How to read these tables
 
-Compare serializers **inside this language**. Prefer the same [category](../analysis/serialization_categories.md) (for example JSON with JSON) so the comparison stays fair.
+Compare serializers **inside this language**. Prefer the same [category](../analysis/serialization_categories.md) (for example JSON with JSON) and the same [I/O mode](../analysis/modes.md) so the comparison stays fair.
 
 | Term | Meaning |
 |------|---------|
 | **data type** | Sample shape: `message`, `document`, `telemetry`, `strings`, or `event` (CSV `TestDataName`; older text may say “fixture”) |
-| **bytes mode** | In-memory buffer API (encode to bytes / decode from a buffer) |
-| **stream mode** | Stream-style API (write/read through a stream) |
+| **bytes mode** | In-memory buffer API (encode to bytes / decode from a buffer). On C# this is often the **string** path — see [Modes](../analysis/modes.md). |
+| **stream mode** | Stream-style API (write/read through a stream). May be native or adapted — see [Modes](../analysis/modes.md). |
 | **µs** | Microseconds (one microsecond = 1000 nanoseconds). Tables show µs; raw CSVs store nanoseconds. |
 | **Ops/s** | Operations per second from mean total time — higher is faster |
 | **Bold** | Best value in that column (lowest time/size; highest ops/s). Ties are all bolded. |

--- a/docs/go/results.md
+++ b/docs/go/results.md
@@ -7,19 +7,20 @@ This page is a **snapshot of measured numbers** for Go on one machine. Continuou
 | Topic | Where to read |
 |-------|---------------|
 | Which libraries we measure, and caveats | [Go overview](index.md) |
+| I/O modes and run modes | [Modes](../analysis/modes.md) |
 | How CSVs become these tables | [Analysis methodology](../analysis/ANALYSIS_METHODOLOGY.md) |
 | What each metric means | [Metrics catalog](../analysis/METRICS.md) |
 | All languages’ result links | [Results summary](../analysis/BENCHMARK_SUMMARY.md) |
 
 ## How to read these tables
 
-Compare serializers **inside this language**. Prefer the same [category](../analysis/serialization_categories.md) (for example JSON with JSON) so the comparison stays fair.
+Compare serializers **inside this language**. Prefer the same [category](../analysis/serialization_categories.md) (for example JSON with JSON) and the same [I/O mode](../analysis/modes.md) so the comparison stays fair.
 
 | Term | Meaning |
 |------|---------|
 | **data type** | Sample shape: `message`, `document`, `telemetry`, `strings`, or `event` (CSV `TestDataName`; older text may say “fixture”) |
-| **bytes mode** | In-memory buffer API (encode to bytes / decode from a buffer) |
-| **stream mode** | Stream-style API (write/read through a stream) |
+| **bytes mode** | In-memory buffer API (encode to bytes / decode from a buffer). On C# this is often the **string** path — see [Modes](../analysis/modes.md). |
+| **stream mode** | Stream-style API (write/read through a stream). May be native or adapted — see [Modes](../analysis/modes.md). |
 | **µs** | Microseconds (one microsecond = 1000 nanoseconds). Tables show µs; raw CSVs store nanoseconds. |
 | **Ops/s** | Operations per second from mean total time — higher is faster |
 | **Bold** | Best value in that column (lowest time/size; highest ops/s). Ties are all bolded. |

--- a/docs/java/results.md
+++ b/docs/java/results.md
@@ -7,19 +7,20 @@ This page is a **snapshot of measured numbers** for Java on one machine. Continu
 | Topic | Where to read |
 |-------|---------------|
 | Which libraries we measure, and caveats | [Java overview](index.md) |
+| I/O modes and run modes | [Modes](../analysis/modes.md) |
 | How CSVs become these tables | [Analysis methodology](../analysis/ANALYSIS_METHODOLOGY.md) |
 | What each metric means | [Metrics catalog](../analysis/METRICS.md) |
 | All languages’ result links | [Results summary](../analysis/BENCHMARK_SUMMARY.md) |
 
 ## How to read these tables
 
-Compare serializers **inside this language**. Prefer the same [category](../analysis/serialization_categories.md) (for example JSON with JSON) so the comparison stays fair.
+Compare serializers **inside this language**. Prefer the same [category](../analysis/serialization_categories.md) (for example JSON with JSON) and the same [I/O mode](../analysis/modes.md) so the comparison stays fair.
 
 | Term | Meaning |
 |------|---------|
 | **data type** | Sample shape: `message`, `document`, `telemetry`, `strings`, or `event` (CSV `TestDataName`; older text may say “fixture”) |
-| **bytes mode** | In-memory buffer API (encode to bytes / decode from a buffer) |
-| **stream mode** | Stream-style API (write/read through a stream) |
+| **bytes mode** | In-memory buffer API (encode to bytes / decode from a buffer). On C# this is often the **string** path — see [Modes](../analysis/modes.md). |
+| **stream mode** | Stream-style API (write/read through a stream). May be native or adapted — see [Modes](../analysis/modes.md). |
 | **µs** | Microseconds (one microsecond = 1000 nanoseconds). Tables show µs; raw CSVs store nanoseconds. |
 | **Ops/s** | Operations per second from mean total time — higher is faster |
 | **Bold** | Best value in that column (lowest time/size; highest ops/s). Ties are all bolded. |

--- a/docs/javascript/results.md
+++ b/docs/javascript/results.md
@@ -7,19 +7,20 @@ This page is a **snapshot of measured numbers** for JavaScript (Node.js) on one 
 | Topic | Where to read |
 |-------|---------------|
 | Which libraries we measure, and caveats | [JavaScript (Node.js) overview](index.md) |
+| I/O modes and run modes | [Modes](../analysis/modes.md) |
 | How CSVs become these tables | [Analysis methodology](../analysis/ANALYSIS_METHODOLOGY.md) |
 | What each metric means | [Metrics catalog](../analysis/METRICS.md) |
 | All languages’ result links | [Results summary](../analysis/BENCHMARK_SUMMARY.md) |
 
 ## How to read these tables
 
-Compare serializers **inside this language**. Prefer the same [category](../analysis/serialization_categories.md) (for example JSON with JSON) so the comparison stays fair.
+Compare serializers **inside this language**. Prefer the same [category](../analysis/serialization_categories.md) (for example JSON with JSON) and the same [I/O mode](../analysis/modes.md) so the comparison stays fair.
 
 | Term | Meaning |
 |------|---------|
 | **data type** | Sample shape: `message`, `document`, `telemetry`, `strings`, or `event` (CSV `TestDataName`; older text may say “fixture”) |
-| **bytes mode** | In-memory buffer API (encode to bytes / decode from a buffer) |
-| **stream mode** | Stream-style API (write/read through a stream) |
+| **bytes mode** | In-memory buffer API (encode to bytes / decode from a buffer). On C# this is often the **string** path — see [Modes](../analysis/modes.md). |
+| **stream mode** | Stream-style API (write/read through a stream). May be native or adapted — see [Modes](../analysis/modes.md). |
 | **µs** | Microseconds (one microsecond = 1000 nanoseconds). Tables show µs; raw CSVs store nanoseconds. |
 | **Ops/s** | Operations per second from mean total time — higher is faster |
 | **Bold** | Best value in that column (lowest time/size; highest ops/s). Ties are all bolded. |

--- a/docs/python/results.md
+++ b/docs/python/results.md
@@ -7,19 +7,20 @@ This page is a **snapshot of measured numbers** for Python on one machine. Conti
 | Topic | Where to read |
 |-------|---------------|
 | Which libraries we measure, and caveats | [Python overview](index.md) |
+| I/O modes and run modes | [Modes](../analysis/modes.md) |
 | How CSVs become these tables | [Analysis methodology](../analysis/ANALYSIS_METHODOLOGY.md) |
 | What each metric means | [Metrics catalog](../analysis/METRICS.md) |
 | All languages’ result links | [Results summary](../analysis/BENCHMARK_SUMMARY.md) |
 
 ## How to read these tables
 
-Compare serializers **inside this language**. Prefer the same [category](../analysis/serialization_categories.md) (for example JSON with JSON) so the comparison stays fair.
+Compare serializers **inside this language**. Prefer the same [category](../analysis/serialization_categories.md) (for example JSON with JSON) and the same [I/O mode](../analysis/modes.md) so the comparison stays fair.
 
 | Term | Meaning |
 |------|---------|
 | **data type** | Sample shape: `message`, `document`, `telemetry`, `strings`, or `event` (CSV `TestDataName`; older text may say “fixture”) |
-| **bytes mode** | In-memory buffer API (encode to bytes / decode from a buffer) |
-| **stream mode** | Stream-style API (write/read through a stream) |
+| **bytes mode** | In-memory buffer API (encode to bytes / decode from a buffer). On C# this is often the **string** path — see [Modes](../analysis/modes.md). |
+| **stream mode** | Stream-style API (write/read through a stream). May be native or adapted — see [Modes](../analysis/modes.md). |
 | **µs** | Microseconds (one microsecond = 1000 nanoseconds). Tables show µs; raw CSVs store nanoseconds. |
 | **Ops/s** | Operations per second from mean total time — higher is faster |
 | **Bold** | Best value in that column (lowest time/size; highest ops/s). Ties are all bolded. |

--- a/docs/rust/results.md
+++ b/docs/rust/results.md
@@ -7,19 +7,20 @@ This page is a **snapshot of measured numbers** for Rust on one machine. Continu
 | Topic | Where to read |
 |-------|---------------|
 | Which libraries we measure, and caveats | [Rust overview](index.md) |
+| I/O modes and run modes | [Modes](../analysis/modes.md) |
 | How CSVs become these tables | [Analysis methodology](../analysis/ANALYSIS_METHODOLOGY.md) |
 | What each metric means | [Metrics catalog](../analysis/METRICS.md) |
 | All languages’ result links | [Results summary](../analysis/BENCHMARK_SUMMARY.md) |
 
 ## How to read these tables
 
-Compare serializers **inside this language**. Prefer the same [category](../analysis/serialization_categories.md) (for example JSON with JSON) so the comparison stays fair.
+Compare serializers **inside this language**. Prefer the same [category](../analysis/serialization_categories.md) (for example JSON with JSON) and the same [I/O mode](../analysis/modes.md) so the comparison stays fair.
 
 | Term | Meaning |
 |------|---------|
 | **data type** | Sample shape: `message`, `document`, `telemetry`, `strings`, or `event` (CSV `TestDataName`; older text may say “fixture”) |
-| **bytes mode** | In-memory buffer API (encode to bytes / decode from a buffer) |
-| **stream mode** | Stream-style API (write/read through a stream) |
+| **bytes mode** | In-memory buffer API (encode to bytes / decode from a buffer). On C# this is often the **string** path — see [Modes](../analysis/modes.md). |
+| **stream mode** | Stream-style API (write/read through a stream). May be native or adapted — see [Modes](../analysis/modes.md). |
 | **µs** | Microseconds (one microsecond = 1000 nanoseconds). Tables show µs; raw CSVs store nanoseconds. |
 | **Ops/s** | Operations per second from mean total time — higher is faster |
 | **Bold** | Best value in that column (lowest time/size; highest ops/s). Ties are all bolded. |

--- a/docs/swift/results.md
+++ b/docs/swift/results.md
@@ -7,19 +7,20 @@ This page is a **snapshot of measured numbers** for Swift on one machine. Contin
 | Topic | Where to read |
 |-------|---------------|
 | Which libraries we measure, and caveats | [Swift overview](index.md) |
+| I/O modes and run modes | [Modes](../analysis/modes.md) |
 | How CSVs become these tables | [Analysis methodology](../analysis/ANALYSIS_METHODOLOGY.md) |
 | What each metric means | [Metrics catalog](../analysis/METRICS.md) |
 | All languages’ result links | [Results summary](../analysis/BENCHMARK_SUMMARY.md) |
 
 ## How to read these tables
 
-Compare serializers **inside this language**. Prefer the same [category](../analysis/serialization_categories.md) (for example JSON with JSON) so the comparison stays fair.
+Compare serializers **inside this language**. Prefer the same [category](../analysis/serialization_categories.md) (for example JSON with JSON) and the same [I/O mode](../analysis/modes.md) so the comparison stays fair.
 
 | Term | Meaning |
 |------|---------|
 | **data type** | Sample shape: `message`, `document`, `telemetry`, `strings`, or `event` (CSV `TestDataName`; older text may say “fixture”) |
-| **bytes mode** | In-memory buffer API (encode to bytes / decode from a buffer) |
-| **stream mode** | Stream-style API (write/read through a stream) |
+| **bytes mode** | In-memory buffer API (encode to bytes / decode from a buffer). On C# this is often the **string** path — see [Modes](../analysis/modes.md). |
+| **stream mode** | Stream-style API (write/read through a stream). May be native or adapted — see [Modes](../analysis/modes.md). |
 | **µs** | Microseconds (one microsecond = 1000 nanoseconds). Tables show µs; raw CSVs store nanoseconds. |
 | **Ops/s** | Operations per second from mean total time — higher is faster |
 | **Bold** | Best value in that column (lowest time/size; highest ops/s). Ties are all bolded. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -152,6 +152,7 @@ nav:
       - Overview: analysis/index.md
       - 📊 Dashboard: dashboard/
       - Architecture: analysis/architecture.md
+      - Modes: analysis/modes.md
       - Adding a Language: analysis/ADDING_A_LANGUAGE.md
       - Categories: analysis/serialization_categories.md
       - Methodology: analysis/ANALYSIS_METHODOLOGY.md


### PR DESCRIPTION
## Summary
- New **Modes** page (`docs/analysis/modes.md`): plain-language guide to **I/O modes** (bytes/string vs stream) and **run modes** (smoke…research).
- Covers why both I/O paths exist, C# string/Base64, stream honesty (native / text-on-stream / adapted), fair comparison, and which run preset to use.
- Linked from Benchmarks hub, architecture, methodology, metrics, Results “how to read”, Results generator, and MkDocs nav (**Benchmarks → Modes**).

## Validation
- Tests: analysis (57), python (29), javascript (8), rust (10), C++ roundtrips — **pass**
- Benchmarks: **skipped** — prose/docs only (`detect-changed-langs` empty; README/md + Results prose + reports generator)
- Error CSVs: N/A
- Analysis re-bench: N/A
- Dashboard: `sync-data.py` run; `*_latest.json.gz` content unchanged (recompression churn discarded)

## Notes
- Terminology: **benchmark runner**, **data type** (no harness/fixture on the new page).
- No numeric Results tables regenerated (links/glossary only).