### PR TITLE
docs(experiments): why experiments sit beside the Dashboard

### DIFF
--- a/dashboard/experiments.css
+++ b/dashboard/experiments.css
@@ -45,6 +45,10 @@ body.dash-view-experiments #filter-policy-meta {
   margin: 0.25rem 0;
 }
 
+.exp-why p {
+  margin: 0.5rem 0 0;
+}
+
 .exp-story p {
   margin: 0.35rem 0;
 }

--- a/dashboard/experiments.js
+++ b/dashboard/experiments.js
@@ -242,6 +242,51 @@ function selectHtml(id, label, values, current, labelFn) {
     </div>`;
 }
 
+function renderWhyExperiments() {
+  return `
+    <details class="exp-howto exp-why glass-panel" open>
+      <summary>Why experiments, if the Dashboard already has every number?</summary>
+      <p>
+        The main Dashboard is the <strong>full warehouse</strong>: every library, every record shape.
+        That is the right place to browse. It is the wrong place to pick a library for a real service
+        by sorting on speed.
+      </p>
+      <p>
+        The fastest row in the big table may be a library you <strong>cannot use</strong>.
+        It might write bytes that only one language can read.
+        It might drop field names so partners cannot parse the text.
+        It might be built for a file you write once, not for a web request you write on every click.
+        The Dashboard will still put it first, because it is fast.
+      </p>
+      <p>
+        An experiment starts with a <strong>decision</strong>, not a sort.
+        Example: “We must keep JSON on the public website. Which JSON library is fast enough?”
+        We keep only the libraries that could be the answer. We time one shared record.
+        We write down what we would give up.
+      </p>
+      <p>
+        Think of a grocery store and a recipe. The store has every product — that is the main Dashboard.
+        The recipe lists only what you need for dinner, and why — that is an experiment.
+        You need both. The store does not tell you what to cook.
+      </p>
+      <p>
+        Concrete traps the big table does not prevent:
+      </p>
+      <ul>
+        <li><strong>Different jobs in one list.</strong> JSON, compact bytes, and a Python-only format can share a table. “What is fastest?” is not one question.</li>
+        <li><strong>A tiny gap looks like a winner.</strong> 1.7 µs vs 1.8 µs is not a reason to rewrite a service.</li>
+        <li><strong>Your constraint is invisible.</strong> If browsers must keep JSON, the big table still shows every format.</li>
+        <li><strong>One record is not one hundred.</strong> The winner at 1 can lose at 100.</li>
+        <li><strong>Numbers without a story.</strong> “Binary is faster” is how teams break a public website.</li>
+      </ul>
+      <p>
+        We do not run a second benchmark. We cut the same numbers down to a fair contest
+        and put the story next to them.
+        <a href="../experiments/">Longer notes</a>
+      </p>
+    </details>`;
+}
+
 function renderHowToRead() {
   return `
     <details class="exp-howto glass-panel">
@@ -415,10 +460,11 @@ function renderList(root) {
     <div class="exp-header">
       <h2 class="chart-title">Experiments</h2>
       <p class="section-help">
-        Each item is <strong>one question</strong>. Compare libraries inside one language.
-        <a href="../experiments/">Read the notes</a> if you want the why and the examples.
+        Each item is <strong>one question</strong> — a fair slice of the big Dashboard, not a second set of clocks.
+        Compare libraries inside one language.
       </p>
     </div>
+    ${renderWhyExperiments()}
     ${renderHowToRead()}
     <div class="exp-list" role="list">
       ${items
@@ -504,6 +550,7 @@ async function renderDetail(root, id) {
       <p class="exp-kicker">Experiment ${meta.number != null ? meta.number : ''}</p>
       <h2 class="chart-title">${escapeHtml(meta.title || data.question || meta.question)}</h2>
       <p class="section-help">${escapeHtml(meta.question || data.question || '')}</p>
+      <p class="section-help">This is a fair slice of the main Dashboard for one decision, not extra clocks. <a href="#experiments">Why we keep experiments separate</a></p>
     </div>
     ${renderStory(meta)}
     ${renderHowToRead()}

--- a/docs/experiments/index.md
+++ b/docs/experiments/index.md
@@ -12,6 +12,58 @@ Compare libraries **inside one language**. A Python time and a Java time are not
 
 ---
 
+## Why experiments, if the Dashboard already has every number?
+
+The main Dashboard is the **full set of measurements**. Every language, every library we registered, every record shape, both “in memory” and “as if to a file.” It is the warehouse. You can browse, sort, and compare.
+
+That warehouse is easy to misuse.
+
+If you open Python and sort by speed, the top row might be a library you **cannot use** for your job. It might write bytes that only Python can read. It might skip field names so partners cannot parse the text. It might be built for a game file you write once, not for a web request you write on every click. The Dashboard will still put that row at the top, because it is fast.
+
+An experiment is the opposite of “show me everything.” We start with a **decision**:
+
+> We must keep JSON on the public website. Which JSON library is fast enough?
+
+Then we keep **only** the libraries that could be the answer. We time **one** record (the same one for everyone in that test). We write down what we would give up if we picked the faster row.
+
+Think of a grocery store and a recipe. The store has every product. That is the main Dashboard. The recipe lists only what you need for tonight’s dinner, and why. That is an experiment. You need both. The store does not tell you what to cook. The recipe does not replace the store.
+
+### What goes wrong if we only use the big table
+
+**1. Different jobs sit in the same list.**  
+JSON (text people can read), MessagePack (compact bytes, no shared field file), Protocol Buffers (shared field numbers), and Python pickle (Python only) can all appear in one language table. “What is fastest?” is not one question. “What is fastest **for a public API that must stay JSON**?” is one question. Experiment 1 is that question. Experiment 2 is a different question: “may we leave JSON on a private path?”
+
+**2. A small gap looks like a winner.**  
+On a tiny record, 1.7 µs versus 1.8 µs is not a reason to rewrite a service. The experiment page says when the gap is “about the same” or “a bit slower,” so we do not crown a winner we cannot defend.
+
+**3. The Dashboard does not know your constraint.**  
+You may be stuck with JSON because browsers and partners already speak it. You may be stuck with Protocol Buffers because two languages share a field file. The big table cannot hide the rows that break that rule. An experiment can.
+
+**4. One record is not one hundred records.**  
+A web call is usually one body. A log shipper often writes many records at once. The library that wins at 1 can lose at 100 (Experiment 10). The main Dashboard shows both, side by side. Without the experiment, it is easy to quote the wrong column.
+
+**5. Size after gzip is not the same as raw size.**  
+Teams say “just turn compression on.” Experiment 9 asks whether that erases the reason to leave JSON. The main Dashboard can show extra size columns. It does not ask the question or name the three records we used (words, numbers, a tiny ping).
+
+**6. Numbers without a story invite the wrong change.**  
+A common mistake: someone sees “binary is faster,” changes the public website, and then spends months helping partners who can no longer use ordinary tools. Experiments exist so we **ask a narrow question first**, measure only that, and then decide.
+
+### What an experiment adds that the big table does not
+
+| The main Dashboard | An experiment |
+|--------------------|---------------|
+| Every library we measured | Only libraries that could answer **this** question |
+| Every record shape, mixed | One record (or a planned set), named and shown |
+| Speed, size, charts | The same numbers, plus **why**, an **example**, and the **trade-off** |
+| You pick the filter | We already picked the fair comparison |
+| Easy to browse | Built to support **one decision** |
+
+The experiment still uses the same clock and the same record builder. We do not invent a second benchmark. We **cut the big table down to a fair contest** and write the story next to it.
+
+If you only want to look around, use the main Dashboard. If you have to choose a library for a real service, start with the experiment that matches your constraint.
+
+---
+
 ## How to read a table
 
 Times are the **middle** value (the median), in **microseconds**. Smaller is better for time and for size.

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ ideally one format family), not to crown a single global winner.
 | You want… | Go here |
 |-----------|---------|
 | Interactive charts, Pareto trade-offs, compare lab | **[Dashboard](dashboard/)** |
-| One-question tests in everyday words | **[Experiments](experiments/)** |
+| One-question tests (why we do not only use the big table) | **[Experiments](experiments/)** |
 | Course on formats and trade-offs (101–401) | **[Learn](theory/101/)** |
 | Per-language library lists and result tables | **[Languages](c/)** (sidebar: C, C#, C++, …) |
 | Methodology, metrics, how to add a codec | **[Method](analysis/)** |


### PR DESCRIPTION
## Summary
- Explain, in everyday words, why we keep **experiments** when the main Dashboard already has every number.
- The big table is the warehouse. An experiment is a recipe: one question, only the libraries that could be the answer, one record, and the trade-off.
- Same text on the Experiments docs page and on the Dashboard list (open by default).

## Validation
- Browser: why panel visible on \`#experiments\`; detail page links back.