### PR TITLE
Stop tracking experiment run logs

### DIFF
--- a/.grok/skills/implement-experiment/SKILL.md
+++ b/.grok/skills/implement-experiment/SKILL.md
@@ -165,7 +165,7 @@ uv run python ../experiments/NN-short-kebab/summarize.py --all
 | `experiments/PLAN.md` | Status + After Experiment *n* |
 | `experiments/README.md` | Index row for the new folder |
 
-`results.md` at the experiment root is the quick look. Per-language `results.md` stays for detail. **Do not commit** `<lang>/logs/` (raw CSVs). Local logs are for a later `summarize.py --all` on the same machine only.
+`results.md` at the experiment root is the quick look. Per-language `results.md` stays for detail. **Do not commit** `<lang>/logs/` (raw CSVs). Local logs are for a later `summarize.py --all` on the same machine only. Saved results are enough.
 
 ---
 


### PR DESCRIPTION
## Summary
- Remove Experiment 1 and Experiment 2 CSVs / config sidecars from git.
- Saved `results.md` and `results.json` stay.
- Drop the `.gitignore` exception that forced `experiments/**/logs/` into the repo.
- Teach implement-experiment: do not commit experiment logs.

## Notes
- Local log files are not deleted from the working tree.
- Experiment 3 PR #85 already drops its own logs; after this merges, rebase #85 to avoid a double-delete conflict.