### PR TITLE
feat(analysis): exploratory ranks + multi-session claim tooling

### DIFF
--- a/analysis/ANALYSIS_CRITIQUE.md
+++ b/analysis/ANALYSIS_CRITIQUE.md
@@ -63,9 +63,10 @@ It sits between raw harness output (timestamped `logs/<lang>/YYYY-MM-DD-HHMMSS.c
 `compute_statistics()` produces:
 - per-group bootstrap CIs
 - median, MAD, CV, multiple percentiles
-- `effect_vs_fastest_cliffs_delta` + label + Hedges’ g
+- `effect_vs_fastest_cliffs_delta` + label + Hedges’ g + MWU/Holm p (A-1; exploratory multi-way)
 - fidelity, memory, warmup/outlier counts
 - `_times_total_filtered` for further tests
+- multi-session aggregate path (`--multi-session`, claim levels L1–L3) for A-6/B-3
 
 **What actually appears in published docs:**
 

--- a/analysis/CRITIQUE_AND_IMPROVEMENTS.md
+++ b/analysis/CRITIQUE_AND_IMPROVEMENTS.md
@@ -38,7 +38,13 @@ This document records an unvarnished review of the v2 refactor and what was fixe
 
 **Problem:** Comparing Rust `sonic-rs` ns to Python `orjson` ns invites invalid conclusions.
 
-**Mitigation:** Reports group by language; effect sizes are within (language, data, mode). Emphasize **within-language ranks**, not absolute cross-runtime champions.
+**Mitigation:** Reports group by language; effect sizes are within (language, data, mode). Emphasize **within-language ranks**, not absolute cross-runtime champions. Claim ladder L1/L2/L3 ([Claims and replication](../docs/analysis/CLAIMS_AND_REPLICATION.md)); multi-session CLI for within-language generalization language only.
+
+### 4b. Multi-way ranks without multiplicity (A-1) — **addressed**
+
+**Problem:** Effect-vs-fastest tables can be read as confirmatory without multiplicity control.
+
+**Fixed (analysis):** Mann–Whitney + **within-group Holm**; median reference; exploratory banners on Results; metrics catalog fields `effect_vs_fastest_p_value(_holm)`. Pairwise A/B remains the confirmatory path.
 
 ### 5. Fidelity is heuristic (LOW–MEDIUM)
 

--- a/analysis/src/benchmark_analysis/cli.py
+++ b/analysis/src/benchmark_analysis/cli.py
@@ -271,6 +271,157 @@ def _resolve_logs_assignment(
     return lang, resolved
 
 
+def _expand_multi_session_specs(specs: Sequence[str]) -> List[str]:
+    """Flatten repeated flags and comma-separated tokens."""
+    out: List[str] = []
+    for spec in specs:
+        for part in str(spec).split(","):
+            part = part.strip()
+            if part:
+                out.append(part)
+    return out
+
+
+def _resolve_multi_session_paths(
+    specs: Sequence[str],
+    *,
+    logs_root: Path,
+    languages: Optional[Sequence[str]] = None,
+) -> Dict[str, List[str]]:
+    """Resolve multi-session tokens to ``{language: [csv_path, ...]}``.
+
+    Accepted token forms:
+    - path to a CSV file
+    - ``LANG:stem`` or ``LANG:latest`` shorthand under logs_root
+    - ``LANG=stem`` (same as ``LANG:stem``; useful with commas: ``python=a,python=b``)
+    - bare language when ``-l`` is set is not enough alone — need at least two stems
+    """
+    by_lang: Dict[str, List[str]] = {}
+    tokens = _expand_multi_session_specs(specs)
+    # Support LANG=stem1 style (split left=right once)
+    normalized: List[Tuple[Optional[str], str]] = []
+    for tok in tokens:
+        if "=" in tok and not Path(tok).exists() and not tok.startswith("/"):
+            left, right = tok.split("=", 1)
+            left, right = left.strip(), right.strip()
+            if re.fullmatch(r"[A-Za-z][A-Za-z0-9_-]*", left) and right:
+                lang = _try_normalize_language(left) or left.lower()
+                # right may still be stem or path
+                if ":" not in right and not Path(right).exists():
+                    normalized.append((lang, f"{lang}:{right}"))
+                else:
+                    normalized.append((lang, right))
+                continue
+        normalized.append((None, tok))
+
+    for forced_lang, tok in normalized:
+        path = _resolve_log_spec(tok, logs_root=logs_root)
+        if not path or not os.path.isfile(path):
+            raise SystemExit(
+                f"Cannot resolve --multi-session token {tok!r} under {logs_root}"
+            )
+        lang = forced_lang or _infer_language_from_path(path)
+        if lang is None and languages and len(languages) == 1:
+            lang = _normalize_language(languages[0])
+        if lang is None:
+            raise SystemExit(
+                f"Cannot determine language for --multi-session {tok!r}. "
+                f"Use LANG:stem or pair with -l LANG."
+            )
+        by_lang.setdefault(lang, []).append(path)
+
+    # De-dupe while preserving order
+    for lang in list(by_lang):
+        seen = set()
+        uniq: List[str] = []
+        for p in by_lang[lang]:
+            if p not in seen:
+                seen.add(p)
+                uniq.append(p)
+        by_lang[lang] = uniq
+
+    if languages:
+        wanted = {_normalize_language(x) for x in languages}
+        by_lang = {k: v for k, v in by_lang.items() if k in wanted}
+
+    return by_lang
+
+
+def _run_multi_session(
+    *,
+    specs: Sequence[str],
+    logs_root: Path,
+    reports_root: Path,
+    languages: Optional[Sequence[str]],
+    stats_config: Optional[Dict] = None,
+) -> None:
+    """Multi-session aggregation: write JSON + markdown per language."""
+    import json
+    import datetime
+
+    from .multi_session import (
+        aggregate_multi_session,
+        load_stats_for_csv,
+        machine_id_from_sidecar,
+        multi_session_markdown,
+    )
+
+    by_lang = _resolve_multi_session_paths(
+        specs, logs_root=logs_root, languages=languages
+    )
+    if not by_lang:
+        print("Error: --multi-session resolved to no CSV paths.")
+        sys.exit(1)
+
+    os.makedirs(str(reports_root), exist_ok=True)
+    for lang, paths in sorted(by_lang.items()):
+        if len(paths) < 2:
+            print(
+                f"Error: multi-session for '{lang}' needs ≥2 distinct CSVs "
+                f"(got {len(paths)}). Pass more --multi-session tokens."
+            )
+            sys.exit(1)
+        sessions: List[Dict] = []
+        for p in paths:
+            stem = Path(p).stem
+            stats = load_stats_for_csv(
+                p, language_hint=lang, stats_config=stats_config
+            )
+            sessions.append(
+                {
+                    "run_id": stem,
+                    "machine_id": machine_id_from_sidecar(p),
+                    "stats": stats,
+                }
+            )
+            print(f"  session {stem}: {len(stats)} groups from {p}")
+        report = aggregate_multi_session(sessions, language=lang)
+        report["generated"] = datetime.datetime.now().isoformat()
+        report["source_paths"] = paths
+        json_path = reports_root / f"multi_session_{lang}.json"
+        md_path = reports_root / f"multi_session_{lang}.md"
+        with open(json_path, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2)
+        with open(md_path, "w", encoding="utf-8") as f:
+            f.write(multi_session_markdown(report))
+        print(
+            f"Multi-session ({lang}): claim_level={report.get('claim_level')} "
+            f"n_sessions={report.get('n_sessions')} "
+            f"machines={report.get('machine_ids') or ['(unknown)']}"
+        )
+        print(f"  Wrote {json_path}")
+        print(f"  Wrote {md_path}")
+        # Console: top rank-frequency rows
+        for row in (report.get("rank_stability") or [])[:8]:
+            top = (row.get("fastest_frequency") or [{}])[0]
+            print(
+                f"  {row.get('test_data')} n={row.get('data_type_instance_count')} "
+                f"{row.get('mode')}: most-often-fastest="
+                f"{top.get('serializer')} "
+                f"({top.get('wins')}/{row.get('n_sessions_ranked')} sessions)"
+            )
+
+
 def _generate_artifacts(
     *,
     all_records: Dict[str, List[Dict]],
@@ -430,6 +581,18 @@ def main():
         action="store_true",
         help="List available result files per language and exit",
     )
+    parser.add_argument(
+        "--multi-session",
+        action="append",
+        default=[],
+        metavar="CSV_OR_SHORTHAND",
+        help=(
+            "Multi-session aggregate (claim level L2/L3 tooling). "
+            "Pass two+ CSV paths or LANG:stem shorthands; repeat the flag or use commas. "
+            "Also accepts LANG=stem1,stem2. Writes reports/multi_session_<lang>.json "
+            "and .md. See docs/analysis/CLAIMS_AND_REPLICATION.md."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -438,6 +601,17 @@ def main():
         stats_cfg["_metrics_profile"] = args.metrics_profile
         os.environ["BENCHMARK_METRICS_PROFILE"] = args.metrics_profile
     logs_root = Path(args.logs_root)
+
+    # Multi-session aggregation (early exit — does not need full matrix load)
+    if args.multi_session:
+        _run_multi_session(
+            specs=args.multi_session,
+            logs_root=logs_root,
+            reports_root=reports_root,
+            languages=args.languages,
+            stats_config=stats_cfg,
+        )
+        return
 
     if args.list:
         print("Available result files (latest marked with *):")

--- a/analysis/src/benchmark_analysis/environment.py
+++ b/analysis/src/benchmark_analysis/environment.py
@@ -22,6 +22,7 @@ Or::
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import platform
@@ -275,16 +276,51 @@ def _public_cwd(cwd: Optional[str] = None) -> str:
     return f"{repo_name}/{rel_s}"
 
 
+def _cpu_governor() -> Optional[str]:
+    """Best-effort CPU frequency governor (Linux); None if unavailable."""
+    # Prefer cpu0; do not require root.
+    path = Path("/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor")
+    try:
+        if path.is_file():
+            return path.read_text(encoding="utf-8").strip() or None
+    except OSError:
+        pass
+    return None
+
+
+def _machine_id(cpu: Dict[str, Any], os_block: Dict[str, Any]) -> str:
+    """Stable short fingerprint for multi-machine claims.
+
+    Not a security identifier — only enough to tell “same host class” apart
+    across sessions without storing the raw hostname in public docs by default.
+    """
+    parts = [
+        str(cpu.get("model") or ""),
+        str(cpu.get("architecture") or platform.machine() or ""),
+        str(os_block.get("system") or platform.system() or ""),
+        str(os_block.get("release") or ""),
+        str(cpu.get("logical_cores") or os.cpu_count() or ""),
+    ]
+    # Optional: include hostname only in the hash material (not exported raw)
+    # so two identical VMs on different hosts still differ when hostnames do.
+    host = platform.node() or ""
+    raw = "|".join(parts + [host])
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
 def _gather_environment() -> Dict[str, Any]:
-    return {
+    cpu = _cpu_info()
+    os_block = {
+        "system": platform.system(),
+        "release": platform.release(),
+        "version": platform.version(),
+        "architecture": platform.machine(),
+    }
+    gov = _cpu_governor()
+    env: Dict[str, Any] = {
         "captured_at": datetime.now(timezone.utc).isoformat(),
-        "os": {
-            "system": platform.system(),
-            "release": platform.release(),
-            "version": platform.version(),
-            "architecture": platform.machine(),
-        },
-        "cpu": _cpu_info(),
+        "os": os_block,
+        "cpu": cpu,
         "memory": _memory_info(),
         "runtimes": _runtime_versions(),
         "git": _git_info(),
@@ -292,7 +328,13 @@ def _gather_environment() -> Dict[str, Any]:
             "pid": os.getpid(),
             "cwd": _public_cwd(),
         },
+        # Claim scoping (single-session default; multi-session uses machine_id)
+        "machine_id": _machine_id(cpu, os_block),
+        "claim_level_hint": "L1_single_session",
     }
+    if gov is not None:
+        env["cpu_governor"] = gov
+    return env
 
 
 def configs_path_for_csv(result_csv_path: str) -> Path:

--- a/analysis/src/benchmark_analysis/metrics_catalog.py
+++ b/analysis/src/benchmark_analysis/metrics_catalog.py
@@ -29,6 +29,9 @@ _DEFAULT_IMPORTANCE: Dict[str, str] = {
     "effect_vs_fastest_cliffs_delta": "medium",
     "effect_vs_fastest_cliffs_label": "medium",
     "effect_vs_fastest_hedges_g": "low",
+    "effect_vs_fastest_p_value": "low",
+    "effect_vs_fastest_p_value_holm": "medium",
+    "effect_vs_fastest_significant_holm": "medium",
 }
 
 _DEFAULT_MULTI_WAY = ["high"]

--- a/analysis/src/benchmark_analysis/multi_session.py
+++ b/analysis/src/benchmark_analysis/multi_session.py
@@ -1,0 +1,233 @@
+"""Multi-session aggregation for claim levels L2/L3.
+
+Given several analyzed run stats dicts (or raw CSVs turned into stats),
+summarize rank stability and session-to-session spread **within one language**.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+
+def _group_key(entry: Dict[str, Any]) -> Tuple:
+    return (
+        entry.get("language"),
+        entry.get("serializer"),
+        entry.get("test_data"),
+        entry.get("type_config_hash"),
+        entry.get("data_type_instance_count"),
+        entry.get("mode"),
+    )
+
+
+def _rank_key(entry: Dict[str, Any]) -> Tuple:
+    """Group for ranking (exclude serializer)."""
+    return (
+        entry.get("language"),
+        entry.get("test_data"),
+        entry.get("type_config_hash"),
+        entry.get("data_type_instance_count"),
+        entry.get("mode"),
+    )
+
+
+def _point(entry: Dict[str, Any]) -> float:
+    v = entry.get("total_median_ns")
+    if v is None or v != v:
+        v = entry.get("avg_time_total_ns") or float("inf")
+    return float(v)
+
+
+def aggregate_multi_session(
+    sessions: Sequence[Dict[str, Any]],
+    *,
+    language: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Aggregate a list of session payloads.
+
+    Each session is::
+        {"run_id": str, "machine_id": optional str, "stats": {group_key: entry}}
+
+    Returns JSON-serializable summary with per-serializer-across-sessions stats
+    and rank-frequency tables.
+    """
+    # serializer key -> list of session medians
+    by_ser: Dict[Tuple, List[float]] = defaultdict(list)
+    # rank group -> Counter of fastest serializer per session
+    rank_wins: Dict[Tuple, Counter] = defaultdict(Counter)
+    machine_ids: List[str] = []
+    run_ids: List[str] = []
+
+    for sess in sessions:
+        run_id = str(sess.get("run_id") or "unknown")
+        run_ids.append(run_id)
+        mid = sess.get("machine_id")
+        if mid:
+            machine_ids.append(str(mid))
+        stats = sess.get("stats") or {}
+        # Rank winners within this session
+        by_rg: Dict[Tuple, List[Dict[str, Any]]] = defaultdict(list)
+        for entry in stats.values():
+            if not isinstance(entry, dict):
+                continue
+            if language and entry.get("language") != language:
+                continue
+            by_ser[_group_key(entry)].append(_point(entry))
+            by_rg[_rank_key(entry)].append(entry)
+        for rg, entries in by_rg.items():
+            if not entries:
+                continue
+            best = min(entries, key=_point)
+            rank_wins[rg][str(best.get("serializer"))] += 1
+
+    n_sessions = len(sessions)
+    unique_machines = sorted(set(machine_ids))
+    # L2 requires ≥3 sessions and exactly one *known* machine_id (missing
+    # sidecars must not silently invent "same host").
+    claim_level = "L1_single_session"
+    if len(unique_machines) >= 2:
+        claim_level = "L3_multi_machine"
+    elif n_sessions >= 3 and len(unique_machines) == 1:
+        claim_level = "L2_multi_session_same_host"
+    elif n_sessions >= 3 and len(unique_machines) == 0:
+        claim_level = "L2_multi_session_host_unknown"
+
+    groups_out: List[Dict[str, Any]] = []
+    for gkey, vals in sorted(by_ser.items(), key=lambda t: str(t[0])):
+        arr = np.asarray(vals, dtype=float)
+        groups_out.append(
+            {
+                "language": gkey[0],
+                "serializer": gkey[1],
+                "test_data": gkey[2],
+                "type_config_hash": gkey[3],
+                "data_type_instance_count": gkey[4],
+                "mode": gkey[5],
+                "n_sessions": int(len(arr)),
+                "median_of_session_medians_ns": float(np.median(arr)),
+                "iqr_across_sessions_ns": float(
+                    np.percentile(arr, 75) - np.percentile(arr, 25)
+                )
+                if len(arr) >= 2
+                else 0.0,
+                "min_session_ns": float(np.min(arr)),
+                "max_session_ns": float(np.max(arr)),
+            }
+        )
+
+    rank_table: List[Dict[str, Any]] = []
+    for rg, counter in sorted(rank_wins.items(), key=lambda t: str(t[0])):
+        total = sum(counter.values()) or 1
+        top = counter.most_common(5)
+        rank_table.append(
+            {
+                "language": rg[0],
+                "test_data": rg[1],
+                "type_config_hash": rg[2],
+                "data_type_instance_count": rg[3],
+                "mode": rg[4],
+                "n_sessions_ranked": total,
+                "fastest_frequency": [
+                    {"serializer": s, "wins": w, "fraction": w / total} for s, w in top
+                ],
+            }
+        )
+
+    return {
+        "schema_version": 1,
+        "language": language,
+        "n_sessions": n_sessions,
+        "run_ids": run_ids,
+        "machine_ids": unique_machines,
+        "claim_level": claim_level,
+        "groups": groups_out,
+        "rank_stability": rank_table,
+    }
+
+
+def load_stats_for_csv(
+    csv_path: str,
+    *,
+    language_hint: Optional[str] = None,
+    stats_config: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Parse one CSV and return compute_statistics result."""
+    from .parser import parse_csv_file
+    from .stats import compute_statistics, load_stats_config
+
+    recs, _skipped = parse_csv_file(csv_path, language_hint=language_hint)
+    cfg = stats_config or load_stats_config()
+    return compute_statistics(recs, config=cfg, language_hint=language_hint)
+
+
+def machine_id_from_sidecar(csv_path: str) -> Optional[str]:
+    try:
+        from .environment import load_environment
+
+        doc = load_environment(csv_path)
+        if not doc:
+            return None
+        env = doc.get("environment") if isinstance(doc.get("environment"), dict) else doc
+        mid = env.get("machine_id") if isinstance(env, dict) else None
+        return str(mid) if mid else None
+    except Exception:
+        return None
+
+
+def multi_session_from_paths(
+    paths: Sequence[str],
+    *,
+    language: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build multi-session report from CSV paths."""
+    sessions: List[Dict[str, Any]] = []
+    for p in paths:
+        path = Path(p)
+        if not path.is_file():
+            continue
+        stem = path.stem
+        stats = load_stats_for_csv(str(path), language_hint=language)
+        sessions.append(
+            {
+                "run_id": stem,
+                "machine_id": machine_id_from_sidecar(str(path)),
+                "stats": stats,
+            }
+        )
+    return aggregate_multi_session(sessions, language=language)
+
+
+def multi_session_markdown(report: Dict[str, Any]) -> str:
+    """Short markdown summary for humans."""
+    lines = [
+        f"# Multi-session report ({report.get('language') or 'all'})",
+        "",
+        f"- **Sessions:** {report.get('n_sessions')}",
+        f"- **Run ids:** {', '.join(report.get('run_ids') or [])}",
+        f"- **Machine ids:** {', '.join(report.get('machine_ids') or ['(unknown)'])}",
+        f"- **Claim level (heuristic):** `{report.get('claim_level')}`",
+        "",
+        "See [Claims and replication](../docs/analysis/CLAIMS_AND_REPLICATION.md) "
+        "for what L1/L2/L3 allow you to say.",
+        "",
+        "## Rank stability (how often each serializer is fastest)",
+        "",
+    ]
+    for row in (report.get("rank_stability") or [])[:40]:
+        td = row.get("test_data")
+        n = row.get("data_type_instance_count")
+        mode = row.get("mode")
+        lines.append(f"### {td} · n={n} · {mode}")
+        lines.append("")
+        lines.append("| serializer | wins | fraction |")
+        lines.append("|------------|-----:|---------:|")
+        for f in row.get("fastest_frequency") or []:
+            lines.append(
+                f"| {f.get('serializer')} | {f.get('wins')} | {f.get('fraction', 0):.2f} |"
+            )
+        lines.append("")
+    return "\n".join(lines)

--- a/analysis/src/benchmark_analysis/reports.py
+++ b/analysis/src/benchmark_analysis/reports.py
@@ -1167,10 +1167,13 @@ def generate_language_results_pages(
             "",
             f"**Generated:** {datetime.now().isoformat()}",
             "",
-            f"This page is a **snapshot of measured numbers** for {title} on one machine. "
+            f"This page is a **snapshot of measured numbers** for {title} on **one machine, "
+            "one session** (claim level **L1**). "
             "Continuous integration deploys the documentation site; it does **not** re-run "
             "analysis when docs are published. Re-running benchmarks on another computer "
-            "will usually change the numbers a little.",
+            "will usually change the numbers a little. "
+            "Stronger multi-session / multi-machine claims need more evidence — see "
+            "[Claims and replication](../analysis/CLAIMS_AND_REPLICATION.md).",
             "",
             f"| Topic | Where to read |",
             f"|-------|---------------|",
@@ -1178,6 +1181,7 @@ def generate_language_results_pages(
             f"| I/O modes and run modes | [Modes](../analysis/modes.md) |",
             f"| How CSVs become these tables | [Analysis methodology](../analysis/ANALYSIS_METHODOLOGY.md) |",
             f"| What each metric means | [Metrics catalog](../analysis/METRICS.md) |",
+            f"| What you may claim (L1/L2/L3) | [Claims and replication](../analysis/CLAIMS_AND_REPLICATION.md) |",
             f"| All languages’ result links | [Results summary](../analysis/BENCHMARK_SUMMARY.md) |",
             "",
             "## How to read these tables",
@@ -1209,7 +1213,18 @@ def generate_language_results_pages(
             "",
         ]
 
-        # B-6 stream honesty banner (native / text_on_stream / adapted)
+        # Exploratory ranking banner (multi-way effect-vs-fastest is descriptive)
+        lines.append(
+            "> **Exploratory ranks:** effect sizes vs the fastest codec are **descriptive**. "
+            "When we attach Holm-adjusted tests, they only correct for many serializers "
+            "**inside one** (data type × batch size × I/O mode) group — not for every "
+            "comparison on this page. Prefer pairwise A/B "
+            "(`analyze-benchmarks --compare-a … --compare-b …`) for confirmatory checks. "
+            "See [Analysis methodology — ranks](../analysis/ANALYSIS_METHODOLOGY.md#exploratory-ranks)."
+        )
+        lines.append("")
+
+        # Stream honesty banner (native / text_on_stream / adapted)
         try:
             from .stream_honesty import (
                 stream_honesty_banner_md,

--- a/analysis/src/benchmark_analysis/stats.py
+++ b/analysis/src/benchmark_analysis/stats.py
@@ -55,6 +55,13 @@ _DEFAULT_STATS_CFG: Dict[str, Any] = {
             "small": 0.33,
             "medium": 0.474,
         },
+        # Effect vs fastest within each (lang, data, n, mode) group
+        "vs_fastest": {
+            "reference": "median",  # mean | median
+            "test": "mann_whitney_u",
+            "multiple_comparison": "holm",  # none | holm
+            "exploratory_in_multi_way": True,
+        },
     },
     "hypothesis_tests": {
         "enabled": True,
@@ -80,7 +87,13 @@ def load_stats_config(config_path: Optional[str] = None) -> Dict[str, Any]:
         for k, v in stats.items():
             if isinstance(v, dict) and isinstance(cfg.get(k), dict):
                 merged = dict(cfg[k])
-                merged.update(v)
+                for sk, sv in v.items():
+                    if isinstance(sv, dict) and isinstance(merged.get(sk), dict):
+                        nested = dict(merged[sk])
+                        nested.update(sv)
+                        merged[sk] = nested
+                    else:
+                        merged[sk] = sv
                 cfg[k] = merged
             else:
                 cfg[k] = v
@@ -908,8 +921,20 @@ def compute_statistics(
 
 
 def _attach_effect_sizes(results: Dict, cfg: Dict[str, Any]) -> None:
-    """Attach effect size vs fastest serializer in same (lang, data, instance, mode) group."""
-    thr = (cfg.get("effect_sizes") or {}).get("cliffs_delta_thresholds")
+    """Attach effect size + MWU vs fastest in same (lang, data, instance, mode) group.
+
+    Multiplicity: Holm correction is applied **within each group only**.
+    Multi-way Results treat these as exploratory; see methodology.
+    """
+    eff = cfg.get("effect_sizes") or {}
+    thr = eff.get("cliffs_delta_thresholds")
+    vs = eff.get("vs_fastest") or {}
+    ref_mode = str(vs.get("reference") or "median").strip().lower()
+    mcc = str(vs.get("multiple_comparison") or "holm").strip().lower()
+    ht = cfg.get("hypothesis_tests") or {}
+    alpha = float(ht.get("alpha", 0.05))
+    run_test = bool(ht.get("enabled", True)) and str(vs.get("test") or "mann_whitney_u") == "mann_whitney_u"
+
     groups: Dict[Tuple, List[Any]] = defaultdict(list)
     for key, entry in results.items():
         gkey = (
@@ -921,29 +946,76 @@ def _attach_effect_sizes(results: Dict, cfg: Dict[str, Any]) -> None:
         )
         groups[gkey].append((key, entry))
 
+    def _ref_score(entry: Dict[str, Any]) -> float:
+        if ref_mode == "median":
+            v = entry.get("total_median_ns")
+            if v is not None and v == v:  # not NaN
+                return float(v)
+        return float(entry.get("avg_time_total_ns") or float("inf"))
+
     for gkey, items in groups.items():
         if len(items) < 2:
             for _, entry in items:
                 entry["effect_vs_fastest_cliffs_delta"] = 0.0
                 entry["effect_vs_fastest_cliffs_label"] = "reference"
                 entry["effect_vs_fastest_hedges_g"] = 0.0
+                entry["effect_vs_fastest_p_value"] = None
+                entry["effect_vs_fastest_p_value_holm"] = None
+                entry["effect_vs_fastest_significant_holm"] = None
                 entry["fastest_in_group"] = entry["serializer"]
+                entry["effect_vs_fastest_exploratory"] = True
             continue
-        fastest_key, fastest_entry = min(items, key=lambda t: t[1]["avg_time_total_ns"] or float("inf"))
+
+        fastest_key, fastest_entry = min(items, key=lambda t: _ref_score(t[1]))
         fast_times = fastest_entry.get("_times_total_filtered") or []
+
+        # Collect MWU p-values for non-reference members (stable order)
+        non_ref: List[Tuple[Any, Dict[str, Any]]] = []
+        raw_ps: List[float] = []
         for key, entry in items:
-            entry["fastest_in_group"] = fastest_entry["serializer"]
             if key == fastest_key:
-                entry["effect_vs_fastest_cliffs_delta"] = 0.0
-                entry["effect_vs_fastest_cliffs_label"] = "reference"
-                entry["effect_vs_fastest_hedges_g"] = 0.0
                 continue
             mine = entry.get("_times_total_filtered") or []
-            cd = cliffs_delta(mine, fast_times)
-            hg = hedges_g(mine, fast_times)
+            p = 1.0
+            if run_test and len(mine) >= 2 and len(fast_times) >= 2:
+                _u, p = mann_whitney_u(mine, fast_times)
+            raw_ps.append(float(p))
+            non_ref.append((key, entry))
+
+        if mcc == "holm" and raw_ps:
+            adj_ps = holm_correction(raw_ps)
+        else:
+            adj_ps = list(raw_ps)
+
+        for (key, entry), p_raw, p_adj in zip(non_ref, raw_ps, adj_ps):
+            entry["fastest_in_group"] = fastest_entry["serializer"]
+            entry["effect_vs_fastest_exploratory"] = True
+            mine = entry.get("_times_total_filtered") or []
+            cd = cliffs_delta(mine, fast_times) if mine and fast_times else 0.0
+            hg = hedges_g(mine, fast_times) if mine and fast_times else 0.0
             entry["effect_vs_fastest_cliffs_delta"] = cd
             entry["effect_vs_fastest_cliffs_label"] = cliffs_delta_label(cd, thr)
             entry["effect_vs_fastest_hedges_g"] = hg
+            if run_test and len(mine) >= 2 and len(fast_times) >= 2:
+                entry["effect_vs_fastest_p_value"] = p_raw
+                entry["effect_vs_fastest_p_value_holm"] = p_adj
+                entry["effect_vs_fastest_significant_holm"] = bool(p_adj < alpha)
+            else:
+                entry["effect_vs_fastest_p_value"] = None
+                entry["effect_vs_fastest_p_value_holm"] = None
+                entry["effect_vs_fastest_significant_holm"] = None
+
+        for key, entry in items:
+            if key != fastest_key:
+                continue
+            entry["fastest_in_group"] = entry["serializer"]
+            entry["effect_vs_fastest_cliffs_delta"] = 0.0
+            entry["effect_vs_fastest_cliffs_label"] = "reference"
+            entry["effect_vs_fastest_hedges_g"] = 0.0
+            entry["effect_vs_fastest_p_value"] = None
+            entry["effect_vs_fastest_p_value_holm"] = None
+            entry["effect_vs_fastest_significant_holm"] = None
+            entry["effect_vs_fastest_exploratory"] = True
 
 
 def compare_versions(

--- a/analysis/tests/test_environment_ts.py
+++ b/analysis/tests/test_environment_ts.py
@@ -59,15 +59,20 @@ def test_capture_writes_configs_json_from_csv_stem(monkeypatch, tmp_path: Path):
     assert doc["benchmark_ts"] == "2026-07-01-195234"
     assert doc.get("schema_version") == 1
     assert "environment" in doc
-    cwd = doc["environment"]["process"]["cwd"]
+    env = doc["environment"]
+    cwd = env["process"]["cwd"]
     assert not cwd.startswith("/")
     assert "/home/" not in cwd
     assert cwd == repo_root().resolve().name or cwd.startswith(repo_root().resolve().name + "/")
+    # Claim-scoping fields for multi-session / multi-machine reports
+    assert isinstance(env.get("machine_id"), str) and len(env["machine_id"]) == 16
+    assert env.get("claim_level_hint") == "L1_single_session"
     out = tmp_path / "2026-07-01-195234.configs.json"
     assert out.is_file()
     text = out.read_text()
     assert '"benchmark_ts": "2026-07-01-195234"' in text
     assert "/home/" not in text
+    assert "machine_id" in text
     # serializers scraped from CSV when present
     assert doc.get("serializers", {}).get("count") == 1
 

--- a/analysis/tests/test_multi_session.py
+++ b/analysis/tests/test_multi_session.py
@@ -1,0 +1,148 @@
+"""Tests for multi-session aggregation and CLI resolution."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from benchmark_analysis.multi_session import (
+    aggregate_multi_session,
+    multi_session_markdown,
+)
+from benchmark_analysis.cli import _resolve_multi_session_paths, _expand_multi_session_specs
+
+
+def _entry(ser: str, median: float, lang: str = "python", mode: str = "bytes", n: int = 1):
+    return {
+        "language": lang,
+        "serializer": ser,
+        "test_data": "message",
+        "type_config_hash": "h",
+        "data_type_instance_count": n,
+        "mode": mode,
+        "total_median_ns": median,
+        "avg_time_total_ns": median,
+    }
+
+
+def test_aggregate_rank_stability_and_l2_claim():
+    # Three sessions, same machine; ser_a wins 2/3
+    sessions = [
+        {
+            "run_id": "s1",
+            "machine_id": "abcd1234",
+            "stats": {
+                "a": _entry("ser_a", 100),
+                "b": _entry("ser_b", 200),
+            },
+        },
+        {
+            "run_id": "s2",
+            "machine_id": "abcd1234",
+            "stats": {
+                "a": _entry("ser_a", 110),
+                "b": _entry("ser_b", 90),
+            },
+        },
+        {
+            "run_id": "s3",
+            "machine_id": "abcd1234",
+            "stats": {
+                "a": _entry("ser_a", 105),
+                "b": _entry("ser_b", 180),
+            },
+        },
+    ]
+    report = aggregate_multi_session(sessions, language="python")
+    assert report["n_sessions"] == 3
+    assert report["claim_level"] == "L2_multi_session_same_host"
+    assert report["machine_ids"] == ["abcd1234"]
+    assert len(report["groups"]) == 2
+    # ser_a medians 100,110,105 → median 105
+    a = next(g for g in report["groups"] if g["serializer"] == "ser_a")
+    assert a["n_sessions"] == 3
+    assert a["median_of_session_medians_ns"] == pytest.approx(105.0)
+    rank = report["rank_stability"][0]
+    wins = {f["serializer"]: f["wins"] for f in rank["fastest_frequency"]}
+    assert wins["ser_a"] == 2
+    assert wins["ser_b"] == 1
+
+
+def test_aggregate_l3_when_two_machines():
+    sessions = [
+        {"run_id": "s1", "machine_id": "host_a", "stats": {"a": _entry("ser_a", 100)}},
+        {"run_id": "s2", "machine_id": "host_b", "stats": {"a": _entry("ser_a", 120)}},
+    ]
+    report = aggregate_multi_session(sessions, language="python")
+    assert report["claim_level"] == "L3_multi_machine"
+    assert set(report["machine_ids"]) == {"host_a", "host_b"}
+
+
+def test_aggregate_l1_single_session():
+    sessions = [
+        {"run_id": "only", "machine_id": "m1", "stats": {"a": _entry("ser_a", 100)}},
+    ]
+    report = aggregate_multi_session(sessions, language="python")
+    assert report["claim_level"] == "L1_single_session"
+
+
+def test_aggregate_l2_host_unknown_when_no_machine_ids():
+    sessions = [
+        {"run_id": "s1", "machine_id": None, "stats": {"a": _entry("ser_a", 100)}},
+        {"run_id": "s2", "machine_id": None, "stats": {"a": _entry("ser_a", 110)}},
+        {"run_id": "s3", "machine_id": None, "stats": {"a": _entry("ser_a", 105)}},
+    ]
+    report = aggregate_multi_session(sessions, language="python")
+    assert report["claim_level"] == "L2_multi_session_host_unknown"
+    assert report["machine_ids"] == []
+
+
+def test_multi_session_markdown_mentions_claim_level():
+    report = aggregate_multi_session(
+        [
+            {"run_id": "s1", "machine_id": "m", "stats": {"a": _entry("a", 1), "b": _entry("b", 2)}},
+            {"run_id": "s2", "machine_id": "m", "stats": {"a": _entry("a", 1), "b": _entry("b", 2)}},
+            {"run_id": "s3", "machine_id": "m", "stats": {"a": _entry("a", 1), "b": _entry("b", 2)}},
+        ],
+        language="python",
+    )
+    md = multi_session_markdown(report)
+    assert "L2_multi_session_same_host" in md
+    assert "Rank stability" in md
+
+
+def test_expand_multi_session_specs_commas():
+    assert _expand_multi_session_specs(["a,b", "c"]) == ["a", "b", "c"]
+
+
+def test_resolve_multi_session_paths_shorthand(tmp_path: Path):
+    lang_dir = tmp_path / "python"
+    lang_dir.mkdir()
+    p1 = lang_dir / "2026-07-01-120000.csv"
+    p2 = lang_dir / "2026-07-02-120000.csv"
+    p1.write_text("x\n")
+    p2.write_text("x\n")
+    by = _resolve_multi_session_paths(
+        ["python:2026-07-01", "python:2026-07-02"],
+        logs_root=tmp_path,
+    )
+    assert "python" in by
+    assert len(by["python"]) == 2
+    assert all(Path(p).is_file() for p in by["python"])
+
+
+def test_resolve_multi_session_paths_lang_eq_form(tmp_path: Path):
+    lang_dir = tmp_path / "rust"
+    lang_dir.mkdir()
+    (lang_dir / "2026-06-01-100000.csv").write_text("x\n")
+    (lang_dir / "2026-06-02-100000.csv").write_text("x\n")
+    by = _resolve_multi_session_paths(
+        ["rust=2026-06-01,rust=2026-06-02"],
+        logs_root=tmp_path,
+    )
+    assert len(by["rust"]) == 2

--- a/analysis/tests/test_stats.py
+++ b/analysis/tests/test_stats.py
@@ -263,6 +263,97 @@ def test_effect_sizes_attached():
     assert slow_entry["effect_vs_fastest_cliffs_delta"] > 0
 
 
+def test_effect_vs_fastest_mwu_holm_and_reference():
+    """MWU + within-group Holm; reference has null p; adjusted p ≥ raw p."""
+    recs = (
+        _make_records(25, ser_ns=1000, serializer="fast")
+        + _make_records(25, ser_ns=5000, serializer="slow")
+        + _make_records(25, ser_ns=5200, serializer="slow2")
+    )
+    stats = compute_statistics(
+        recs,
+        config={
+            "exclude_warmup": True,
+            "outlier_method": "none",
+            "bootstrap": {"enabled": False},
+            "effect_sizes": {
+                "enabled": True,
+                "vs_fastest": {
+                    "reference": "median",
+                    "test": "mann_whitney_u",
+                    "multiple_comparison": "holm",
+                },
+            },
+            "hypothesis_tests": {"enabled": True, "alpha": 0.05},
+        },
+    )
+    by = {v["serializer"]: v for v in stats.values()}
+    assert by["fast"]["effect_vs_fastest_cliffs_label"] == "reference"
+    assert by["fast"]["effect_vs_fastest_p_value"] is None
+    assert by["fast"]["effect_vs_fastest_significant_holm"] is None
+    assert by["fast"]["effect_vs_fastest_exploratory"] is True
+
+    for name in ("slow", "slow2"):
+        e = by[name]
+        assert e["fastest_in_group"] == "fast"
+        assert e["effect_vs_fastest_p_value"] is not None
+        assert e["effect_vs_fastest_p_value_holm"] is not None
+        assert e["effect_vs_fastest_p_value_holm"] + 1e-12 >= e["effect_vs_fastest_p_value"]
+        assert e["effect_vs_fastest_cliffs_delta"] > 0
+        assert e["effect_vs_fastest_significant_holm"] is True
+        assert e["effect_vs_fastest_exploratory"] is True
+
+
+def test_effect_vs_fastest_reference_prefers_median():
+    """Reference codec is argmin median total when vs_fastest.reference=median.
+
+    Construct left-skewed 'mean_fast' (low mean, high median) vs stable 'median_fast'
+    so mean-reference and median-reference disagree.
+    """
+    recs = []
+    n = 21
+    for i in range(n):
+        # After warmup skip (i=0), 20 samples: 9 tiny + 11 large → low mean, high median
+        total = 10.0 if 1 <= i <= 9 else 2000.0
+        recs.append({
+            "Language": "python",
+            "StringOrStream": "bytes",
+            "TestDataName": "message",
+            "Repetitions": n,
+            "RepetitionIndex": i,
+            "SerializerName": "mean_fast",
+            "TimeSer": total / 2,
+            "TimeDeser": total / 2,
+            "Size": 100,
+            "TimeSerAndDeser": total,
+            "OpPerSecSer": 0,
+            "OpPerSecDeser": 0,
+            "OpPerSecSerAndDeser": 0,
+            "FidelityScore": 1.0,
+        })
+    # Stable ~1200 ns total → better median than mean_fast's 2000, worse mean than mean_fast's mix
+    recs += _make_records(n, ser_ns=600, deser_ns=600, serializer="median_fast")
+    stats = compute_statistics(
+        recs,
+        config={
+            "exclude_warmup": True,
+            "outlier_method": "none",
+            "bootstrap": {"enabled": False},
+            "effect_sizes": {
+                "enabled": True,
+                "vs_fastest": {"reference": "median"},
+            },
+            "hypothesis_tests": {"enabled": False},
+        },
+    )
+    by = {v["serializer"]: v for v in stats.values()}
+    # Sanity: mean prefers mean_fast; median prefers median_fast
+    assert by["mean_fast"]["total_mean_ns"] < by["median_fast"]["total_mean_ns"]
+    assert by["mean_fast"]["total_median_ns"] > by["median_fast"]["total_median_ns"]
+    assert by["median_fast"]["effect_vs_fastest_cliffs_label"] == "reference"
+    assert by["mean_fast"]["fastest_in_group"] == "median_fast"
+
+
 def test_prepare_and_stats_share_sample_population():
     """Sanitized rows must equal the n used in compute_statistics."""
     recs = _make_records(25)

--- a/docs/analysis/ANALYSIS_METHODOLOGY.md
+++ b/docs/analysis/ANALYSIS_METHODOLOGY.md
@@ -98,9 +98,9 @@ Configured warmup length: `reproducibility.warmup_repetitions` = **1**.
 
 ### Outlier filtering
 
-Default method: **Tukey interquartile range (IQR)** (`statistics.outlier_method: iqr`, `iqr_k: 1.5`), applied **all-or-nothing** across the three times of each repetition (serialize, deserialize, total).
+Default method: **[John Tukey](https://en.wikipedia.org/wiki/John_Tukey "John Tukey — invented exploratory data analysis and popularized boxplot/IQR fences")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> [interquartile range (IQR)](https://en.wikipedia.org/wiki/Interquartile_range "Interquartile range — spread of the middle 50% of values")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />** fences (`statistics.outlier_method: iqr`, `iqr_k: 1.5`), applied **all-or-nothing** across the three times of each repetition (serialize, deserialize, total).
 
-**Idea in plain language:** look at the middle half of the data (from the 25th to the 75th percentile). Anything far outside fences built from that middle half is treated as an outlier. If *any* of the three times is an outlier, the **whole repetition** is dropped so the three series stay paired.
+**Idea in plain language:** look at the middle half of the data (from the 25th to the 75th [percentile](https://en.wikipedia.org/wiki/Percentile "Percentile — value below which a given percentage of observations fall")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />). Anything far outside fences built from that middle half is treated as an [outlier](https://en.wikipedia.org/wiki/Outlier "Outlier — observation far from the bulk of the data")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />. If *any* of the three times is an outlier, the **whole repetition** is dropped so the three series stay paired.
 
 | Rule | Default behavior |
 |------|------------------|
@@ -110,16 +110,16 @@ Default method: **Tukey interquartile range (IQR)** (`statistics.outlier_method:
 | IQR = 0 for a metric | That metric does not remove anyone |
 | Would drop the entire group | Keep the original series |
 | Method `none` | Skip filtering |
-| Method `winsorize` | Clip each series at the 5th and 95th percentiles; never drop rows |
+| Method `winsorize` | [Winsorize](https://en.wikipedia.org/wiki/Winsorizing "Winsorizing — replace extreme values with less extreme ones")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />: clip each series at the 5th and 95th percentiles; never drop rows |
 
-Removed count: `outliers_removed`. Final `runs` is the same for serialize, deserialize, and total. IQR mainly stabilizes the **mean** against rare stalls; always look at dispersion and confidence intervals too.
+Removed count: `outliers_removed`. Final `runs` is the same for serialize, deserialize, and total. IQR mainly stabilizes the **mean** against rare stalls; always look at dispersion and [confidence intervals](https://en.wikipedia.org/wiki/Confidence_interval "Confidence interval — range of plausible values for a parameter")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> too.
 
 ### Descriptive statistics (per group)
 
 | Kind | What we report |
 |------|----------------|
-| Central tendency | Mean and median of serialize / deserialize / total times |
-| Dispersion | Standard deviation, median absolute deviation (MAD), coefficient of variation, min/max, percentiles (default 5, 25, 50, 75, 95, 99) |
+| Central tendency | [Mean](https://en.wikipedia.org/wiki/Arithmetic_mean "Arithmetic mean — average") and [median](https://en.wikipedia.org/wiki/Median "Median — middle value when sorted") of serialize / deserialize / total times |
+| Dispersion | [Standard deviation](https://en.wikipedia.org/wiki/Standard_deviation "Standard deviation — typical distance from the mean"), [median absolute deviation (MAD)](https://en.wikipedia.org/wiki/Median_absolute_deviation "Median absolute deviation — robust scale measure"), [coefficient of variation](https://en.wikipedia.org/wiki/Coefficient_of_variation "Coefficient of variation — std / mean"), min/max, percentiles (default 5, 25, 50, 75, 95, 99) |
 | Size | Median serialized `Size` (bytes) |
 | Throughput | Operations per second from mean total time |
 | Provenance | `runs`, `runs_raw`, `warmup_skipped`, `outliers_removed` |
@@ -133,7 +133,7 @@ Removed count: `outliers_removed`. Final `runs` is the same for serialize, deser
 
 ### Bootstrap confidence interval on the mean
 
-When bootstrap is enabled (default), analysis resamples the total-time series many times (**percentile** bootstrap: 2000 iterations, 95% confidence, seed 42) and reports:
+When bootstrap is enabled (default), analysis resamples the total-time series many times using the **[bootstrap](https://en.wikipedia.org/wiki/Bootstrapping_(statistics) "Bootstrapping (statistics) — resampling to estimate uncertainty")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />** (**percentile** method: 2000 iterations, 95% [confidence interval](https://en.wikipedia.org/wiki/Confidence_interval "Confidence interval — range of plausible values for a parameter")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />, seed 42) and reports:
 
 - `total_ci_low_ns`
 - `total_ci_high_ns`
@@ -144,14 +144,36 @@ Produced only when the post-filter sample size is at least `min_samples_for_infe
 
 ### Effect sizes versus the fastest in the group
 
-When effect sizes are enabled (default), each serializer is compared—inside the same language, data type, and I/O mode—to the **fastest** peer (lowest mean total time):
+When [effect sizes](https://en.wikipedia.org/wiki/Effect_size "Effect size — how large a difference is, not only whether it is significant")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> are enabled (default), each serializer is compared—inside the same language, data type, batch size, and I/O mode—to the **fastest** peer. The reference is chosen by **lowest median total time** when available (falls back to mean). That matches the [nonparametric](https://en.wikipedia.org/wiki/Nonparametric_statistics "Nonparametric statistics — methods that avoid strong distribution assumptions")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> story of the suite.
 
 | Method | Role in plain language |
 |--------|------------------------|
-| **Cliff’s δ (delta)** | How often this library is slower or faster than the reference, without assuming a normal distribution |
-| **Hedges’ g** | Standardized mean difference with a small-sample correction |
+| **[Cliff’s δ (delta)](https://en.wikipedia.org/wiki/Effect_size#Effect_size_for_ordinal_data "Cliff’s delta — probability one sample is larger than another")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />** | How often this library is slower or faster than the reference, without assuming a normal distribution |
+| **[Hedges’ g](https://en.wikipedia.org/wiki/Effect_size#Hedges'_g "Hedges’ g — standardized mean difference with small-sample correction")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />** | Standardized mean difference with a small-sample correction |
+| **[Mann–Whitney U](https://en.wikipedia.org/wiki/Mann%E2%80%93Whitney_U_test "Mann–Whitney U test — nonparametric two-sample rank test")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> + [Holm](https://en.wikipedia.org/wiki/Holm%E2%80%93Bonferroni_method "Holm–Bonferroni method — stepwise p-value adjustment for multiple tests")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />** | Optional [p-values](https://en.wikipedia.org/wiki/P-value "P-value — probability of data as extreme as observed under the null") vs the reference; Holm adjusts for **many serializers in that one group only** |
 
-Use these for **within-language** interpretation. Do not treat them as cross-runtime rankings.
+Use these for **within-language** interpretation. Do not treat them as cross-runtime rankings. Multi-way tables treat ranks as **exploratory** — see [Exploratory ranks](#exploratory-ranks).
+
+### Exploratory ranks {#exploratory-ranks}
+
+This section is written for a **first-year university student**.
+
+#### What problem are we solving?
+
+A Results page often shows **many** libraries side by side. Picking a “winner” and then testing every other library against that winner is like running **many quizzes at once** — the [multiple comparisons problem](https://en.wikipedia.org/wiki/Multiple_comparisons_problem "Multiple comparisons problem — more tests raise the chance of false positives")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />. If you celebrate every small “significant” mark without adjusting for how many quizzes you ran, you overstate confidence.
+
+#### What we do
+
+1. **Show effect sizes** ([Cliff’s δ](https://en.wikipedia.org/wiki/Effect_size#Effect_size_for_ordinal_data "Cliff’s delta") label, and in machine-readable JSON also [Hedges’ g](https://en.wikipedia.org/wiki/Effect_size#Hedges'_g "Hedges’ g")) so you can see *how large* a gap looks.
+2. **Attach [Mann–Whitney](https://en.wikipedia.org/wiki/Mann%E2%80%93Whitney_U_test "Mann–Whitney U test") [p-values](https://en.wikipedia.org/wiki/P-value "P-value")** vs the group’s fastest codec when samples allow.
+3. **[Holm](https://en.wikipedia.org/wiki/Holm%E2%80%93Bonferroni_method "Holm–Bonferroni method")-adjust those p-values inside the group** `(language × data type × type-config × batch N × I/O mode)` only — not across every cell on the page.
+4. **Label multi-way Results as exploratory.** Prefer **pairwise A/B** (`--compare-a` / `--compare-b`) when you need a confirmatory “did *this* change beat *that* baseline?” answer.
+
+#### Plain-language takeaway
+
+> Scores (effect sizes) help you browse. Adjusted p-values inside one group reduce “many quizzes” mistakes. They are **not** a global [family-wise](https://en.wikipedia.org/wiki/Family-wise_error_rate "Family-wise error rate — chance of any false positive in a family of tests") guarantee for the whole Results page, and default published ranks are still **L1 single-session** evidence ([Claims and replication](CLAIMS_AND_REPLICATION.md)).
+
+Config knobs live under `statistics.effect_sizes.vs_fastest` (defaults in code if YAML omits them): `reference: median`, `test: mann_whitney_u`, `multiple_comparison: holm`.
 
 ### Version A/B (same language, two runs)
 
@@ -164,7 +186,7 @@ analyze-benchmarks --compare-a csharp:190424 --compare-b csharp:191316
 analyze-benchmarks --compare-a rust:185249 --compare-b rust:191316
 ```
 
-This writes `reports/VERSION_COMPARE.md` (under `paths.reports_root`, default `reports/`) with percent change, Cliff’s δ, Hedges’ g, **Mann–Whitney U**, and **Holm**-adjusted p-values when hypothesis tests are enabled (`alpha` 0.05).
+This writes `reports/VERSION_COMPARE.md` (under `paths.reports_root`, default `reports/`) with percent change, [Cliff’s δ](https://en.wikipedia.org/wiki/Effect_size#Effect_size_for_ordinal_data "Cliff’s delta"), [Hedges’ g](https://en.wikipedia.org/wiki/Effect_size#Hedges'_g "Hedges’ g"), **[Mann–Whitney U](https://en.wikipedia.org/wiki/Mann%E2%80%93Whitney_U_test "Mann–Whitney U test")**, and **[Holm](https://en.wikipedia.org/wiki/Holm%E2%80%93Bonferroni_method "Holm–Bonferroni method")**-adjusted p-values when hypothesis tests are enabled (`alpha` 0.05).
 
 Regression gates: `analyze-benchmarks --check-regression` against `paths.baseline_filename` (default `reports/baseline.json`); save a baseline with `--save-baseline`. Details: [Regression gate](#regression-gate).
 
@@ -213,7 +235,7 @@ You can restore the old noisier behavior with `regression.combine: or` or `--reg
 
 ### Cliff’s δ (optional, when we saved samples)
 
-If the baseline file stores a sample of old timings, we also compute **Cliff’s δ** between current and baseline samples (positive ≈ current slower). By default δ is **diagnostic** only (`require_for_fail: false`). That keeps the gate simple while still reporting a nonparametric effect size.
+If the baseline file stores a sample of old timings, we also compute **[Cliff’s δ](https://en.wikipedia.org/wiki/Effect_size#Effect_size_for_ordinal_data "Cliff’s delta — nonparametric effect size")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />** between current and baseline samples (positive ≈ current slower). By default δ is **diagnostic** only (`require_for_fail: false`). That keeps the gate simple while still reporting a nonparametric effect size.
 
 ### Baseline file (what we store)
 
@@ -239,14 +261,52 @@ Config lives under `regression:` in [`config/benchmark_config.yaml`](../../confi
 
 ---
 
+## Multi-session and multi-machine claims {#multi-session-claims}
+
+This section is written for a **first-year university student**. Full ladder: [Claims and replication](CLAIMS_AND_REPLICATION.md).
+
+### Why one run is not enough for strong claims
+
+One full matrix on one laptop is a **snapshot**. Noise (other programs, thermal state, cloud neighbors) can move ranks a little. Stronger language needs **more races**:
+
+| Level | Evidence | Example claim |
+|-------|----------|---------------|
+| **L1** | One session, one host | “On this machine, this session, ….” |
+| **L2** | ≥3 sessions, same known `machine_id` | “Stable across repeated sessions on this host….” |
+| **L2 (host unknown)** | ≥3 sessions, missing sidecars | “Repeated sessions, but host fingerprint missing….” |
+| **L3** | ≥2 distinct `machine_id`s | “Consistent across machines in this set….” |
+
+Default Results pages are **L1**. Sidecars store `environment.machine_id` so analysis can tell hosts apart.
+
+### Aggregate several CSVs
+
+```bash
+analyze-benchmarks --list -l python
+analyze-benchmarks \
+  --multi-session python:STEM1 \
+  --multi-session python:STEM2 \
+  --multi-session python:STEM3
+```
+
+Writes `reports/multi_session_<lang>.json` and `.md` with:
+
+- median-of-session-medians and IQR across sessions  
+- how often each serializer is fastest (rank stability)  
+- heuristic `claim_level` (`L2_…` / `L3_…`)
+
+For research-oriented L2/L3 collection tips and soft host checks, see [Claims and replication](CLAIMS_AND_REPLICATION.md).
+
+---
+
 ## Outputs
 
 | Output | Content |
 |--------|---------|
-| `docs/<lang>/results.md` | Pivot tables and latency-chart embeds for one language |
+| `docs/<lang>/results.md` | Pivot tables and latency-chart embeds for one language (**L1** snapshot + exploratory-rank banner) |
 | `docs/analysis/plots/violin/*.png` | Combined mean bars (serialize/deserialize) plus split violin shapes (µs, linear from 0; top five by mean total) |
 | `docs/analysis/BENCHMARK_SUMMARY.md` | **Static** index of links (not regenerated by the CLI) |
-| `logs/<lang>/*.configs.json` | Run sidecar: environment and optional dataset / serializer metadata (legacy `*.environment.json` still works) |
+| `logs/<lang>/*.configs.json` | Run sidecar: environment (`machine_id`, optional governor), dataset / serializer metadata (legacy `*.environment.json` still works) |
+| `reports/multi_session_<lang>.json` / `.md` | Optional L2/L3 aggregate from `--multi-session` |
 | Console | Load counts, warmup and outlier tallies |
 
 Latency charts use the **same** sanitized records as the summary tables. There is no separate hidden filter for plots. Display may still limit charts to the top five serializers by mean time; that does not change table membership.
@@ -273,11 +333,35 @@ Honest methodology includes what the suite **cannot** claim.
 - **Paired series:** serialize, deserialize, and total times share one all-or-nothing keep-mask.
 - **Mann–Whitney:** uses SciPy when available (tie-aware); otherwise a pure-NumPy fallback with tie-corrected variance and continuity correction.
 - **Regression gates:** default combine is **and** (practical % and CI support). `--save-baseline` is skipped when `--check-regression` fails, so a degraded run cannot overwrite the gate baseline. See [Regression gate](#regression-gate).
+- **Effect vs fastest:** reference is **median** total by default; Mann–Whitney + **within-group Holm** when hypothesis tests are enabled. Multi-way ranks are **exploratory** ([Exploratory ranks](#exploratory-ranks)).
+- **Claim scope:** default Results are **L1** single-session / single-host. Multi-session tooling does not rewrite Results automatically ([Claims and replication](CLAIMS_AND_REPLICATION.md)).
 - **Cliff’s δ for large N:** if the full pair count exceeds about two million, a seeded 100 000-pair random sample is used.
 - Some documented config keys are parsed for documentation but do not yet change runtime behaviour; the implementation still computes the full rich metric set.
 
 ## References
 
+### Wikipedia (statistical terms used on this page)
+
+| Term | Link |
+|------|------|
+| Interquartile range (IQR) | [en.wikipedia.org/wiki/Interquartile_range](https://en.wikipedia.org/wiki/Interquartile_range) |
+| John Tukey | [en.wikipedia.org/wiki/John_Tukey](https://en.wikipedia.org/wiki/John_Tukey) |
+| Confidence interval | [en.wikipedia.org/wiki/Confidence_interval](https://en.wikipedia.org/wiki/Confidence_interval) |
+| Bootstrapping | [en.wikipedia.org/wiki/Bootstrapping_(statistics)](https://en.wikipedia.org/wiki/Bootstrapping_(statistics)) |
+| Effect size | [en.wikipedia.org/wiki/Effect_size](https://en.wikipedia.org/wiki/Effect_size) |
+| Cliff’s delta | [Effect size § ordinal data](https://en.wikipedia.org/wiki/Effect_size#Effect_size_for_ordinal_data) |
+| Hedges’ g | [Effect size § Hedges' g](https://en.wikipedia.org/wiki/Effect_size#Hedges'_g) |
+| Mann–Whitney U test | [en.wikipedia.org/wiki/Mann–Whitney_U_test](https://en.wikipedia.org/wiki/Mann%E2%80%93Whitney_U_test) |
+| Holm–Bonferroni method | [en.wikipedia.org/wiki/Holm–Bonferroni_method](https://en.wikipedia.org/wiki/Holm%E2%80%93Bonferroni_method) |
+| P-value | [en.wikipedia.org/wiki/P-value](https://en.wikipedia.org/wiki/P-value) |
+| Multiple comparisons problem | [en.wikipedia.org/wiki/Multiple_comparisons_problem](https://en.wikipedia.org/wiki/Multiple_comparisons_problem) |
+| Family-wise error rate | [en.wikipedia.org/wiki/Family-wise_error_rate](https://en.wikipedia.org/wiki/Family-wise_error_rate) |
+| Nonparametric statistics | [en.wikipedia.org/wiki/Nonparametric_statistics](https://en.wikipedia.org/wiki/Nonparametric_statistics) |
+| Median | [en.wikipedia.org/wiki/Median](https://en.wikipedia.org/wiki/Median) |
+| Median absolute deviation | [en.wikipedia.org/wiki/Median_absolute_deviation](https://en.wikipedia.org/wiki/Median_absolute_deviation) |
+| Winsorizing | [en.wikipedia.org/wiki/Winsorizing](https://en.wikipedia.org/wiki/Winsorizing) |
+
+### Other
+
 - Tukey, J.W. (1977). *Exploratory Data Analysis* (IQR fences).
-- Cliff’s delta; Hedges’ g; Mann–Whitney U (standard non-parametric toolkit).
 - [Seaborn violin / catplot](https://seaborn.pydata.org/generated/seaborn.catplot.html).

--- a/docs/analysis/CLAIMS_AND_REPLICATION.md
+++ b/docs/analysis/CLAIMS_AND_REPLICATION.md
@@ -1,0 +1,154 @@
+# Claims and replication
+
+This page is written for a **first-year university student**. No advanced stats course required.
+
+It answers one practical question:
+
+> **After I look at a Results table, what am I allowed to say out loud?**
+
+Different amounts of evidence support different claim strengths. We call those levels **L1**, **L2**, and **L3**.
+
+---
+
+## Learning goals
+
+By the end of this page you should be able to:
+
+1. Tell whether a published Results page is a **single-session snapshot** (L1).
+2. Explain why repeating the suite on the **same machine** (L2) is stronger than one lucky run.
+3. Explain why **different machines** (L3) are needed before you talk about “generalizes across hardware.”
+4. Know the command that aggregates several CSVs for one language.
+
+---
+
+## Everyday analogy
+
+Imagine you want to know which car is fastest.
+
+| Evidence | Everyday claim you may make |
+|----------|-----------------------------|
+| **One race, one track, one day** | “On this track, today, car A finished first.” |
+| **Several races, same track** | “Across repeated races on this track, car A usually wins.” |
+| **Races on several tracks** | “Across this set of tracks, car A tends to win.” |
+
+You still should **not** claim “fastest car in the world on every road forever.” That would need far more evidence than this suite produces.
+
+---
+
+## Claim levels (L1 / L2 / L3)
+
+| Level | Evidence | Allowed claim language | What this suite ships by default |
+|-------|----------|------------------------|----------------------------------|
+| **L1 — single session** | One full (or smoke) run on **one host** | “On **this machine**, in **this session**…” | Language **Results** pages (`docs/<lang>/results.md`) |
+| **L2 — multi-session, same host** | ≥ **3** timestamped runs with the **same** `machine_id` | “Stable across **repeated sessions on this host**…” | Optional: `analyze-benchmarks --multi-session …` |
+| **L3 — multi-machine** | ≥ **2** distinct `machine_id` values | “Consistent across **these machines**…” (still not “all hardware”) | Optional multi-session report with different hosts |
+
+Default Results headers state claim level **L1**. They do **not** claim multi-machine generalization.
+
+### How `machine_id` works
+
+Each run can write a sidecar next to the CSV:
+
+```text
+logs/<lang>/YYYY-MM-DD-HHMMSS.csv
+logs/<lang>/YYYY-MM-DD-HHMMSS.configs.json
+```
+
+Inside `environment` the analysis package stores a short **`machine_id`** fingerprint (hash of CPU model, architecture, OS, core count, and hostname material). It is **not** a security identifier. It is only enough to tell “same host class / same box” apart when you merge sessions.
+
+You may also see `claim_level_hint: L1_single_session` on a single capture, and optional `cpu_governor` on Linux when `/sys` is readable.
+
+---
+
+## What L1 is good for (and what it is not)
+
+**Good for:**
+
+- Choosing among libraries **inside one language** on hardware like yours.
+- Spotting huge gaps (for example 10× slower), not hair-thin ties.
+- Pairing with effect sizes and confidence intervals on **that** session.
+
+**Not good for:**
+
+- “Library X is the fastest serializer on Earth.”
+- Treating one CI runner’s numbers as eternal truth after a noisy day.
+- Cross-language absolute latency races (different runtimes and GCs).
+
+---
+
+## How to collect L2 evidence (same host)
+
+1. Run a full matrix (or the language you care about) **three or more times**, on a quiet machine if you can:
+   ```bash
+   ./scripts/run-all-benchmarks.sh -m full -l python
+   # wait / cool down, then again…
+   ./scripts/run-all-benchmarks.sh -m full -l python
+   ./scripts/run-all-benchmarks.sh -m full -l python
+   ```
+2. List stems:
+   ```bash
+   analyze-benchmarks --list -l python
+   ```
+3. Aggregate:
+   ```bash
+   analyze-benchmarks --multi-session python:STEM1 --multi-session python:STEM2 --multi-session python:STEM3
+   # or commas / LANG=stem form:
+   analyze-benchmarks --multi-session python=STEM1,python=STEM2,python=STEM3
+   ```
+4. Read:
+   - `reports/multi_session_python.json` — machine ids, claim_level heuristic, per-group medians across sessions, rank stability
+   - `reports/multi_session_python.md` — short human summary
+
+The report’s `claim_level` field is a **heuristic**:
+
+- fewer than 3 sessions → `L1_single_session`
+- ≥3 sessions, **exactly one known** `machine_id` → `L2_multi_session_same_host`
+- ≥3 sessions, **no** machine ids in sidecars → `L2_multi_session_host_unknown` (repeat runs, host not verified)
+- ≥2 distinct machine ids → `L3_multi_machine`
+
+Missing sidecars never invent L3. Prefer re-running so each CSV has a `*.configs.json` with `machine_id`.
+
+---
+
+## How to collect L3 evidence (several machines)
+
+Repeat full runs on **different hosts**, copy the CSVs + `*.configs.json` sidecars into one analysis machine (or point `--logs-root` at a shared tree), then run the same `--multi-session` command with stems from each host.
+
+Only then is language like “consistent across machines **in this set**” honest. It is still not a survey of all CPUs or cloud instance types.
+
+---
+
+## Research-mode soft checks (optional)
+
+For publication-oriented L2/L3 work, prefer:
+
+- Linux CPU governor **performance** (when you control the host)
+- A quiet machine (no heavy parallel builds)
+- Fixed library versions (the CSV already records `SerializerVersion`)
+
+Set `BENCHMARK_RESEARCH=1` and run:
+
+```bash
+./scripts/check-research-env.sh
+```
+
+This script **warns**; it does **not** fail CI smokes. Isolation features like `isolcpus` are documented, not enforced.
+
+---
+
+## Ranks on a single Results page
+
+Even inside **one** L1 session, ranking many libraries is like grading many quizzes at once ([multiple comparisons](https://en.wikipedia.org/wiki/Multiple_comparisons_problem "Multiple comparisons problem")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />). [Effect sizes](https://en.wikipedia.org/wiki/Effect_size "Effect size")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" /> versus the fastest codec are **descriptive / exploratory**. [Holm](https://en.wikipedia.org/wiki/Holm%E2%80%93Bonferroni_method "Holm–Bonferroni method")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />-adjusted tests only correct inside one (data type × batch size × I/O mode) group. Prefer pairwise A/B for confirmatory library-vs-library checks.
+
+Details: [Analysis methodology — exploratory ranks](ANALYSIS_METHODOLOGY.md#exploratory-ranks).
+
+---
+
+## Related pages
+
+| Page | Why |
+|------|-----|
+| [Analysis methodology](ANALYSIS_METHODOLOGY.md) | Warmup, outliers, CIs, ranks, multi-session command |
+| [Metrics](METRICS.md) | Column definitions including effect-vs-fastest fields |
+| [Modes](modes.md) | Smoke vs full vs research run presets |
+| [Results summary](BENCHMARK_SUMMARY.md) | Links to published L1 snapshots |

--- a/docs/analysis/METRICS.md
+++ b/docs/analysis/METRICS.md
@@ -50,7 +50,7 @@ These fields are written by each language benchmark runner. Column order (v1.2+)
 | `FidelityScore` | 0–1 | high | optional | `1.0` means the round-trip check passed |
 | `NativeKind` | enum | low | optional | Codec shape family (serde, message, codable, …) when the runner records it |
 | `StreamMode` | enum | **high** on stream rows | optional on old CSVs; **required on new stream rows** | Honesty label: `native` \| `text_on_stream` \| `adapted` — see [Modes — stream honesty](modes.md#three-levels-of-stream-honesty) |
-| `RunOrder` | index | low | optional | Monotonic 0-based index of written timed rows in process order (schedule audit; B-1) |
+| `RunOrder` | index | low | optional | Monotonic 0-based index of written timed rows in process order (schedule audit) |
 | `SchedulePosition` | index | low | optional | 0-based position of this serializer within its `(cell, mode, rep)` after shuffle |
 
 ---
@@ -72,7 +72,7 @@ After warmup drop and optional outlier filter, analysis groups rows by:
 | `total_mean_ns` / `ser_mean_ns` / `deser_mean_ns` | Arithmetic means | medium | no |
 | `total_std_ns` / `*_mad_ns` / `*_cv` | Dispersion (spread) | medium | no (context) |
 | `total_p5_ns` … `total_p99_ns` | Percentiles | medium (p95/p99) / low (others) | no |
-| `total_ci_low_ns` / `total_ci_high_ns` | Bootstrap confidence interval on **mean** total | medium | — |
+| `total_ci_low_ns` / `total_ci_high_ns` | [Bootstrap](https://en.wikipedia.org/wiki/Bootstrapping_(statistics) "Bootstrapping (statistics)") [confidence interval](https://en.wikipedia.org/wiki/Confidence_interval "Confidence interval") on **mean** total | medium | — |
 | `avg_ops_per_sec` | `1e9 / total_mean_ns` | high (display) | **yes** |
 | `runs` / `runs_raw` / `warmup_skipped` / `outliers_removed` | Sample provenance | high | — |
 
@@ -91,10 +91,18 @@ After warmup drop and optional outlier filter, analysis groups rows by:
 
 | id | Definition | Importance | When |
 |----|------------|------------|------|
-| `effect_vs_fastest_cliffs_delta` | Cliff’s δ vs fastest mean total | medium | multi-way attach |
-| `effect_vs_fastest_cliffs_label` | negligible…large / reference | medium | multi-way |
-| `effect_vs_fastest_hedges_g` | Hedges’ g | low | multi-way |
-| `mann_whitney_u` / `p_value` / `p_value_holm` | Two-sample non-parametric test | medium–high for pairwise | `--compare-a` / `--compare-b` |
+| `effect_vs_fastest_cliffs_delta` | [Cliff’s δ](https://en.wikipedia.org/wiki/Effect_size#Effect_size_for_ordinal_data "Cliff’s delta") vs fastest (reference = lowest **[median](https://en.wikipedia.org/wiki/Median "Median")** total, else mean) | medium | multi-way attach |
+| `effect_vs_fastest_cliffs_label` | negligible…large / `reference` | medium | multi-way tables |
+| `effect_vs_fastest_hedges_g` | [Hedges’ g](https://en.wikipedia.org/wiki/Effect_size#Hedges'_g "Hedges’ g") vs reference | low | multi-way attach / pairwise profile |
+| `effect_vs_fastest_p_value` | [Mann–Whitney U](https://en.wikipedia.org/wiki/Mann%E2%80%93Whitney_U_test "Mann–Whitney U test") [p](https://en.wikipedia.org/wiki/P-value "P-value") vs reference (raw) | low | machine-readable / full profile |
+| `effect_vs_fastest_p_value_holm` | [Holm](https://en.wikipedia.org/wiki/Holm%E2%80%93Bonferroni_method "Holm–Bonferroni method")-adjusted p **within the same group only** | medium | JSON / pairwise-capable profiles |
+| `effect_vs_fastest_significant_holm` | `p_holm < alpha` (default 0.05) | medium | JSON; not a multi-page [family-wise](https://en.wikipedia.org/wiki/Family-wise_error_rate "Family-wise error rate") claim |
+| `effect_vs_fastest_exploratory` | Always true for multi-way attach (exploratory labeling) | — | JSON |
+| `mann_whitney_u` / `p_value` / `p_value_holm` | Two-sample [nonparametric](https://en.wikipedia.org/wiki/Nonparametric_statistics "Nonparametric statistics") test between version A and B | medium–high for pairwise | `--compare-a` / `--compare-b` |
+
+**Reading tip:** multi-way Results treat ranks as **exploratory**. Prefer [Claims and replication](CLAIMS_AND_REPLICATION.md) for L1/L2/L3 language, and pairwise A/B for confirmatory library comparisons.
+
+Full URL list: [Analysis methodology — References](ANALYSIS_METHODOLOGY.md#references).
 
 ### Planned (not all implemented)
 

--- a/docs/analysis/index.md
+++ b/docs/analysis/index.md
@@ -72,8 +72,9 @@ Full mode guide: [Modes](modes.md). Data-type glossary: [Test data — vocabular
 | **[Modes](modes.md)** | I/O modes (bytes/stream) and run modes (smoke…research) | Why Results have two mode columns; which run preset to use |
 | **[Categories](serialization_categories.md)** | Four families of serializers (JSON, binary, schema-driven, native) | Fair “apples to apples” groups |
 | **[Test data](test_data_configuration.md)** | The five sample data types and how sizes are chosen | What we serialize |
-| **[Methodology](ANALYSIS_METHODOLOGY.md)** | Warmup, outliers, confidence intervals, effect sizes | How CSVs become published numbers |
+| **[Methodology](ANALYSIS_METHODOLOGY.md)** | Warmup, outliers, confidence intervals, effect sizes, exploratory ranks | How CSVs become published numbers |
 | **[Metrics](METRICS.md)** | Names and meanings of every reported measurement | “What does this column mean?” |
+| **[Claims and replication](CLAIMS_AND_REPLICATION.md)** | L1 / L2 / L3: what you may claim from one run vs many | Honest generalization language |
 | **[Adding a language](ADDING_A_LANGUAGE.md)** | Checklist to plug in a new language benchmark runner | Extending the suite |
 | **[Results summary](BENCHMARK_SUMMARY.md)** | Links to each language’s numbers and how to regenerate them | The published snapshots |
 

--- a/docs/c/index.md
+++ b/docs/c/index.md
@@ -49,7 +49,7 @@ cmake --build c/build --target c_serializer_tests
 
 Also: [`c/README.md`](../../c/README.md). [Serialization Categories](../analysis/serialization_categories.md).
 
-## Stream honesty (B-6)
+## Stream honesty
 
 Stream mode uses an in-memory `FILE*` (`fmemopen`) wrapper around full encode/decode buffers — **`StreamMode=adapted`** for every stream row. It is not a per-library incremental stream API. See [Modes — stream honesty](../analysis/modes.md#three-levels-of-stream-honesty).
 

--- a/docs/javascript/index.md
+++ b/docs/javascript/index.md
@@ -36,7 +36,7 @@ Node benchmarks run on V8 with `performance.now()` converted to nanoseconds.
 | v8-serializer | Native | `node:v8` | `v8.serialize` / `v8.deserialize` |
 | devalue | Native | `devalue` | `stringify` / `parse` |
 
-### Stream I/O (B-6)
+### Stream I/O
 
 **Not measured.** The Node suite times the same buffer `serialize` / `deserialize` path for every codec; there is no distinct stream API loop. The benchmark runner emits **bytes only** so Results do not claim a second I/O mode. See [Modes — stream honesty](../analysis/modes.md#three-levels-of-stream-honesty).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -159,5 +159,6 @@ nav:
       - Categories: analysis/serialization_categories.md
       - Methodology: analysis/ANALYSIS_METHODOLOGY.md
       - Metrics: analysis/METRICS.md
+      - Claims and replication: analysis/CLAIMS_AND_REPLICATION.md
       - Test Data: analysis/test_data_configuration.md
       - Results Summary: analysis/BENCHMARK_SUMMARY.md

--- a/scripts/check-research-env.sh
+++ b/scripts/check-research-env.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Soft checks for research-oriented L2/L3 collection.
+# Warns only — never fails CI smoke by default.
+#
+# Usage:
+#   BENCHMARK_RESEARCH=1 ./scripts/check-research-env.sh
+#   ./scripts/check-research-env.sh   # still runs, but quieter about intent
+set -euo pipefail
+
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+WARN=0
+
+ok()   { echo -e "  ${GREEN}OK${NC}  $*"; }
+warn() { echo -e "  ${YELLOW}WARN${NC} $*"; WARN=$((WARN + 1)); }
+
+echo "Research-host soft checks (non-fatal)"
+if [[ "${BENCHMARK_RESEARCH:-}" == "1" ]]; then
+  echo "  BENCHMARK_RESEARCH=1 — treating this as a publication-oriented host"
+else
+  echo "  (set BENCHMARK_RESEARCH=1 to emphasize research-mode guidance)"
+fi
+
+# CPU governor (Linux)
+gov_path="/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor"
+if [[ -r "$gov_path" ]]; then
+  gov="$(tr -d '[:space:]' <"$gov_path" || true)"
+  if [[ "$gov" == "performance" ]]; then
+    ok "cpu governor=$gov"
+  elif [[ -n "$gov" ]]; then
+    warn "cpu governor=$gov (prefer 'performance' for stable L2/L3 timings)"
+  else
+    warn "cpu governor unreadable content"
+  fi
+else
+  warn "cpu governor not available (non-Linux or no cpufreq sysfs)"
+fi
+
+# Load average vs cores (very rough quiet-host hint)
+if command -v nproc >/dev/null 2>&1 && [[ -r /proc/loadavg ]]; then
+  cores="$(nproc)"
+  load1="$(awk '{print $1}' /proc/loadavg)"
+  # bash arithmetic only on integers — use awk for float compare
+  busy="$(awk -v l="$load1" -v c="$cores" 'BEGIN { print (l > c*0.75) ? 1 : 0 }')"
+  if [[ "$busy" == "1" ]]; then
+    warn "loadavg 1m=$load1 on ${cores} cores (host may be busy)"
+  else
+    ok "loadavg 1m=$load1 on ${cores} cores"
+  fi
+fi
+
+# isolcpus is optional and rare on developer laptops
+if [[ -r /proc/cmdline ]] && grep -q 'isolcpus=' /proc/cmdline 2>/dev/null; then
+  ok "isolcpus present in kernel cmdline"
+else
+  echo "  note: isolcpus not set (optional; not required for ordinary L1 Results)"
+fi
+
+echo
+if [[ "$WARN" -gt 0 ]]; then
+  echo "Finished with $WARN warning(s). See docs/analysis/CLAIMS_AND_REPLICATION.md"
+else
+  echo "Finished with no warnings."
+fi
+# Always exit 0 — soft check only
+exit 0


### PR DESCRIPTION
## Summary
- Multi-way effect-vs-fastest now uses **median** reference, Mann–Whitney tests, and **within-group Holm** adjustment; Results pages label ranks as **exploratory** (prefer pairwise A/B for confirmatory checks).
- Sidecars gain `machine_id` / L1 claim hint; **`--multi-session`** aggregates rank stability and L1/L2/L3 claim levels; soft `check-research-env.sh` for research hosts.
- Student docs: claims ladder (`CLAIMS_AND_REPLICATION.md`), methodology sections, Wikipedia links for statistical terms; strip internal ticket tags from public docs.

## Validation
- Tests: analysis **83** pass; python **29** pass; javascript **9** pass; rust **13** pass; cpp roundtrips OK. Java/mvn unavailable (warn only).
- Benchmarks: **skipped** (no benchmark-runner language changes; analysis/docs only).
- Error CSVs: N/A (no rebench).
- Analysis: no forced full-matrix Results regen (banners apply on next `analyze-benchmarks`).
- Dashboard: `sync-data.py` verified latest stems present; **no commit** of timestamp-only gzip churn.

## Notes
- Default Results remain **L1** single-session / single-host; multi-session is opt-in CLI.
- Older CSVs without `machine_id` in sidecars report `L2_multi_session_host_unknown` when aggregating ≥3 sessions.
- Example: `analyze-benchmarks --multi-session python:STEM1 --multi-session python:STEM2 --multi-session python:STEM3`