### PR TITLE
go: use ugorji NumBytesWritten (from #79) + codec v1.3.2

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/segmentio/encoding v0.5.4
 	github.com/shamaton/msgpack/v3 v3.1.2
-	github.com/ugorji/go/codec v1.3.1
+	github.com/ugorji/go/codec v1.3.2
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 	go.mongodb.org/mongo-driver v1.17.9
 	google.golang.org/protobuf v1.36.11

--- a/go/go.sum
+++ b/go/go.sum
@@ -61,8 +61,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
-github.com/ugorji/go/codec v1.3.1 h1:waO7eEiFDwidsBN6agj1vJQ4AG7lh2yqXyOXqhgQuyY=
-github.com/ugorji/go/codec v1.3.1/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
+github.com/ugorji/go/codec v1.3.2 h1:zkEASHHyEClGeURfgNT9PJZVfAbs9oEX9QXggwWNJbc=
+github.com/ugorji/go/codec v1.3.2/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
 github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=

--- a/go/serializers/ugorji.go
+++ b/go/serializers/ugorji.go
@@ -87,12 +87,11 @@ func (s *ugorjiCodec) DeserializeBytes(buf []byte) (any, error) {
 }
 
 func (s *ugorjiCodec) SerializeStream(fx model.Fixture, w io.Writer) (int, error) {
-	cw := &countWriter{w: w}
-	s.strenc.Reset(cw)
+	s.strenc.Reset(w)
 	if err := s.strenc.Encode(fx.Value); err != nil {
 		return 0, err
 	}
-	return cw.n, nil
+	return s.strenc.NumBytesWritten(), nil
 }
 
 func (s *ugorjiCodec) DeserializeStream(r io.Reader) (any, error) {


### PR DESCRIPTION
## Summary
- Lands [@ugorji](https://github.com/ugorji)'s change from #79: use `Encoder.NumBytesWritten()` instead of a `countWriter` wrapper in stream serialize.
- Bumps `github.com/ugorji/go/codec` **v1.3.1 → v1.3.2**, which added `NumBytesWritten()` (see [codec/v1.3.2](https://github.com/ugorji/go/releases/tag/codec%2Fv1.3.2) and the author's note on #79).

## Why not merge #79 as-is?
#79 fails CI: `NumBytesWritten` is undefined on the pinned v1.3.1 Encoder. This PR is the complete, buildable form of that change.

## Test plan
- [x] `go test ./serializers/` with codec v1.3.2
- [ ] CI go-benchmark smoke on this PR

Closes #79