### PR TITLE
fix(cpp): make official libprotobuf sysroot setup work

### DIFF
--- a/cpp/scripts/setup-protobuf-sysroot.sh
+++ b/cpp/scripts/setup-protobuf-sysroot.sh
@@ -7,7 +7,8 @@ CPP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 SYSROOT="$CPP_DIR/third_party/protobuf-sysroot"
 CACHE="$CPP_DIR/third_party/_protobuf_debs"
 VER="3.12.4-1ubuntu7.22.04.6"
-MIRROR="${PROTOBUF_DEB_MIRROR:-http://us.archive.ubuntu.com/ubuntu/pool/main/p/protobuf}"
+# us.archive has 404'd some 3.12.4 jammy debs; archive.ubuntu.com still has them.
+MIRROR="${PROTOBUF_DEB_MIRROR:-http://archive.ubuntu.com/ubuntu/pool/main/p/protobuf}"
 
 if [[ -x "$SYSROOT/usr/bin/protoc" && -f "$SYSROOT/usr/include/google/protobuf/message.h" && -f "$SYSROOT/usr/lib/x86_64-linux-gnu/libprotobuf.a" ]]; then
   echo "[skip] protobuf sysroot already present at $SYSROOT"
@@ -17,6 +18,7 @@ if [[ -x "$SYSROOT/usr/bin/protoc" && -f "$SYSROOT/usr/include/google/protobuf/m
 fi
 
 mkdir -p "$CACHE" "$SYSROOT"
+REPO_ROOT="$(cd "$CPP_DIR/.." && pwd)"
 debs=(
   "libprotobuf23_${VER}_amd64.deb"
   "libprotoc23_${VER}_amd64.deb"
@@ -26,6 +28,10 @@ debs=(
 )
 
 for deb in "${debs[@]}"; do
+  if [[ ! -f "$CACHE/$deb" && -f "$REPO_ROOT/$deb" ]]; then
+    echo "[copy] $deb from repo root"
+    cp "$REPO_ROOT/$deb" "$CACHE/$deb"
+  fi
   if [[ ! -f "$CACHE/$deb" ]]; then
     echo "[get] $deb"
     curl -fsSL -o "$CACHE/$deb" "$MIRROR/$deb"


### PR DESCRIPTION
## Summary
- Wrapper/env (B5 first half): `cpp/scripts/setup-protobuf-sysroot.sh` no longer dies on a `us.archive` 404.
- Uses `archive.ubuntu.com` and will copy `protobuf-compiler_*.deb` from the repo root if the mirror is missing it.
- After the script, CMake reports `serializer: protobuf (libprotobuf) REAL via sysroot`. The sysroot stays gitignored.

## Validation
- Script extracts headers + `libprotobuf.a` + `protoc 3.12.4`.
- `serializer_benchmark_cpp` rebuilt; official codec name is `protobuf`.

## Notes
- Experiment 7 re-run (add `protobuf` to the C++ list) is the next PR.