### PR TITLE
docs(experiments): record why C1–C3 stay for a later task

### DIFF
--- a/experiments/PLAN.md
+++ b/experiments/PLAN.md
@@ -1318,9 +1318,9 @@ We go **row by row**. A wrapper (harness) change is its **own PR**, then we re-r
 
 | Step | What | Note |
 |------|------|------|
-| C1 | Python BSON client + list in Experiment 6 | new serializer |
-| C2 | C# BSON client + list in Experiment 6 | new serializer |
-| C3 | Experiment 13 `schedule: sequential` vs shuffle | runner flag |
+| C1 | Python BSON client + list in Experiment 6 | **skipped** — new serializer (register, tests, fidelity). Leave for a later add-serializers task. |
+| C2 | C# BSON client + list in Experiment 6 | **skipped** — same: no BSON writer is registered; that is a new client, not an experiment yaml change. |
+| C3 | Experiment 13 `schedule: sequential` vs shuffle | **skipped** — `experiment.yaml` has no schedule key; adding `sequential` is a runner flag plus a full nine-language re-run. Too large for this pass. |
 
 ### Leave for a later, larger task
 


### PR DESCRIPTION
## Summary
- The Not covered fix plan said to skip a C-step if it is too large.
- C1/C2 are new BSON serializers. C3 needs a runner schedule flag plus a nine-language Experiment 13 re-run.
- PLAN.md now says so. No harness change.

## Validation
- Docs only.