### PR TITLE
fix(runners): record SizeGzip/SizeZstd in non-Python CSV logs

### DIFF
--- a/analysis/tests/test_parser.py
+++ b/analysis/tests/test_parser.py
@@ -76,3 +76,19 @@ def test_infer_language_from_path_cpp_not_c(tmp_path):
     recs, _ = parse_csv_file(str(csv))
     assert recs
     assert recs[0]["Language"] == "cpp"
+
+
+def test_parse_size_gzip_zstd():
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False, newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["Language", "StringOrStream", "TestDataName", "Repetitions", "RepetitionIndex",
+                    "SerializerName", "SerializerVersion", "TimeSer", "TimeDeser", "Size",
+                    "TimeSerAndDeser", "OpPerSecSer", "OpPerSecDeser", "OpPerSecSerAndDeser",
+                    "MemoryPeakBytes", "FidelityScore", "SizeGzip", "SizeZstd"])
+        w.writerow(["go", "bytes", "strings", 10, 1, "encoding/json", "1.24", 100, 200, 448,
+                    300, 1, 1, 1, 0, 1.0, 229, 180])
+        path = f.name
+    recs, skipped = parse_csv_file(path)
+    assert skipped == 0
+    assert recs[0]["SizeGzip"] == 229
+    assert recs[0]["SizeZstd"] == 180

--- a/c-sharp/src/Compress.cs
+++ b/c-sharp/src/Compress.cs
@@ -1,0 +1,24 @@
+using System.IO;
+using System.IO.Compression;
+
+namespace GLD.SerializerBenchmark
+{
+    /// <summary>
+    /// One-shot gzip(6) of already-written bytes. Not on the timed path.
+    /// zstd is 0: no encoder ships with net8.0.
+    /// </summary>
+    internal static class Compress
+    {
+        public static void Sizes(byte[] raw, out int gzip, out int zstd)
+        {
+            gzip = 0;
+            zstd = 0;
+            if (raw == null || raw.Length == 0) return;
+            using var ms = new MemoryStream();
+            // CompressionLevel.Optimal is zlib's default (~level 6).
+            using (var gz = new GZipStream(ms, CompressionLevel.Optimal, leaveOpen: true))
+                gz.Write(raw, 0, raw.Length);
+            gzip = (int)ms.Length;
+        }
+    }
+}

--- a/c-sharp/src/Log.cs
+++ b/c-sharp/src/Log.cs
@@ -104,6 +104,12 @@ namespace GLD.SerializerBenchmark
 
         /// <summary>Position within shuffled serializer list for this rep; -1 if unset.</summary>
         public int SchedulePosition { get; set; } = -1;
+
+        /// <summary>One-shot gzip(6) of written bytes (not timed). 0 if unset.</summary>
+        public int SizeGzip { get; set; }
+
+        /// <summary>One-shot zstd(3) of written bytes (not timed). 0 if unavailable.</summary>
+        public int SizeZstd { get; set; }
     }
 
     public class LogStorage
@@ -140,7 +146,7 @@ namespace GLD.SerializerBenchmark
                 "Language,StringOrStream,TestDataName,Repetitions,RepetitionIndex,SerializerName," +
                 "SerializerVersion,TimeSer,TimeDeser,Size,TimeSerAndDeser,OpPerSecSer,OpPerSecDeser," +
                 "OpPerSecSerAndDeser,MemoryPeakBytes,FidelityScore,DataTypeInstanceCount,TypeConfigHash," +
-                "StreamMode,RunOrder,SchedulePosition";
+                "StreamMode,RunOrder,SchedulePosition,SizeGzip,SizeZstd";
             fileHeaderLine = fileHeaderLine.Replace(",", _separator);
             _logFileStreamWriter.WriteLine(fileHeaderLine);
 
@@ -163,7 +169,9 @@ namespace GLD.SerializerBenchmark
                 log.TypeConfigHash ?? "",
                 log.StreamMode ?? "",
                 log.RunOrder >= 0 ? log.RunOrder.ToString() : "",
-                log.SchedulePosition >= 0 ? log.SchedulePosition.ToString() : ""
+                log.SchedulePosition >= 0 ? log.SchedulePosition.ToString() : "",
+                log.SizeGzip > 0 ? log.SizeGzip.ToString() : "",
+                log.SizeZstd > 0 ? log.SizeZstd.ToString() : ""
                 );
             _logFileStreamWriter.WriteLine(line);
         }

--- a/c-sharp/src/Tester.cs
+++ b/c-sharp/src/Tester.cs
@@ -295,6 +295,18 @@ namespace GLD.SerializerBenchmark
                 GC.KeepAlive(processed);
                 // Untimed domain conversion (annotated/KeyTuple → suite POCO).
                 processed = serializer.ToDomain(processed);
+
+                // One-shot compress of written bytes — after the clock.
+                byte[] raw;
+                if (streaming)
+                    raw = serializedStream.ToArray();
+                else
+                    raw = serializedString != null
+                        ? System.Text.Encoding.UTF8.GetBytes(serializedString)
+                        : System.Array.Empty<byte>();
+                Compress.Sizes(raw, out var gz, out var zs);
+                log.SizeGzip = gz;
+                log.SizeZstd = zs;
             }
             catch (Exception ex)
             {

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -19,6 +19,7 @@ set(BENCH_SOURCES
   src/run_v2.c
   src/schedule.c
   src/csv_log.c
+  src/compress.c
   src/batch_cell.c
   src/runner.c
   src/register_serializers.c
@@ -26,10 +27,26 @@ set(BENCH_SOURCES
   src/serializers/ser_custom_binary.c
 )
 set(BENCH_LIBS m)
+find_package(ZLIB REQUIRED)
+list(APPEND BENCH_LIBS ZLIB::ZLIB)
+find_package(PkgConfig QUIET)
+if(PkgConfig_FOUND)
+  pkg_check_modules(LIBZSTD QUIET libzstd)
+endif()
+if(LIBZSTD_FOUND)
+  list(APPEND BENCH_LIBS ${LIBZSTD_LIBRARIES})
+  add_compile_definitions(HAS_ZSTD=1)
+  message(STATUS "compress: libzstd REAL")
+else()
+  message(STATUS "compress: libzstd SKIPPED (SizeZstd will be empty)")
+endif()
 set(BENCH_INCLUDES
   ${CMAKE_CURRENT_SOURCE_DIR}/include
   ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
+if(LIBZSTD_FOUND)
+  list(APPEND BENCH_INCLUDES ${LIBZSTD_INCLUDE_DIRS})
+endif()
 add_compile_definitions(HAS_CUSTOM_BINARY=1)
 
 if(EXISTS ${TP}/cJSON/cJSON.c)

--- a/c/include/bench.h
+++ b/c/include/bench.h
@@ -129,8 +129,12 @@ void csv_logger_write(csv_logger_t *L, const char *mode, const char *td,
                       double fidelity, const char *version,
                       int instance_count, const char *type_config_hash,
                       const char *stream_mode,
-                      int run_order, int schedule_position);
+                      int run_order, int schedule_position,
+                      size_t size_gzip, size_t size_zstd);
 void csv_logger_close(csv_logger_t *L);
+
+/* One-shot gzip(6) / zstd(3) of already-written bytes. Not timed. zstd is 0 if libzstd is absent. */
+void bench_compress_sizes(const uint8_t *data, size_t n, size_t *out_gzip, size_t *out_zstd);
 
 int bench_serialize_cell(const serializer_t *S, const test_fixture_t *fx,
                          uint8_t *buf, size_t buf_cap, size_t *out_len);

--- a/c/src/compress.c
+++ b/c/src/compress.c
@@ -1,0 +1,56 @@
+#include "bench.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <zlib.h>
+
+#ifdef HAS_ZSTD
+#include <zstd.h>
+#endif
+
+/* gzip format (header + CRC), level 6 — matches Python gzip.compress(..., 6). */
+static size_t gzip_size(const uint8_t *data, size_t n) {
+    if (!data || n == 0) return 0;
+    z_stream strm;
+    memset(&strm, 0, sizeof strm);
+    /* windowBits 15+16 = gzip wrapper. */
+    if (deflateInit2(&strm, 6, Z_DEFLATED, 15 + 16, 8, Z_DEFAULT_STRATEGY) != Z_OK) {
+        return 0;
+    }
+    uLong bound = compressBound((uLong)n) + 32;
+    uint8_t *out = (uint8_t *)malloc(bound);
+    if (!out) {
+        deflateEnd(&strm);
+        return 0;
+    }
+    strm.next_in = (Bytef *)data;
+    strm.avail_in = (uInt)n;
+    strm.next_out = out;
+    strm.avail_out = (uInt)bound;
+    int rc = deflate(&strm, Z_FINISH);
+    size_t len = (rc == Z_STREAM_END) ? (size_t)strm.total_out : 0;
+    deflateEnd(&strm);
+    free(out);
+    return len;
+}
+
+#ifdef HAS_ZSTD
+static size_t zstd_size(const uint8_t *data, size_t n) {
+    if (!data || n == 0) return 0;
+    size_t bound = ZSTD_compressBound(n);
+    void *out = malloc(bound);
+    if (!out) return 0;
+    size_t got = ZSTD_compress(out, bound, data, n, 3);
+    free(out);
+    return ZSTD_isError(got) ? 0 : got;
+}
+#endif
+
+void bench_compress_sizes(const uint8_t *data, size_t n, size_t *out_gzip, size_t *out_zstd) {
+    if (out_gzip) *out_gzip = gzip_size(data, n);
+#ifdef HAS_ZSTD
+    if (out_zstd) *out_zstd = zstd_size(data, n);
+#else
+    if (out_zstd) *out_zstd = 0;
+#endif
+}

--- a/c/src/csv_log.c
+++ b/c/src/csv_log.c
@@ -15,7 +15,7 @@ csv_logger_t *csv_logger_create(const char *path) {
         "Language,StringOrStream,TestDataName,Repetitions,RepetitionIndex,SerializerName,"
         "SerializerVersion,TimeSer,TimeDeser,Size,TimeSerAndDeser,OpPerSecSer,OpPerSecDeser,"
         "OpPerSecSerAndDeser,MemoryPeakBytes,FidelityScore,DataTypeInstanceCount,TypeConfigHash,"
-        "StreamMode,RunOrder,SchedulePosition\n");
+        "StreamMode,RunOrder,SchedulePosition,SizeGzip,SizeZstd\n");
     return L;
 }
 
@@ -25,24 +25,27 @@ void csv_logger_write(csv_logger_t *L, const char *mode, const char *td,
                       double fidelity, const char *version,
                       int instance_count, const char *type_config_hash,
                       const char *stream_mode,
-                      int run_order, int schedule_position) {
+                      int run_order, int schedule_position,
+                      size_t size_gzip, size_t size_zstd) {
     if (!L || !L->f) return;
     uint64_t tot = ser_ns + deser_ns;
     double ops_s = ser_ns ? 1e9 / (double)ser_ns : 0;
     double ops_d = deser_ns ? 1e9 / (double)deser_ns : 0;
     double ops_t = tot ? 1e9 / (double)tot : 0;
     if (instance_count < 1) instance_count = 1;
-    char ro[32] = "", sp[32] = "";
+    char ro[32] = "", sp[32] = "", gz[32] = "", zs[32] = "";
     if (run_order >= 0) snprintf(ro, sizeof ro, "%d", run_order);
     if (schedule_position >= 0) snprintf(sp, sizeof sp, "%d", schedule_position);
+    if (size_gzip > 0) snprintf(gz, sizeof gz, "%zu", size_gzip);
+    if (size_zstd > 0) snprintf(zs, sizeof zs, "%zu", size_zstd);
     fprintf(L->f,
-        "c,%s,%s,%d,%d,%s,%s,%llu,%llu,%zu,%llu,%.6f,%.6f,%.6f,0,%.1f,%d,%s,%s,%s,%s\n",
+        "c,%s,%s,%d,%d,%s,%s,%llu,%llu,%zu,%llu,%.6f,%.6f,%.6f,0,%.1f,%d,%s,%s,%s,%s,%s,%s\n",
         mode, td, reps, rep_idx, ser, version ? version : "",
         (unsigned long long)ser_ns, (unsigned long long)deser_ns, size,
         (unsigned long long)tot, ops_s, ops_d, ops_t, fidelity,
         instance_count, type_config_hash ? type_config_hash : "",
         stream_mode ? stream_mode : "",
-        ro, sp);
+        ro, sp, gz, zs);
 }
 
 void csv_logger_close(csv_logger_t *L) {

--- a/c/src/run_v2.c
+++ b/c/src/run_v2.c
@@ -120,9 +120,11 @@ static int run_one_trial(serializer_t *S, test_fixture_t *fx, const char *type_i
     }
     {
         const char *sm = (mode && strcmp(mode, "stream") == 0) ? "adapted" : "";
+        size_t gz = 0, zs = 0;
+        bench_compress_sizes(buf, out_len, &gz, &zs);
         csv_logger_write(log, mode, type_id, repetitions, r, S->name,
                          t1 - t0, t2 - t1, out_len, 1.0, S->version,
-                         n, type_hash, sm, ro, sp);
+                         n, type_hash, sm, ro, sp, gz, zs);
     }
     return 0;
 }

--- a/c/src/runner.c
+++ b/c/src/runner.c
@@ -143,9 +143,11 @@ int run_benchmarks(int repetitions, const char *ser_filter, const char *data_fil
                     }
                     if (!had_error) {
                         const char *sm = (mode && strcmp(mode, "stream") == 0) ? "adapted" : "";
+                        size_t gz = 0, zs = 0;
+                        bench_compress_sizes(buf, out_len, &gz, &zs);
                         csv_logger_write(log, mode, fx->name, repetitions, r, S->name,
                                          t1 - t0, t2 - t1, out_len, 1.0, S->version,
-                                         1, "", sm, -1, -1);
+                                         1, "", sm, -1, -1, gz, zs);
                     }
                 }
             }

--- a/c/tests/test_roundtrip.c
+++ b/c/tests/test_roundtrip.c
@@ -16,6 +16,16 @@ static int checks = 0;
     } \
 } while (0)
 
+static void test_compress_sizes(void) {
+    size_t gz = 0, zs = 0;
+    bench_compress_sizes((const uint8_t *)"hello", 5, &gz, &zs);
+    CHECK(gz >= 20 && gz <= 40, "gzip(hello)=%zu want ~25", gz);
+    /* zstd is optional */
+    (void)zs;
+    bench_compress_sizes(NULL, 0, &gz, &zs);
+    CHECK(gz == 0 && zs == 0, "empty compress should be 0,0");
+}
+
 static void test_all_roundtrips(void) {
     serializer_t sers[BENCH_MAX_SERIALIZERS];
     int n = 0;
@@ -89,6 +99,7 @@ int main(void) {
     test_schedule_golden();
     test_v2_type_names();
     test_telemetry_points_from_config();
+    test_compress_sizes();
     test_all_roundtrips();
     printf("%d checks, %d failures\n", checks, failures);
     return failures ? 1 : 0;

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -9,6 +9,20 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-O2> $<$<COMPILE_LANGUAGE:C>:-O2> -Wall)
 
+find_package(ZLIB REQUIRED)
+find_package(PkgConfig QUIET)
+if(PkgConfig_FOUND)
+  pkg_check_modules(LIBZSTD QUIET libzstd)
+endif()
+if(LIBZSTD_FOUND)
+  add_compile_definitions(HAS_ZSTD=1)
+  include_directories(${LIBZSTD_INCLUDE_DIRS})
+  link_libraries(${LIBZSTD_LIBRARIES})
+  message(STATUS "compress: libzstd REAL")
+else()
+  message(STATUS "compress: libzstd SKIPPED (SizeZstd will be empty)")
+endif()
+
 include(FetchContent)
 set(FETCHCONTENT_QUIET OFF)
 set(CPP_TP "${CMAKE_CURRENT_SOURCE_DIR}/third_party")
@@ -261,6 +275,7 @@ target_link_libraries(serializer_benchmark_cpp PRIVATE
   yas_hdr
   cista_hdr
   pthread
+  ZLIB::ZLIB
 )
 
 if(BENCH_HAS_LIBPROTOBUF)
@@ -350,6 +365,7 @@ target_link_libraries(cpp_serializer_tests PRIVATE
   yas_hdr
   cista_hdr
   pthread
+  ZLIB::ZLIB
 )
 if(TARGET msgpack-cxx)
   target_link_libraries(cpp_serializer_tests PRIVATE msgpack-cxx)

--- a/cpp/include/bench/csv_log.hpp
+++ b/cpp/include/bench/csv_log.hpp
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <string>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 namespace bench {
@@ -21,11 +22,14 @@ class CsvLogger {
                  uint64_t deser_ns, size_t size, double fidelity, const std::string& native_kind,
                  const std::string& stream_mode, int instance_count,
                  const std::string& type_config_hash, int run_order = -1,
-                 int schedule_position = -1);
+                 int schedule_position = -1, size_t size_gzip = 0, size_t size_zstd = 0);
 
  private:
   FILE* f_ = nullptr;
 };
+
+/* One-shot gzip(6) / zstd(3) of already-written bytes. Not timed. zstd is 0 if libzstd is absent. */
+std::pair<size_t, size_t> compress_sizes(const uint8_t* data, size_t n);
 
 void save_errors(const std::string& path,
                  const std::vector<std::tuple<std::string, std::string, std::string, int, std::string>>&

--- a/cpp/src/csv_log.cpp
+++ b/cpp/src/csv_log.cpp
@@ -1,9 +1,17 @@
 #include "bench/csv_log.hpp"
 
 #include <cstdint>
+#include <cstdlib>
+#include <cstring>
 #include <stdexcept>
 #include <tuple>
+#include <utility>
 #include <vector>
+#include <zlib.h>
+
+#ifdef HAS_ZSTD
+#include <zstd.h>
+#endif
 
 namespace bench {
 
@@ -14,7 +22,7 @@ CsvLogger::CsvLogger(const std::string& path) {
                "Language,StringOrStream,TestDataName,Repetitions,RepetitionIndex,SerializerName,"
                "SerializerVersion,TimeSer,TimeDeser,Size,TimeSerAndDeser,OpPerSecSer,OpPerSecDeser,"
                "OpPerSecSerAndDeser,MemoryPeakBytes,FidelityScore,NativeKind,StreamMode,"
-               "DataTypeInstanceCount,TypeConfigHash,RunOrder,SchedulePosition\n");
+               "DataTypeInstanceCount,TypeConfigHash,RunOrder,SchedulePosition,SizeGzip,SizeZstd\n");
 }
 
 CsvLogger::~CsvLogger() {
@@ -26,22 +34,55 @@ void CsvLogger::write_row(const std::string& mode, const std::string& test_data,
                           uint64_t ser_ns, uint64_t deser_ns, size_t size, double fidelity,
                           const std::string& native_kind, const std::string& stream_mode,
                           int instance_count, const std::string& type_config_hash, int run_order,
-                          int schedule_position) {
+                          int schedule_position, size_t size_gzip, size_t size_zstd) {
   uint64_t tot = ser_ns + deser_ns;
   double ops_s = ser_ns ? 1e9 / static_cast<double>(ser_ns) : 0;
   double ops_d = deser_ns ? 1e9 / static_cast<double>(deser_ns) : 0;
   double ops_t = tot ? 1e9 / static_cast<double>(tot) : 0;
   if (instance_count < 1) instance_count = 1;
-  char ro[32] = "", sp[32] = "";
+  char ro[32] = "", sp[32] = "", gz[32] = "", zs[32] = "";
   if (run_order >= 0) std::snprintf(ro, sizeof ro, "%d", run_order);
   if (schedule_position >= 0) std::snprintf(sp, sizeof sp, "%d", schedule_position);
+  if (size_gzip > 0) std::snprintf(gz, sizeof gz, "%zu", size_gzip);
+  if (size_zstd > 0) std::snprintf(zs, sizeof zs, "%zu", size_zstd);
   std::fprintf(f_,
-               "cpp,%s,%s,%d,%d,%s,%s,%llu,%llu,%zu,%llu,%.6f,%.6f,%.6f,0,%.1f,%s,%s,%d,%s,%s,%s\n",
+               "cpp,%s,%s,%d,%d,%s,%s,%llu,%llu,%zu,%llu,%.6f,%.6f,%.6f,0,%.1f,%s,%s,%d,%s,%s,%s,%s,%s\n",
                mode.c_str(), test_data.c_str(), reps, rep_idx, ser.c_str(), version.c_str(),
                static_cast<unsigned long long>(ser_ns), static_cast<unsigned long long>(deser_ns),
                size, static_cast<unsigned long long>(tot), ops_s, ops_d, ops_t, fidelity,
                native_kind.c_str(), stream_mode.c_str(), instance_count, type_config_hash.c_str(),
-               ro, sp);
+               ro, sp, gz, zs);
+}
+
+std::pair<size_t, size_t> compress_sizes(const uint8_t* data, size_t n) {
+  if (!data || n == 0) return {0, 0};
+  size_t gz = 0;
+  z_stream strm;
+  std::memset(&strm, 0, sizeof strm);
+  if (deflateInit2(&strm, 6, Z_DEFLATED, 15 + 16, 8, Z_DEFAULT_STRATEGY) == Z_OK) {
+    uLong bound = compressBound(static_cast<uLong>(n)) + 32;
+    auto* out = static_cast<uint8_t*>(std::malloc(bound));
+    if (out) {
+      strm.next_in = const_cast<Bytef*>(reinterpret_cast<const Bytef*>(data));
+      strm.avail_in = static_cast<uInt>(n);
+      strm.next_out = out;
+      strm.avail_out = static_cast<uInt>(bound);
+      if (deflate(&strm, Z_FINISH) == Z_STREAM_END) gz = static_cast<size_t>(strm.total_out);
+      std::free(out);
+    }
+    deflateEnd(&strm);
+  }
+  size_t zs = 0;
+#ifdef HAS_ZSTD
+  size_t bound = ZSTD_compressBound(n);
+  void* out = std::malloc(bound);
+  if (out) {
+    size_t got = ZSTD_compress(out, bound, data, n, 3);
+    if (!ZSTD_isError(got)) zs = got;
+    std::free(out);
+  }
+#endif
+  return {gz, zs};
 }
 
 void save_errors(

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -40,6 +40,8 @@ struct Measure {
   uint64_t ser_ns = 0;
   uint64_t deser_ns = 0;
   size_t size = 0;
+  size_t size_gzip = 0;
+  size_t size_zstd = 0;
 };
 
 // Optimization barrier (issue #59) — mirrors Google Benchmark DoNotOptimize.
@@ -71,6 +73,9 @@ static Measure measure_bytes(bench::ISerializer& ser, const bench::Fixture& fx,
   if (!bench::fidelity(fx.value, out)) {
     throw std::runtime_error(std::string("roundtrip fidelity failed for ") + ser.name());
   }
+  auto [gz, zs] = bench::compress_sizes(buf.data(), buf.size());
+  m.size_gzip = gz;
+  m.size_zstd = zs;
   return m;
 }
 
@@ -91,6 +96,9 @@ static Measure measure_stream(bench::ISerializer& ser, const bench::Fixture& fx,
   if (!bench::fidelity(fx.value, out)) {
     throw std::runtime_error(std::string("stream roundtrip fidelity failed for ") + ser.name());
   }
+  auto [gz, zs] = bench::compress_sizes(buf.data(), m.size);
+  m.size_gzip = gz;
+  m.size_zstd = zs;
   return m;
 }
 
@@ -223,7 +231,7 @@ int main(int argc, char** argv) {
         }
         logger.write_row(mode, fx.type_id, reps, rep_idx, ser.name(), ser.version(), m.ser_ns,
                          m.deser_ns, m.size, 1.0, ser.native_kind(), ser.stream_mode(),
-                         fx.instance_count, fx.type_config_hash, ro, sp);
+                         fx.instance_count, fx.type_config_hash, ro, sp, m.size_gzip, m.size_zstd);
       };
 
       if (strategy == "none") {

--- a/experiments/PLAN.md
+++ b/experiments/PLAN.md
@@ -1310,7 +1310,7 @@ We go **row by row**. A wrapper (harness) change is its **own PR**, then we re-r
 |------|------|------------------|
 | B1 | **C runner reads `type_config.points`** and raise `V2_MAX_POINTS` to 512 | **done** [#96](https://github.com/leo-gan/GLD.SerializerBenchmark/pull/96) |
 | B2 | Re-run Experiment 4 in C (and keep Rust) | **this re-run** |
-| B3 | **One-shot gzip(6) / zstd(3) of written bytes** in Go, Java, JS, Rust, C, C++, C#, Swift CSV (`SizeGzip`, `SizeZstd`). Parser already accepts those columns. Not timed. | wrapper |
+| B3 | **One-shot gzip(6) / zstd(3) of written bytes** in Go, Java, JS, Rust, C, C++, C#, Swift CSV (`SizeGzip`, `SizeZstd`). Parser already accepts those columns. Not timed. gzip everywhere; zstd where the language already has an encoder (Go, Rust, C/C++/JS when libzstd or Node zstd is present). Java / C# / Swift leave `SizeZstd` empty. | **this wrapper** |
 | B4 | Re-run Experiment 9 in those languages | experiment, after B3 |
 | B5 | Run `cpp/scripts/setup-protobuf-sysroot.sh` so official C++ `protobuf` registers; re-run Experiment 7 C++ | wrapper/env + experiment |
 

--- a/go/compress.go
+++ b/go/compress.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+// compressSizes returns one-shot gzip(6) and zstd(3) lengths of raw.
+// Not on the timed path. Empty input or a codec error yields 0.
+func compressSizes(raw []byte) (gz, zs int) {
+	if len(raw) == 0 {
+		return 0, 0
+	}
+	var buf bytes.Buffer
+	w, err := gzip.NewWriterLevel(&buf, 6)
+	if err != nil {
+		return 0, 0
+	}
+	if _, err := w.Write(raw); err != nil {
+		_ = w.Close()
+		return 0, 0
+	}
+	if err := w.Close(); err != nil {
+		return 0, 0
+	}
+	gz = buf.Len()
+
+	enc, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.EncoderLevelFromZstd(3)))
+	if err == nil {
+		zs = len(enc.EncodeAll(raw, nil))
+		_ = enc.Close()
+	}
+	return gz, zs
+}

--- a/go/compress_test.go
+++ b/go/compress_test.go
@@ -1,0 +1,23 @@
+package main
+
+import "testing"
+
+func TestCompressSizesGzipHello(t *testing.T) {
+	gz, zs := compressSizes([]byte("hello"))
+	if gz < 20 || gz > 40 {
+		t.Fatalf("gzip(hello) size %d, want ~25", gz)
+	}
+	if zs == 0 {
+		t.Fatal("zstd(hello) size is 0")
+	}
+	if zs >= gz+20 {
+		t.Fatalf("zstd %d unexpectedly larger than gzip %d", zs, gz)
+	}
+}
+
+func TestCompressSizesEmpty(t *testing.T) {
+	gz, zs := compressSizes(nil)
+	if gz != 0 || zs != 0 {
+		t.Fatalf("empty: got %d %d", gz, zs)
+	}
+}

--- a/go/csv_log.go
+++ b/go/csv_log.go
@@ -19,7 +19,7 @@ func NewCsvLogger(path string) (*CsvLogger, error) {
 	if err != nil {
 		return nil, err
 	}
-	header := "Language,StringOrStream,TestDataName,Repetitions,RepetitionIndex,SerializerName,SerializerVersion,TimeSer,TimeDeser,Size,TimeSerAndDeser,OpPerSecSer,OpPerSecDeser,OpPerSecSerAndDeser,MemoryPeakBytes,FidelityScore,NativeKind,StreamMode,DataTypeInstanceCount,TypeConfigHash,RunOrder,SchedulePosition\n"
+	header := "Language,StringOrStream,TestDataName,Repetitions,RepetitionIndex,SerializerName,SerializerVersion,TimeSer,TimeDeser,Size,TimeSerAndDeser,OpPerSecSer,OpPerSecDeser,OpPerSecSerAndDeser,MemoryPeakBytes,FidelityScore,NativeKind,StreamMode,DataTypeInstanceCount,TypeConfigHash,RunOrder,SchedulePosition,SizeGzip,SizeZstd\n"
 	if _, err := f.WriteString(header); err != nil {
 		_ = f.Close()
 		return nil, err
@@ -38,6 +38,7 @@ func (c *CsvLogger) WriteRow(
 	instanceCount int,
 	typeConfigHash string,
 	runOrder, schedulePosition int,
+	sizeGzip, sizeZstd int,
 ) error {
 	total := timeSerNs + timeDeserNs
 	opsSer, opsDeser, opsTot := 0.0, 0.0, 0.0
@@ -62,13 +63,21 @@ func (c *CsvLogger) WriteRow(
 		sp = fmt.Sprintf("%d", schedulePosition)
 	}
 	_, err := fmt.Fprintf(c.f,
-		"go,%s,%s,%d,%d,%s,%s,%d,%d,%d,%d,%.6f,%.6f,%.6f,0,%.1f,%s,%s,%s,%s,%s,%s\n",
+		"go,%s,%s,%d,%d,%s,%s,%d,%d,%d,%d,%.6f,%.6f,%.6f,0,%.1f,%s,%s,%s,%s,%s,%s,%s,%s\n",
 		mode, testData, repetitions, repIndex, serializer, version,
 		timeSerNs, timeDeserNs, size, total,
 		opsSer, opsDeser, opsTot, fidelity, nativeKind, streamMode,
 		ic, typeConfigHash, ro, sp,
+		optInt(sizeGzip), optInt(sizeZstd),
 	)
 	return err
+}
+
+func optInt(n int) string {
+	if n > 0 {
+		return fmt.Sprintf("%d", n)
+	}
+	return ""
 }
 
 func (c *CsvLogger) Flush() error { return c.f.Sync() }

--- a/go/go.mod
+++ b/go/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/hamba/avro/v2 v2.31.0
 	github.com/json-iterator/go v1.1.12
 	github.com/kelindar/binary v1.0.19
+	github.com/klauspost/compress v1.18.2
 	github.com/linkedin/goavro/v2 v2.15.0
 	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/segmentio/encoding v0.5.4

--- a/go/go.sum
+++ b/go/go.sum
@@ -29,6 +29,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kelindar/binary v1.0.19 h1:DNyQCtKjkLhBh9pnP49OWREddLB0Mho+1U/AOt/Qzxw=
 github.com/kelindar/binary v1.0.19/go.mod h1:/twdz8gRLNMffx0U4UOgqm1LywPs6nd9YK2TX52MDh8=
+github.com/klauspost/compress v1.18.2 h1:iiPHWW0YrcFgpBYhsA6D1+fqHssJscY/Tm/y2Uqnapk=
+github.com/klauspost/compress v1.18.2/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/klauspost/cpuid/v2 v2.2.11 h1:0OwqZRYI2rFrjS4kvkDnqJkKHdHaRnCm68/DY4OxRzU=
 github.com/klauspost/cpuid/v2 v2.2.11/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/linkedin/goavro/v2 v2.15.0 h1:pDj1UrjUOO62iXhgBiE7jQkpNIc5/tA5eZsgolMjgVI=

--- a/go/main.go
+++ b/go/main.go
@@ -247,6 +247,8 @@ func main() {
 		type prepared struct {
 			ser       serializers.BenchSerializer
 			streamBuf *bytes.Buffer
+			sizeGzip  int
+			sizeZstd  int
 		}
 		var ready []prepared
 		failed := map[string]bool{}
@@ -266,9 +268,15 @@ func main() {
 				failed[ser.Name()] = true
 				continue
 			}
+			gz, zs := 0, 0
+			if raw, serr := ser.SerializeBytes(fx); serr == nil {
+				gz, zs = compressSizes(raw)
+			}
 			ready = append(ready, prepared{
 				ser:       ser,
 				streamBuf: bytes.NewBuffer(make([]byte, 0, 64*1024)),
+				sizeGzip:  gz,
+				sizeZstd:  zs,
 			})
 		}
 		byName := map[string]prepared{}
@@ -332,6 +340,7 @@ func main() {
 						ser.Version(), ser.NativeKind().String(), ser.StreamMode().String(),
 						w.instanceCount, w.typeConfigHash,
 						ro, sp,
+						p.sizeGzip, p.sizeZstd,
 					)
 				}
 			}

--- a/java/src/main/java/benchmark/Compress.java
+++ b/java/src/main/java/benchmark/Compress.java
@@ -1,0 +1,32 @@
+package benchmark;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.zip.GZIPOutputStream;
+
+/** One-shot compressed sizes of already-written bytes (not timed). */
+public final class Compress {
+  private Compress() {}
+
+  /**
+   * gzip(6) length and zstd(3) length. The JDK has no zstd encoder, so the
+   * second value is always 0.
+   */
+  public static int[] sizes(byte[] raw) {
+    if (raw == null || raw.length == 0) {
+      return new int[] {0, 0};
+    }
+    ByteArrayOutputStream bos = new ByteArrayOutputStream(Math.max(32, raw.length));
+    try (GZIPOutputStream gzos =
+        new GZIPOutputStream(bos) {
+          {
+            def.setLevel(6);
+          }
+        }) {
+      gzos.write(raw);
+    } catch (IOException e) {
+      return new int[] {0, 0};
+    }
+    return new int[] {bos.size(), 0};
+  }
+}

--- a/java/src/main/java/benchmark/CsvLogger.java
+++ b/java/src/main/java/benchmark/CsvLogger.java
@@ -18,7 +18,7 @@ public final class CsvLogger implements AutoCloseable {
         "Language,StringOrStream,TestDataName,Repetitions,RepetitionIndex,SerializerName,"
             + "SerializerVersion,TimeSer,TimeDeser,Size,TimeSerAndDeser,OpPerSecSer,OpPerSecDeser,"
             + "OpPerSecSerAndDeser,MemoryPeakBytes,FidelityScore,NativeKind,StreamMode,"
-            + "DataTypeInstanceCount,TypeConfigHash,RunOrder,SchedulePosition\n");
+            + "DataTypeInstanceCount,TypeConfigHash,RunOrder,SchedulePosition,SizeGzip,SizeZstd\n");
   }
 
   public void writeRow(
@@ -37,7 +37,9 @@ public final class CsvLogger implements AutoCloseable {
       int instanceCount,
       String typeConfigHash,
       int runOrder,
-      int schedulePosition)
+      int schedulePosition,
+      int sizeGzip,
+      int sizeZstd)
       throws IOException {
     long total = timeSerNs + timeDeserNs;
     double opsSer = timeSerNs > 0 ? 1e9 / timeSerNs : 0;
@@ -46,12 +48,14 @@ public final class CsvLogger implements AutoCloseable {
     String ic = instanceCount > 0 ? Integer.toString(instanceCount) : "";
     String ro = runOrder >= 0 ? Integer.toString(runOrder) : "";
     String sp = schedulePosition >= 0 ? Integer.toString(schedulePosition) : "";
+    String gz = sizeGzip > 0 ? Integer.toString(sizeGzip) : "";
+    String zs = sizeZstd > 0 ? Integer.toString(sizeZstd) : "";
     // Locale.US: decimal point must stay '.' — default locales (e.g. de_DE) use ',' and
     // would inject extra CSV columns for OpPerSec* / FidelityScore.
     w.write(
         String.format(
             Locale.US,
-            "java,%s,%s,%d,%d,%s,%s,%d,%d,%d,%d,%.6f,%.6f,%.6f,0,%.1f,%s,%s,%s,%s,%s,%s\n",
+            "java,%s,%s,%d,%d,%s,%s,%d,%d,%d,%d,%.6f,%.6f,%.6f,0,%.1f,%s,%s,%s,%s,%s,%s,%s,%s\n",
             mode,
             testData,
             repetitions,
@@ -71,7 +75,9 @@ public final class CsvLogger implements AutoCloseable {
             ic,
             typeConfigHash == null ? "" : typeConfigHash,
             ro,
-            sp));
+            sp,
+            gz,
+            zs));
   }
 
   public void flush() throws IOException {

--- a/java/src/main/java/benchmark/Main.java
+++ b/java/src/main/java/benchmark/Main.java
@@ -34,10 +34,14 @@ public final class Main {
   private static final class Prepared {
     final BenchSerializer ser;
     final ByteArrayOutputStream streamScratch;
+    final int sizeGzip;
+    final int sizeZstd;
 
-    Prepared(BenchSerializer ser) {
+    Prepared(BenchSerializer ser, int sizeGzip, int sizeZstd) {
       this.ser = ser;
       this.streamScratch = new ByteArrayOutputStream(64 * 1024);
+      this.sizeGzip = sizeGzip;
+      this.sizeZstd = sizeZstd;
     }
   }
 
@@ -133,7 +137,15 @@ public final class Main {
             failed.add(ser.name());
             continue;
           }
-          Prepared p = new Prepared(ser);
+          int gz = 0, zs = 0;
+          try {
+            int[] csz = Compress.sizes(ser.serializeBytes(fx));
+            gz = csz[0];
+            zs = csz[1];
+          } catch (Exception ignored) {
+            // leave compressed sizes empty
+          }
+          Prepared p = new Prepared(ser, gz, zs);
           ready.add(p);
           byName.put(ser.name(), p);
         }
@@ -193,7 +205,9 @@ public final class Main {
                     w.instanceCount(),
                     w.typeConfigHash(),
                     ro,
-                    sp);
+                    sp,
+                    p.sizeGzip,
+                    p.sizeZstd);
               } catch (Exception e) {
                 System.err.printf(
                     "[ERROR] %s / %s / %s: %s%n", ser.name(), fx.name, mode, e.toString());

--- a/java/src/test/java/benchmark/RoundtripTest.java
+++ b/java/src/test/java/benchmark/RoundtripTest.java
@@ -42,4 +42,12 @@ class RoundtripTest {
           () -> "fidelity failed for " + ser.name() + " on " + type);
     }
   }
+
+  @Test
+  void compressSizesGzipHello() {
+    int[] c = Compress.sizes("hello".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+    assertTrue(c[0] >= 20 && c[0] <= 40, "gzip=" + c[0]);
+    int[] empty = Compress.sizes(new byte[0]);
+    assertTrue(empty[0] == 0 && empty[1] == 0);
+  }
 }

--- a/javascript/src/compress.js
+++ b/javascript/src/compress.js
@@ -1,0 +1,27 @@
+import zlib from 'node:zlib';
+
+/** One-shot gzip(6) / zstd(3) of already-written bytes. Not timed. */
+export function compressSizes(buf) {
+  if (buf == null) return [0, 0];
+  const raw = Buffer.isBuffer(buf) ? buf : Buffer.from(buf);
+  if (raw.length === 0) return [0, 0];
+  let gz = 0;
+  let zs = 0;
+  try {
+    gz = zlib.gzipSync(raw, { level: 6 }).length;
+  } catch {
+    gz = 0;
+  }
+  if (typeof zlib.zstdCompressSync === 'function') {
+    try {
+      const params = {};
+      if (zlib.constants && zlib.constants.ZSTD_c_compressionLevel != null) {
+        params[zlib.constants.ZSTD_c_compressionLevel] = 3;
+      }
+      zs = zlib.zstdCompressSync(raw, { params }).length;
+    } catch {
+      zs = 0;
+    }
+  }
+  return [gz, zs];
+}

--- a/javascript/src/runner_v2.js
+++ b/javascript/src/runner_v2.js
@@ -11,6 +11,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
+import { compressSizes } from './compress.js';
 import { makeOne, instances } from './data_v2.js';
 import { ALL_SERIALIZERS, performance } from './serializers/index.js';
 import { deepEqual } from './data.js';
@@ -37,7 +38,7 @@ const logPath = path.join(logDir, `${ts}.csv`);
 const errPath = path.join(logDir, `${ts}.errors.csv`);
 
 const header =
-  'Language,StringOrStream,TestDataName,Repetitions,RepetitionIndex,SerializerName,SerializerVersion,TimeSer,TimeDeser,Size,TimeSerAndDeser,OpPerSecSer,OpPerSecDeser,OpPerSecSerAndDeser,MemoryPeakBytes,FidelityScore,DataTypeInstanceCount,TypeConfigHash,RunOrder,SchedulePosition\n';
+  'Language,StringOrStream,TestDataName,Repetitions,RepetitionIndex,SerializerName,SerializerVersion,TimeSer,TimeDeser,Size,TimeSerAndDeser,OpPerSecSer,OpPerSecDeser,OpPerSecSerAndDeser,MemoryPeakBytes,FidelityScore,DataTypeInstanceCount,TypeConfigHash,RunOrder,SchedulePosition,SizeGzip,SizeZstd\n';
 const lines = [header];
 const errors = ['TestDataName,SerializerName,StringOrStream,Repetition,ErrorText\n'];
 
@@ -119,6 +120,7 @@ for (const cell of cells) {
   const prepared = [];
   const byName = new Map();
   const failed = new Set();
+  const compressByName = new Map();
   for (const ser of serializers) {
     if (ser.supports && !ser.supports(typeId)) continue;
     try {
@@ -129,6 +131,11 @@ for (const cell of cells) {
       );
       failed.add(ser.name);
       continue;
+    }
+    try {
+      compressByName.set(ser.name, compressSizes(ser.serialize(value)));
+    } catch {
+      compressByName.set(ser.name, [0, 0]);
     }
     prepared.push(ser);
     byName.set(ser.name, ser);
@@ -177,6 +184,7 @@ for (const cell of cells) {
             sp = String(pos);
             runOrder++;
           }
+          const [gz, zs] = compressByName.get(ser.name) || [0, 0];
           lines.push(
             [
               'javascript',
@@ -199,6 +207,8 @@ for (const cell of cells) {
               hash,
               ro,
               sp,
+              gz || '',
+              zs || '',
             ].join(',') + '\n',
           );
         } catch (e) {

--- a/javascript/test/runner.test.js
+++ b/javascript/test/runner.test.js
@@ -2,6 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { allFixturesV2, deepEqual, makeOne, V2_TYPE_IDS } from '../src/data.js';
 import { ALL_SERIALIZERS } from '../src/serializers/index.js';
+import { compressSizes } from '../src/compress.js';
 import {
   deriveScheduleSeed,
   goldenPermutation,
@@ -80,6 +81,13 @@ test('all V2 fixtures roundtrip for every supporting serializer', () => {
       }
     }
   }
+});
+
+test('compressSizes gzip of hello is about 25 bytes', () => {
+  const [gz, zs] = compressSizes(Buffer.from('hello'));
+  assert.ok(gz >= 20 && gz <= 40, `gzip=${gz}`);
+  assert.equal(typeof zs, 'number');
+  assert.deepEqual(compressSizes(Buffer.alloc(0)), [0, 0]);
 });
 
 test('JSON serializer roundtrips message', () => {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -282,6 +282,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -805,6 +807,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -991,6 +1003,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "postcard"
@@ -1572,6 +1590,7 @@ dependencies = [
  "ciborium",
  "clap",
  "csv",
+ "flate2",
  "flexbuffers",
  "minicbor",
  "nanoserde",
@@ -1590,6 +1609,7 @@ dependencies = [
  "simd-json",
  "sonic-rs",
  "speedy",
+ "zstd",
 ]
 
 [[package]]
@@ -2083,3 +2103,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -40,6 +40,8 @@ bytes = "1"
 rand = "0.8"
 rand_pcg = "0.3"
 sha2 = "0.10"
+flate2 = "1"
+zstd = "0.13"
 
 [build-dependencies]
 prost-build = "0.13"

--- a/rust/src/compress.rs
+++ b/rust/src/compress.rs
@@ -1,0 +1,37 @@
+//! One-shot gzip(6) / zstd(3) of already-written bytes (not timed).
+
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use std::io::Write;
+
+/// Returns `(gzip_len, zstd_len)`. Either value is 0 on an empty input or codec error.
+pub fn compress_sizes(raw: &[u8]) -> (usize, usize) {
+    if raw.is_empty() {
+        return (0, 0);
+    }
+    let mut enc = GzEncoder::new(Vec::new(), Compression::new(6));
+    let gz = if enc.write_all(raw).is_ok() {
+        enc.finish().map(|v| v.len()).unwrap_or(0)
+    } else {
+        0
+    };
+    let zs = zstd::encode_all(raw, 3).map(|v| v.len()).unwrap_or(0);
+    (gz, zs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::compress_sizes;
+
+    #[test]
+    fn gzip_hello_is_about_25() {
+        let (gz, zs) = compress_sizes(b"hello");
+        assert!((20..=40).contains(&gz), "gzip={gz}");
+        assert!(zs > 0, "zstd should be available");
+    }
+
+    #[test]
+    fn empty_is_zero() {
+        assert_eq!(compress_sizes(b""), (0, 0));
+    }
+}

--- a/rust/src/csv_log.rs
+++ b/rust/src/csv_log.rs
@@ -19,7 +19,7 @@ impl CsvLogger {
         // RunOrder / SchedulePosition optional (empty when not recording).
         writeln!(
             writer,
-            "Language,StringOrStream,TestDataName,Repetitions,RepetitionIndex,SerializerName,SerializerVersion,TimeSer,TimeDeser,Size,TimeSerAndDeser,OpPerSecSer,OpPerSecDeser,OpPerSecSerAndDeser,MemoryPeakBytes,FidelityScore,NativeKind,StreamMode,DataTypeInstanceCount,TypeConfigHash,RunOrder,SchedulePosition"
+            "Language,StringOrStream,TestDataName,Repetitions,RepetitionIndex,SerializerName,SerializerVersion,TimeSer,TimeDeser,Size,TimeSerAndDeser,OpPerSecSer,OpPerSecDeser,OpPerSecSerAndDeser,MemoryPeakBytes,FidelityScore,NativeKind,StreamMode,DataTypeInstanceCount,TypeConfigHash,RunOrder,SchedulePosition,SizeGzip,SizeZstd"
         )?;
         Ok(Self { writer })
     }
@@ -57,7 +57,7 @@ impl CsvLogger {
         };
         writeln!(
             self.writer,
-            "rust,{mode},{test_data},{repetitions},{rep_index},{serializer},{version},{time_ser_ns},{time_deser_ns},{size},{total},{ops_ser:.6},{ops_deser:.6},{ops_tot:.6},0,{fidelity:.1},{native_kind},{stream_mode},,,,"
+            "rust,{mode},{test_data},{repetitions},{rep_index},{serializer},{version},{time_ser_ns},{time_deser_ns},{size},{total},{ops_ser:.6},{ops_deser:.6},{ops_tot:.6},0,{fidelity:.1},{native_kind},{stream_mode},,,,,,"
         )
     }
 
@@ -80,6 +80,8 @@ impl CsvLogger {
         type_config_hash: &str,
         run_order: Option<i32>,
         schedule_position: Option<i32>,
+        size_gzip: usize,
+        size_zstd: usize,
     ) -> std::io::Result<()> {
         let total = time_ser_ns + time_deser_ns;
         let ops_ser = if time_ser_ns > 0 {
@@ -103,9 +105,19 @@ impl CsvLogger {
         let sp = schedule_position
             .map(|v| v.to_string())
             .unwrap_or_default();
+        let gz = if size_gzip > 0 {
+            size_gzip.to_string()
+        } else {
+            String::new()
+        };
+        let zs = if size_zstd > 0 {
+            size_zstd.to_string()
+        } else {
+            String::new()
+        };
         writeln!(
             self.writer,
-            "rust,{mode},{test_data},{repetitions},{rep_index},{serializer},{version},{time_ser_ns},{time_deser_ns},{size},{total},{ops_ser:.6},{ops_deser:.6},{ops_tot:.6},0,{fidelity:.1},{native_kind},{stream_mode},{instance_count},{type_config_hash},{ro},{sp}"
+            "rust,{mode},{test_data},{repetitions},{rep_index},{serializer},{version},{time_ser_ns},{time_deser_ns},{size},{total},{ops_ser:.6},{ops_deser:.6},{ops_tot:.6},0,{fidelity:.1},{native_kind},{stream_mode},{instance_count},{type_config_hash},{ro},{sp},{gz},{zs}"
         )
     }
 

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,5 +1,6 @@
 //! Rust serializer benchmark runner (Data Model v2 only).
 
+mod compress;
 mod csv_log;
 mod data;
 mod run_v2;

--- a/rust/src/run_v2.rs
+++ b/rust/src/run_v2.rs
@@ -16,6 +16,7 @@
 //!   Fisher–Yates shuffle serializers → timed trials (per-serializer buffers).
 //! - `none`: legacy serializer → mode → rep order.
 
+use crate::compress::compress_sizes;
 use crate::csv_log::CsvLogger;
 use crate::data::{self, fidelity, Fixture};
 use crate::schedule::{
@@ -288,6 +289,8 @@ fn write_success(
     ser_ns: u128,
     deser_ns: u128,
     size: usize,
+    size_gzip: usize,
+    size_zstd: usize,
     run_order: Option<i32>,
     schedule_position: Option<i32>,
 ) -> Result<()> {
@@ -308,6 +311,8 @@ fn write_success(
         &cell.type_config_hash,
         run_order,
         schedule_position,
+        size_gzip,
+        size_zstd,
     )?;
     Ok(())
 }
@@ -412,6 +417,7 @@ pub fn run_v2(
                         };
                         match measured {
                             Ok((ser_ns, deser_ns, size)) => {
+                                let (gz, zs) = compress_sizes(&prepared[p_i].ser_buf);
                                 let (ro, sp) = if record_ro {
                                     let ro = global_run_order;
                                     global_run_order += 1;
@@ -429,6 +435,8 @@ pub fn run_v2(
                                     ser_ns,
                                     deser_ns,
                                     size,
+                                    gz,
+                                    zs,
                                     ro,
                                     sp,
                                 )?;
@@ -491,6 +499,7 @@ pub fn run_v2(
                         };
                         match measured {
                             Ok((ser_ns, deser_ns, size)) => {
+                                let (gz, zs) = compress_sizes(&prepared[p_i].ser_buf);
                                 let (ro, sp) = if record_ro {
                                     let ro = global_run_order;
                                     global_run_order += 1;
@@ -508,6 +517,8 @@ pub fn run_v2(
                                     ser_ns,
                                     deser_ns,
                                     size,
+                                    gz,
+                                    zs,
                                     ro,
                                     sp,
                                 )?;

--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -97,8 +97,17 @@ let package = Package(
             ]
         ),
         .target(
+            name: "GzipC",
+            path: "Sources/GzipC",
+            publicHeadersPath: "include",
+            linkerSettings: [
+                .linkedLibrary("z"),
+            ]
+        ),
+        .target(
             name: "SerializerBenchmarkCore",
             dependencies: [
+                "GzipC",
                 "CapnpBridge",
                 .product(name: "IkigaJSON", package: "IkigaJSON"),
                 .product(name: "SwiftMsgpack", package: "swift-msgpack"),

--- a/swift/Sources/GzipC/gzip_size.c
+++ b/swift/Sources/GzipC/gzip_size.c
@@ -1,0 +1,29 @@
+#include "gzip_size.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <zlib.h>
+
+size_t bench_gzip_size(const uint8_t *data, size_t n) {
+    if (!data || n == 0) return 0;
+    z_stream strm;
+    memset(&strm, 0, sizeof strm);
+    if (deflateInit2(&strm, 6, Z_DEFLATED, 15 + 16, 8, Z_DEFAULT_STRATEGY) != Z_OK) {
+        return 0;
+    }
+    uLong bound = compressBound((uLong)n) + 32;
+    uint8_t *out = (uint8_t *)malloc(bound);
+    if (!out) {
+        deflateEnd(&strm);
+        return 0;
+    }
+    strm.next_in = (Bytef *)data;
+    strm.avail_in = (uInt)n;
+    strm.next_out = out;
+    strm.avail_out = (uInt)bound;
+    int rc = deflate(&strm, Z_FINISH);
+    size_t len = (rc == Z_STREAM_END) ? (size_t)strm.total_out : 0;
+    deflateEnd(&strm);
+    free(out);
+    return len;
+}

--- a/swift/Sources/GzipC/include/gzip_size.h
+++ b/swift/Sources/GzipC/include/gzip_size.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* One-shot gzip(6) length of already-written bytes. 0 on empty input or error. */
+size_t bench_gzip_size(const uint8_t *data, size_t n);
+
+#ifdef __cplusplus
+}
+#endif

--- a/swift/Sources/SerializerBenchmarkCore/Compress.swift
+++ b/swift/Sources/SerializerBenchmarkCore/Compress.swift
@@ -1,0 +1,12 @@
+import Foundation
+import GzipC
+
+/// One-shot gzip(6) of already-written bytes. zstd is 0 (no encoder in this target).
+public func compressSizes(_ data: Data) -> (gzip: Int, zstd: Int) {
+    if data.isEmpty { return (0, 0) }
+    let gz = data.withUnsafeBytes { src -> Int in
+        guard let p = src.bindMemory(to: UInt8.self).baseAddress else { return 0 }
+        return Int(bench_gzip_size(p, src.count))
+    }
+    return (gz, 0)
+}

--- a/swift/Sources/SerializerBenchmarkCore/CsvLog.swift
+++ b/swift/Sources/SerializerBenchmarkCore/CsvLog.swift
@@ -16,7 +16,7 @@ public final class CsvLogger {
         self.path = path
         _ = FileManager.default.createFile(atPath: path.path, contents: nil)
         self.handle = try FileHandle(forWritingTo: path)
-        let header = "Language,StringOrStream,TestDataName,Repetitions,RepetitionIndex,SerializerName,SerializerVersion,TimeSer,TimeDeser,Size,TimeSerAndDeser,OpPerSecSer,OpPerSecDeser,OpPerSecSerAndDeser,MemoryPeakBytes,FidelityScore,NativeKind,StreamMode,DataTypeInstanceCount,TypeConfigHash,RunOrder,SchedulePosition\n"
+        let header = "Language,StringOrStream,TestDataName,Repetitions,RepetitionIndex,SerializerName,SerializerVersion,TimeSer,TimeDeser,Size,TimeSerAndDeser,OpPerSecSer,OpPerSecDeser,OpPerSecSerAndDeser,MemoryPeakBytes,FidelityScore,NativeKind,StreamMode,DataTypeInstanceCount,TypeConfigHash,RunOrder,SchedulePosition,SizeGzip,SizeZstd\n"
         handle.write(Data(header.utf8))
     }
 
@@ -36,7 +36,9 @@ public final class CsvLogger {
         instanceCount: Int,
         typeConfigHash: String,
         runOrder: Int = -1,
-        schedulePosition: Int = -1
+        schedulePosition: Int = -1,
+        sizeGzip: Int = 0,
+        sizeZstd: Int = 0
     ) {
         let total = timeSer &+ timeDeser
         let opsSer = timeSer > 0 ? 1e9 / Double(timeSer) : 0
@@ -67,6 +69,8 @@ public final class CsvLogger {
             escapeCSV(typeConfigHash),
             ro,
             sp,
+            sizeGzip > 0 ? String(sizeGzip) : "",
+            sizeZstd > 0 ? String(sizeZstd) : "",
         ].joined(separator: ",") + "\n"
         handle.write(Data(line.utf8))
     }

--- a/swift/Sources/SerializerBenchmarkCore/Runner.swift
+++ b/swift/Sources/SerializerBenchmarkCore/Runner.swift
@@ -120,6 +120,7 @@ public func runBenchmark(_ opts: RunOptions) throws {
                 let serNs: UInt64
                 let deserNs: UInt64
                 let size: Int
+                let written: Data
                 let out: Any
                 if mode == "stream" {
                     let t0 = nowNs()
@@ -132,6 +133,7 @@ public func runBenchmark(_ opts: RunOptions) throws {
                     serNs = t1 &- t0
                     deserNs = t2 &- t1
                     size = n
+                    written = buf
                     out = try toDomain(ser, decoded)
                 } else {
                     let t0 = nowNs()
@@ -144,6 +146,7 @@ public func runBenchmark(_ opts: RunOptions) throws {
                     serNs = t1 &- t0
                     deserNs = t2 &- t1
                     size = buf.count
+                    written = buf
                     out = try toDomain(ser, decoded)
                 }
                 if !fx.fidelity(against: out) {
@@ -156,6 +159,9 @@ public func runBenchmark(_ opts: RunOptions) throws {
                     sp = pos
                     runOrder += 1
                 }
+                let c = compressSizes(written)
+                let gz = c.gzip
+                let zs = c.zstd
                 logger.writeRow(
                     mode: mode,
                     testDataName: fx.name,
@@ -172,7 +178,9 @@ public func runBenchmark(_ opts: RunOptions) throws {
                     instanceCount: fx.instanceCount,
                     typeConfigHash: fx.typeConfigHash,
                     runOrder: ro,
-                    schedulePosition: sp
+                    schedulePosition: sp,
+                    sizeGzip: gz,
+                    sizeZstd: zs
                 )
             } catch {
                 let msg = String(describing: error)

--- a/swift/Tests/SerializerBenchmarkTests/RoundtripTests.swift
+++ b/swift/Tests/SerializerBenchmarkTests/RoundtripTests.swift
@@ -13,6 +13,13 @@ final class RoundtripTests: XCTestCase {
         XCTAssertTrue(fx.fidelity(against: out), "\(ser.name) fidelity for \(fx.name)")
     }
 
+    func testCompressSizesGzipHello() {
+        let c = compressSizes(Data("hello".utf8))
+        XCTAssertGreaterThanOrEqual(c.gzip, 20)
+        XCTAssertLessThanOrEqual(c.gzip, 40)
+        XCTAssertEqual(compressSizes(Data()).gzip, 0)
+    }
+
     func testAllSerializersRoundtripAllTypes() throws {
         for typeId in ["message", "document", "telemetry", "strings", "event"] {
             let fx = try fixtureFromCell(


### PR DESCRIPTION
## Summary
- Wrapper-only (B3): every non-Python runner now writes `SizeGzip` / `SizeZstd` on successful rows.
- One-shot gzip(6) of the already-written bytes, **after** the clock — not a timed compress.
- zstd(3) where an encoder is already available (Go, Rust; C/C++/JS when libzstd or Node zstd is present). Java, C#, and Swift leave `SizeZstd` empty.
- Analysis parser already accepts the columns. Experiment 9 is **not** re-run here (that is B4).

## How to read
- These numbers are sizes, not times. Do not treat compress as part of write time.

## Validation
- Go: `go test ./...` + 2-rep smoke (`SizeGzip`/`SizeZstd` present).
- Java: `RoundtripTest#compressSizesGzipHello`
- JS: `node --test` (includes compressSizes)
- Rust: `cargo test compress::`
- C: `c_serializer_tests` (399 checks)
- C++: `serializer_benchmark_cpp` rebuilt
- C#: `dotnet build`
- Swift: `swift build -c release` with the usual libstdc++ flags
- Analysis: `tests/test_parser.py` including SizeGzip/SizeZstd

Published site Results / dashboard payloads were not regenerated.

## Notes
- Follows `experiments/PLAN.md` Fix plan step B3.