### PR TITLE
go: use UTF8DecodeInvalid in fxamacker/cbor wrapper

### DIFF
--- a/go/serializers/cbor.go
+++ b/go/serializers/cbor.go
@@ -18,15 +18,30 @@ type fxamackerCBOR struct {
 }
 
 func newFxamackerCBOR() *fxamackerCBOR {
-	// Default EncOptions (not CoreDet): CoreDet sorts / normalizes for deterministic
-	// encoding and is slower on struct payloads without map keys. Throughput path
-	// reuses immutable EncMode/DecMode (library-recommended).
-	// https://github.com/fxamacker/cbor#usage
+	// Throughput path reuses immutable EncMode/DecMode (library-recommended).
+	// https://github.com/fxamacker/cbor#quick-start
+
+	// fxamacker/cbor provides struct tag options `toarray` or `keyasint` to
+	// improve speed and reduce encoded size.
+	// To take effect, `toarray` or `keyasint` needs to be added to the Go structs
+	// in this benchmark's fixture file (model/v2/generate.go).
+	// See how to use struct tag options at:
+	// https://github.com/fxamacker/cbor#smaller-encodings-with-struct-tag-options
+
+	// fxamacker/cbor encodes structs faster than Go maps because struct keys
+	// and their sort order are cached per type, while map keys are encoded and
+	// sorted every time.
+
+	// Deterministic encoding isn't required in the benchmarks, so the
+	// default encoding option is used instead of cbor.CoreDetEncOptions.
 	em, err := cbor.EncOptions{}.EncMode()
 	if err != nil {
 		panic(err)
 	}
-	dm, err := cbor.DecOptions{}.DecMode()
+
+	// For untrusted input, the default option validates UTF-8 strings. All the
+	// generated fixtures are valid UTF-8, so the default option isn't used here.
+	dm, err := cbor.DecOptions{UTF8: cbor.UTF8DecodeInvalid}.DecMode()
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This PR uses a decoding option to disable UTF-8 validation because generated fixtures are valid UTF-8 and trusted. Skipping UTF-8 validation improves decoding speed by 2-12%, depending on string content.

Other changes:
- correct a comment about CoreDet
- fix a broken link in a comment
- add a comment to mention fxamacker/cbor provides toarray and keyasint [struct tag options](https://github.com/fxamacker/cbor#smaller-encodings-with-struct-tag-options) that can further improve performance and reduce encoded size if they are added to Go structs in the benchmark file (model/v2/generate.go)