### PR TITLE
feat(dashboard): graph Experiment 1 results with std whiskers

### DIFF
--- a/dashboard/exp-charts.js
+++ b/dashboard/exp-charts.js
@@ -1,0 +1,673 @@
+/**
+ * Experiment figure catalog — PR 1 implements L1, W1, S0/S1 for opted-in ids.
+ * Do not import charts.js or main.js.
+ */
+import { formatSig, formatIntGrouped, formatRelativeCell, LATENCY_US } from './format.js';
+import {
+  compareLabel,
+  competingRows,
+  displayTier,
+  isShapeSkip,
+  skipReason,
+  sortRows,
+  totalStdUs,
+} from './exp-export.js';
+
+export const GRAPH_PROTOTYPE_IDS = new Set(['01-json-library-bakeoff']);
+
+const fontStyle = {
+  family: "'Roboto', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+  size: 11,
+};
+const gridColor = 'rgba(0, 0, 0, 0.06)';
+const tickColor = '#5f6368';
+/** Write vs read series — not green/red (those mean faster/slower). */
+const SERIES_WRITE = '#7eb6ff';
+const SERIES_READ = '#4a148c';
+const tooltipChrome = {
+  backgroundColor: 'rgba(32, 33, 36, 0.95)',
+  titleColor: '#ffffff',
+  bodyColor: '#ffffff',
+  borderColor: '#dadce0',
+  borderWidth: 1,
+  padding: 10,
+  bodyFont: fontStyle,
+  titleFont: { ...fontStyle, weight: 'bold' },
+};
+
+const L1_CAPTION =
+  'The bar is the <strong>middle</strong> time (median). The whisker is <strong>approximate spread</strong>, reconstructed from the published confidence interval of the <strong>mean</strong> (the same reconstruction the table’s Spread column uses). It is not yet the sample standard deviation of the trials. A short whisker means a stable number. Two bars whose whiskers heavily overlap are usually “about the same.”';
+
+/** @type {import('chart.js').Chart[]} */
+const chartInstances = [];
+let latencyChart = null;
+let splitChart = null;
+let sizeChart = null;
+let hatchPattern = null;
+
+export function usesExperimentGraphs(id) {
+  return GRAPH_PROTOTYPE_IDS.has(id);
+}
+
+export function destroyExperimentFigures() {
+  for (const chart of chartInstances) {
+    try {
+      chart.destroy();
+    } catch (_) {
+      /* already gone */
+    }
+  }
+  chartInstances.length = 0;
+  latencyChart = null;
+  splitChart = null;
+  sizeChart = null;
+}
+
+export function figuresToPng(which) {
+  const chart = which === 'latency' ? latencyChart : which === 'split' ? splitChart : sizeChart;
+  if (!chart) return null;
+  return chart.toBase64Image('image/png', 1);
+}
+
+function comparedSizes(rows) {
+  return competingRows(rows).filter((r) => Number.isFinite(Number(r.size_bytes)));
+}
+
+export function sizeTreatment(rows) {
+  const c = comparedSizes(rows);
+  const sizes = [...new Set(c.map((r) => Number(r.size_bytes)))];
+  const skips = rows.filter((r) => isShapeSkip(r));
+  const gz = c.map((r) => r.size_gzip_bytes);
+  const gzipNote =
+    gz.length && gz.every((g) => g != null && Number(g) === Number(gz[0]))
+      ? ` (${formatIntGrouped(gz[0])} after gzip)`
+      : '';
+  const skipNote =
+    skips.length === 1 && skips[0].writes_named_fields === false
+      ? ` ${skips[0].library} also ran (${formatIntGrouped(skips[0].size_bytes)} B). By design it writes a JSON list, not {"id": …}, so we do not rank it here.`
+      : skips.length === 1
+        ? ` ${skips[0].library} ran; we do not rank it in this contest.`
+        : '';
+  if (sizes.length <= 1 && c.length) {
+    return {
+      kind: 'S0',
+      text: `Named JSON ${formatIntGrouped(sizes[0])} B${gzipNote}.${skipNote}`,
+    };
+  }
+  if (sizes.length > 1) return { kind: 'S1' };
+  return { kind: 'none' };
+}
+
+export function glyphFor(row, rows) {
+  const tier = displayTier(row, rows);
+  if (tier === 'skip') return '⬚';
+  if (tier === 'fastest') return '●';
+  if (tier === 'similar') return '○';
+  if (tier === 'close') return '▬';
+  if (tier === 'slower') return '×';
+  return '·';
+}
+
+function clipTickPiece(s) {
+  return s.length > 18 ? `${s.slice(0, 17)}…` : s;
+}
+
+function splitLibraryName(name) {
+  const bySlash = name.split('/');
+  if (bySlash.length > 1) {
+    return [`${bySlash[0]}/`, bySlash.slice(1).join('/')];
+  }
+  const bySpace = name.split(/\s+/).filter(Boolean);
+  if (bySpace.length > 1) {
+    return [bySpace[0], bySpace.slice(1).join(' ')];
+  }
+  return [name];
+}
+
+export function wrapYTick(row, rows) {
+  const prefix = `${glyphFor(row, rows)} `;
+  const name = String(row.library || '');
+  if ((prefix + name).length <= 22) return [prefix + name];
+  const parts = splitLibraryName(name).map(clipTickPiece).slice(0, 2);
+  if (!parts.length) return [prefix.trim()];
+  parts[0] = prefix + parts[0];
+  return parts;
+}
+
+function plotHeight(n) {
+  return Math.max(280, n * 36 + 48);
+}
+
+function escapeHtml(s) {
+  return String(s ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function bestCompared(rows, key) {
+  const nums = competingRows(rows)
+    .map((r) => Number(r[key]))
+    .filter(Number.isFinite);
+  return nums.length ? Math.min(...nums) : null;
+}
+
+function createHatch(color = '#b06000') {
+  const c = document.createElement('canvas');
+  c.width = 8;
+  c.height = 8;
+  const g = c.getContext('2d');
+  g.fillStyle = '#fef7e0';
+  g.fillRect(0, 0, 8, 8);
+  g.strokeStyle = color;
+  g.lineWidth = 1;
+  g.beginPath();
+  g.moveTo(0, 8);
+  g.lineTo(8, 0);
+  g.stroke();
+  return g.createPattern(c, 'repeat');
+}
+
+function getHatch() {
+  if (!hatchPattern && typeof document !== 'undefined') {
+    hatchPattern = createHatch('#b06000');
+  }
+  return hatchPattern;
+}
+
+function l1Fill(row, rows) {
+  const tier = displayTier(row, rows);
+  if (tier === 'skip') return 'transparent';
+  if (tier === 'fastest') return 'rgba(30, 142, 62, 0.90)';
+  if (tier === 'similar') return 'rgba(30, 142, 62, 0.55)';
+  if (tier === 'close') return getHatch() || 'rgba(249, 171, 0, 0.85)';
+  if (tier === 'slower') return 'rgba(217, 48, 37, 0.78)';
+  return 'rgba(95, 99, 104, 0.35)';
+}
+
+function l1Stroke(row, rows) {
+  const tier = displayTier(row, rows);
+  if (tier === 'skip') return 'rgba(128, 134, 139, 0.55)';
+  if (tier === 'fastest' || tier === 'similar') return '#1e8e3e';
+  if (tier === 'close') return '#b06000';
+  if (tier === 'slower') return '#d93025';
+  return '#5f6368';
+}
+
+function l1BorderDash(row) {
+  if (isShapeSkip(row)) return [3, 2];
+  if (totalStdUs(row) == null) return [4, 3];
+  return [];
+}
+
+function parsedX(el) {
+  if (Number.isFinite(el?.parsed?.x)) return el.parsed.x;
+  if (Number.isFinite(el?.$context?.parsed?.x)) return el.$context.parsed.x;
+  return null;
+}
+
+function makeErrorBarsPlugin(stds, datasetIndex = 0) {
+  return {
+    id: 'expErrorBars',
+    afterDatasetsDraw(chart) {
+      const { ctx } = chart;
+      const meta = chart.getDatasetMeta(datasetIndex);
+      if (!meta?.data) return;
+      const xScale = chart.scales.x;
+      if (!xScale) return;
+      ctx.save();
+      ctx.strokeStyle = 'rgba(32, 33, 36, 0.72)';
+      ctx.lineWidth = 1.5;
+      meta.data.forEach((el, i) => {
+        const std = stds[i];
+        if (std == null || !Number.isFinite(std)) return;
+        const median = parsedX(el);
+        if (!Number.isFinite(median)) return;
+        let x0 = xScale.getPixelForValue(Math.max(0, median - std));
+        let x1 = xScale.getPixelForValue(median + std);
+        if (Math.abs(x1 - x0) < 4) {
+          const mid = xScale.getPixelForValue(median);
+          x0 = mid - 2;
+          x1 = mid + 2;
+        }
+        const cap = 3.5;
+        const y = el.y;
+        ctx.beginPath();
+        ctx.moveTo(x0, y);
+        ctx.lineTo(x1, y);
+        ctx.moveTo(x0, y - cap);
+        ctx.lineTo(x0, y + cap);
+        ctx.moveTo(x1, y - cap);
+        ctx.lineTo(x1, y + cap);
+        ctx.stroke();
+      });
+      ctx.restore();
+    },
+  };
+}
+
+function makeValueLabelsPlugin({ rows = [], stds = [], format = formatSig, datasetIndex = 0 } = {}) {
+  return {
+    id: 'expBarValueLabels',
+    afterDatasetsDraw(chart) {
+      const { ctx } = chart;
+      const meta = chart.getDatasetMeta(datasetIndex);
+      if (!meta?.data) return;
+      const xScale = chart.scales.x;
+      const area = chart.chartArea;
+      if (!xScale || !area) return;
+      ctx.save();
+      ctx.font = "11px 'Roboto', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+      ctx.textBaseline = 'middle';
+      ctx.fillStyle = '#202124';
+      meta.data.forEach((el, i) => {
+        const row = rows[i];
+        const median = parsedX(el);
+        if (!Number.isFinite(median)) return;
+        if (row && isShapeSkip(row)) {
+          const text = skipReason(row)?.short || 'left out of ranking';
+          let x = Math.max(el.x, xScale.getPixelForValue(median)) + 16;
+          ctx.fillStyle = '#80868b';
+          if (x + ctx.measureText(text).width > area.right) {
+            x = area.right - ctx.measureText(text).width;
+          }
+          ctx.fillText(text, x, el.y);
+          ctx.fillStyle = '#202124';
+          return;
+        }
+        let right = el.x;
+        const std = stds[i];
+        if (std != null && Number.isFinite(std)) {
+          right = Math.max(right, xScale.getPixelForValue(median + std));
+        }
+        const text = format(median);
+        let x = right + 8;
+        if (x + ctx.measureText(text).width > area.right) {
+          x = area.right - ctx.measureText(text).width;
+        }
+        ctx.fillText(text, x, el.y);
+      });
+      ctx.restore();
+    },
+  };
+}
+
+function figureHtml({ title, helpHtml, pngId, height, canvasLabel }) {
+  return `
+    <section class="exp-figure glass-panel">
+      <div class="chart-header">
+        <h3 class="chart-title">${escapeHtml(title)}</h3>
+        ${pngId ? `<button type="button" class="tab-btn chart-tool-btn" id="${pngId}" title="Download PNG">PNG</button>` : ''}
+      </div>
+      <p class="exp-figure-help">${helpHtml}</p>
+      <div class="exp-figure-plot" style="height:${height}px">
+        <canvas role="img" aria-label="${escapeHtml(canvasLabel)}"></canvas>
+      </div>
+    </section>`;
+}
+
+function legendHtml(rows) {
+  const skips = (rows || []).filter((r) => isShapeSkip(r));
+  const skipChip = skips.length ? '⬚ Writes a JSON list' : '';
+  return `
+    <div class="exp-legend">
+      <span class="exp-chip exp-tier-similar">● Fastest</span>
+      <span class="exp-chip exp-tier-similar">○ About the same</span>
+      <span class="exp-chip exp-tier-close">▬ A bit slower</span>
+      <span class="exp-chip exp-tier-slower">× Clearly slower</span>
+      ${skipChip ? `<span class="exp-chip" title="Timed, but not the same job as the ranked bars">${escapeHtml(skipChip)}</span>` : ''}
+    </div>`;
+}
+
+function commonScaleX(title, tickFmt) {
+  return {
+    min: 0,
+    stacked: false,
+    title: {
+      display: true,
+      text: title,
+      color: tickColor,
+      font: { ...fontStyle, weight: 'bold' },
+    },
+    grid: { color: gridColor },
+    ticks: {
+      color: tickColor,
+      font: fontStyle,
+      callback: (value) => tickFmt(value),
+    },
+  };
+}
+
+function commonScaleY(rows) {
+  return {
+    stacked: false,
+    grid: { display: false },
+    afterFit(scale) {
+      scale.width = Math.max(scale.width, 148);
+    },
+    ticks: {
+      color: tickColor,
+      font: fontStyle,
+      autoSkip: false,
+      callback(_value, index) {
+        const row = rows[index];
+        return row ? wrapYTick(row, rows) : '';
+      },
+    },
+  };
+}
+
+function ratioText(valueNs, bestNs, key) {
+  const us = formatSig(Number(valueNs) / 1000);
+  if (valueNs == null || bestNs == null) return `${us} µs`;
+  const rel = formatRelativeCell(valueNs, bestNs, false, { latency: LATENCY_US }, key);
+  if (rel.ratio == null) return `${us} µs`;
+  return `${us} µs  (${formatSig(rel.ratio, 2)}×)`;
+}
+
+function l1TooltipLines(row, bestTotal, rows) {
+  const lines = [];
+  const skip = skipReason(row);
+  if (skip) lines.push(skip.detail);
+  lines.push(`Write + read   ${ratioText(row.total_median_ns, bestTotal, 'total_median_ns')}`);
+  const std = totalStdUs(row);
+  lines.push(std == null ? 'Spread unknown (not enough trials to reconstruct).' : `Spread (std)   ${formatSig(std)} µs`);
+  const w = Number(row.write_median_ns);
+  const r = Number(row.read_median_ns);
+  const wr = [];
+  if (Number.isFinite(w)) wr.push(`Write  ${formatSig(w / 1000)} µs`);
+  if (Number.isFinite(r)) wr.push(`Read  ${formatSig(r / 1000)} µs`);
+  if (wr.length) lines.push(wr.join(' · '));
+  if (row.size_bytes != null) {
+    let size = `Size   ${formatIntGrouped(row.size_bytes)} B`;
+    if (Number.isFinite(Number(row.size_gzip_bytes))) {
+      size += `  (${formatIntGrouped(row.size_gzip_bytes)} after gzip)`;
+    }
+    lines.push(size);
+  }
+  if (row.runs != null) {
+    lines.push(`Trials ${formatIntGrouped(row.runs)}${row.runs_raw ? ` of ${formatIntGrouped(row.runs_raw)}` : ''}`);
+  }
+  lines.push(`Vs fastest  ${compareLabel(row, rows)}`);
+  return lines;
+}
+
+function makeBarChart(canvas, config) {
+  const ctx = canvas.getContext ? canvas.getContext('2d') : canvas;
+  const chart = new globalThis.Chart(ctx, config);
+  chartInstances.push(chart);
+  return chart;
+}
+
+function suggestedMax(values, stds = []) {
+  let m = 0;
+  values.forEach((v, i) => {
+    if (!Number.isFinite(v)) return;
+    const s = Number.isFinite(stds[i]) ? stds[i] : 0;
+    m = Math.max(m, v + s);
+  });
+  return m > 0 ? m * 1.12 : undefined;
+}
+
+function mountLatency(canvas, rows, lang) {
+  const stds = rows.map(totalStdUs);
+  const bestTotal = bestCompared(rows, 'total_median_ns');
+  const values = rows.map((r) => Number(r.total_median_ns) / 1000);
+  return makeBarChart(canvas, {
+    type: 'bar',
+    plugins: [
+      makeErrorBarsPlugin(stds, 0),
+      makeValueLabelsPlugin({ rows, stds, format: formatSig, datasetIndex: 0 }),
+    ],
+    data: {
+      labels: rows.map((r) => r.library),
+      datasets: [
+        {
+          data: values,
+          backgroundColor: rows.map((r) => l1Fill(r, rows)),
+          borderColor: rows.map((r) => l1Stroke(r, rows)),
+          borderWidth: 1.5,
+          borderDash: (ctx) => l1BorderDash(rows[ctx.dataIndex] || {}),
+          borderRadius: 3,
+          barPercentage: 0.72,
+          categoryPercentage: 0.8,
+        },
+      ],
+    },
+    options: {
+      indexAxis: 'y',
+      responsive: true,
+      maintainAspectRatio: false,
+      animation: false,
+      layout: { padding: { right: 108, left: 4, top: 4, bottom: 4 } },
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          ...tooltipChrome,
+          callbacks: {
+            title: (items) => {
+              const row = rows[items[0]?.dataIndex];
+              if (!row) return '';
+              return row.version ? `${row.library}  ${row.version}` : row.library;
+            },
+            label: (item) => l1TooltipLines(rows[item.dataIndex], bestTotal, rows),
+          },
+        },
+      },
+      scales: {
+        x: { ...commonScaleX('µs', formatSig), suggestedMax: suggestedMax(values, stds) },
+        y: commonScaleY(rows),
+      },
+    },
+  });
+}
+
+function mountSplit(canvas, rows) {
+  return makeBarChart(canvas, {
+    type: 'bar',
+    data: {
+      labels: rows.map((r) => r.library),
+      datasets: [
+        {
+          label: 'Write',
+          data: rows.map((r) => Number(r.write_median_ns) / 1000),
+          backgroundColor: SERIES_WRITE,
+          borderColor: '#1565c0',
+          borderWidth: 1,
+          borderRadius: 3,
+          barPercentage: 0.9,
+          categoryPercentage: 0.65,
+        },
+        {
+          label: 'Read',
+          data: rows.map((r) => Number(r.read_median_ns) / 1000),
+          backgroundColor: SERIES_READ,
+          borderRadius: 3,
+          barPercentage: 0.9,
+          categoryPercentage: 0.65,
+        },
+      ],
+    },
+    options: {
+      indexAxis: 'y',
+      responsive: true,
+      maintainAspectRatio: false,
+      animation: false,
+      layout: { padding: { right: 16, left: 4, top: 4, bottom: 4 } },
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          ...tooltipChrome,
+          callbacks: {
+            title: (items) => {
+              const row = rows[items[0]?.dataIndex];
+              return row?.library || '';
+            },
+            label: (item) => {
+              const name = item.dataset.label;
+              const v = item.parsed.x;
+              return `${name}  ${Number.isFinite(v) ? formatSig(v) : '—'} µs`;
+            },
+          },
+        },
+      },
+      scales: {
+        x: { ...commonScaleX('µs', formatSig), stacked: false },
+        y: { ...commonScaleY(rows), stacked: false },
+      },
+    },
+  });
+}
+
+function sortRowsBySize(rows) {
+  return [...rows].sort((a, b) => {
+    const as = isShapeSkip(a) ? 1 : 0;
+    const bs = isShapeSkip(b) ? 1 : 0;
+    if (as !== bs) return as - bs;
+    return (Number(a.size_bytes) || 1e18) - (Number(b.size_bytes) || 1e18);
+  });
+}
+
+function mountSize(canvas, rows) {
+  const sorted = sortRowsBySize(rows);
+  const bestSize = bestCompared(sorted, 'size_bytes');
+  return makeBarChart(canvas, {
+    type: 'bar',
+    plugins: [makeValueLabelsPlugin({ rows: sorted, stds: [], format: formatIntGrouped, datasetIndex: 0 })],
+    data: {
+      labels: sorted.map((r) => r.library),
+      datasets: [
+        {
+          data: sorted.map((r) => Number(r.size_bytes)),
+          backgroundColor: sorted.map((r) => l1Fill(r, sorted)),
+          borderColor: sorted.map((r) => l1Stroke(r, sorted)),
+          borderWidth: 1.5,
+          borderDash: (ctx) => (isShapeSkip(sorted[ctx.dataIndex] || {}) ? [3, 2] : []),
+          borderRadius: 3,
+          barPercentage: 0.72,
+          categoryPercentage: 0.8,
+        },
+      ],
+    },
+    options: {
+      indexAxis: 'y',
+      responsive: true,
+      maintainAspectRatio: false,
+      animation: false,
+      layout: { padding: { right: 72, left: 4, top: 4, bottom: 4 } },
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          ...tooltipChrome,
+          callbacks: {
+            title: (items) => sorted[items[0]?.dataIndex]?.library || '',
+            label: (item) => {
+              const row = sorted[item.dataIndex];
+              const rel = formatRelativeCell(row.size_bytes, bestSize, false, {}, 'size_bytes');
+              return `Size   ${rel.text}`;
+            },
+          },
+        },
+      },
+      scales: {
+        x: commonScaleX('bytes', formatIntGrouped),
+        y: commonScaleY(sorted),
+      },
+    },
+  });
+}
+
+function hasFiniteSeries(rows, key) {
+  return rows.some((r) => Number.isFinite(Number(r[key])));
+}
+
+/**
+ * @param {HTMLElement} mount
+ * @param {{ id: string, meta: object, lang: string, io: string, rows: object[] }} ctx
+ */
+export function mountExperimentFigures(mount, ctx) {
+  if (!mount) return;
+  const rows = sortRows(ctx.rows || []);
+  latencyChart = null;
+  splitChart = null;
+  sizeChart = null;
+
+  if (!rows.length) {
+    mount.innerHTML = `
+      <div class="exp-figure glass-panel" style="position:relative;min-height:8rem">
+        <p class="chart-empty">No rows for this filter.</p>
+      </div>`;
+    return;
+  }
+
+  if (typeof globalThis.Chart === 'undefined') {
+    mount.innerHTML = `
+      <div class="exp-figure glass-panel" style="position:relative;min-height:8rem">
+        <p class="chart-empty">Graphs need Chart.js (CDN). The table below has the same numbers.</p>
+      </div>`;
+    return;
+  }
+
+  const allSkipped = competingRows(rows).length === 0;
+  const lang = ctx.lang || 'this language';
+  const h = plotHeight(rows.length);
+  const parts = [];
+
+  parts.push(
+    figureHtml({
+      title: 'Write + read (µs)',
+      helpHtml: `${L1_CAPTION}${allSkipped ? ' Nothing in this filter is in the comparison.' : ''}`,
+      pngId: 'exp-png-latency',
+      height: h,
+      canvasLabel: `Horizontal bar chart of write-plus-read time in microseconds for ${lang}, whiskers show spread`,
+    })
+  );
+  parts.push(legendHtml(rows));
+
+  const showW1 = hasFiniteSeries(rows, 'write_median_ns') && hasFiniteSeries(rows, 'read_median_ns');
+  if (showW1) {
+    parts.push(
+      figureHtml({
+        title: 'Write and read, separately',
+        helpHtml: `<span class="exp-chip exp-series-write" style="--exp-series:${SERIES_WRITE};--exp-series-ink:#1565c0"><span class="exp-swatch" aria-hidden="true"></span>Write</span> <span class="exp-chip exp-series-read" style="--exp-series:${SERIES_READ};--exp-series-ink:#4a148c"><span class="exp-swatch" aria-hidden="true"></span>Read</span>`,
+        pngId: 'exp-png-split',
+        height: h,
+        canvasLabel: `Grouped bar chart of write time and read time in microseconds for ${lang}`,
+      })
+    );
+  }
+
+  const treatment = sizeTreatment(rows);
+  if (treatment.kind === 'S0') {
+    parts.push(`<p class="exp-size-callout">${escapeHtml(treatment.text)}</p>`);
+  } else if (treatment.kind === 'S1') {
+    parts.push(
+      figureHtml({
+        title: 'Size (bytes)',
+        helpHtml: 'Smaller is more compact. Compared libraries only share a color key with the time charts.',
+        pngId: 'exp-png-size',
+        height: h,
+        canvasLabel: `Horizontal bar chart of payload size in bytes for ${lang}`,
+      })
+    );
+  }
+
+  mount.innerHTML = parts.join('');
+  const canvases = [...mount.querySelectorAll('canvas')];
+  let i = 0;
+  try {
+    latencyChart = mountLatency(canvases[i++], rows, lang);
+    if (showW1) splitChart = mountSplit(canvases[i++], rows);
+    if (treatment.kind === 'S1') sizeChart = mountSize(canvases[i++], rows);
+  } catch (err) {
+    const plot = mount.querySelectorAll('.exp-figure-plot')[showW1 && !splitChart ? 1 : 0];
+    if (plot) {
+      const p = document.createElement('p');
+      p.className = 'exp-figure-help';
+      p.textContent = `Chart failed: ${err.message}`;
+      plot.appendChild(p);
+    }
+    console.warn('experiment figures', err);
+  }
+}

--- a/dashboard/exp-export.js
+++ b/dashboard/exp-export.js
@@ -1,0 +1,201 @@
+/**
+ * Experiment table export — CSV download, TSV clipboard, shared row helpers.
+ * Do not import main.js.
+ */
+import { formatSig } from './format.js';
+
+const COMPARE_LABEL = {
+  fastest: 'Fastest',
+  reference: 'Fastest',
+  similar: 'About the same',
+  close: 'A bit slower',
+  slower: 'Clearly slower',
+};
+
+const CSV_COLUMNS = [
+  'library',
+  'version',
+  'io',
+  'write_us',
+  'read_us',
+  'total_us',
+  'spread_std_us',
+  'size_bytes',
+  'size_gzip_bytes',
+  'trials',
+  'trials_raw',
+  'vs_fastest',
+  'in_comparison',
+];
+
+/** True skip: different JSON shape. Stream rows are not skips — they are a different filter. */
+export function isShapeSkip(row) {
+  return row?.writes_named_fields === false;
+}
+
+/** Rows that compete in the current view (named JSON; stream if that is all we have). */
+export function competingRows(rows) {
+  const named = (rows || []).filter((r) => !isShapeSkip(r));
+  const official = named.filter((r) => r.in_comparison !== false);
+  return official.length ? official : named;
+}
+
+const TIER_RANK = { fastest: 0, similar: 1, close: 2, slower: 3 };
+
+function milderTier(a, b) {
+  if (!a) return b || '';
+  if (!b) return a;
+  return TIER_RANK[a] <= TIER_RANK[b] ? a : b;
+}
+
+function tierFromMedianRatio(row, rows) {
+  const pool = competingRows(rows);
+  const best = Math.min(...pool.map((r) => Number(r.total_median_ns)).filter(Number.isFinite));
+  const v = Number(row.total_median_ns);
+  if (!Number.isFinite(v) || !Number.isFinite(best) || best <= 0) return '';
+  if (v <= best) return 'fastest';
+  const ratio = v / best;
+  if (ratio <= 1.15) return 'similar';
+  if (ratio <= 1.5) return 'close';
+  return 'slower';
+}
+
+/**
+ * Color / chip tier for the current filter.
+ *
+ * Cliff's delta (published `tier`) asks “how often is this slower?”, not
+ * “how big is the gap?”. A 2% median gap can still be “slower” if it is
+ * consistent. Students see bar length, so we never paint “clearly slower”
+ * when the medians are about the same: take the milder of Cliffs and the
+ * median-ratio band (≤1.15× similar, ≤1.5× close).
+ */
+export function displayTier(row, rows) {
+  if (isShapeSkip(row)) return 'skip';
+  if (row.tier === 'fastest' || row.cliffs_label === 'reference') return 'fastest';
+  const fromRatio = tierFromMedianRatio(row, rows);
+  if (fromRatio === 'fastest') return 'fastest';
+  const fromCliffs =
+    row.tier === 'similar' || row.tier === 'close' || row.tier === 'slower' ? row.tier : '';
+  return milderTier(fromCliffs, fromRatio) || fromRatio;
+}
+
+/**
+ * Why a timed row is drawn but not ranked.
+ * Only the different-JSON-shape case. Stream is a filter, not a skip.
+ */
+export function skipReason(row) {
+  if (!isShapeSkip(row)) return null;
+  return {
+    short: 'writes […] on purpose',
+    label: 'By design — JSON list',
+    chip: row.library || 'library',
+    detail:
+      'By design, not a failed read. This bench uses msgspec array-like Structs: write emits a JSON list [1, "ok", …] and read loads that same list back by field order. Both steps succeed. orjson/json write {"id": 1, "status": "ok"}. This experiment ranks only that named object, so we show the time but do not pick a winner against the list.',
+  };
+}
+
+export function compareLabel(row, rows) {
+  const skip = skipReason(row);
+  if (skip) return skip.label;
+  const key = displayTier(row, rows || [row]);
+  return COMPARE_LABEL[key] || COMPARE_LABEL[row.cliffs_label] || '—';
+}
+
+/** Sample std in µs, or reconstructed from the published mean CI. */
+export function totalStdUs(row) {
+  let ns = row.total_std_ns;
+  if (ns == null) {
+    const lo = Number(row.total_ci_low_ns);
+    const hi = Number(row.total_ci_high_ns);
+    const n = Number(row.runs);
+    if (!Number.isFinite(lo) || !Number.isFinite(hi) || !n || n < 2) return null;
+    ns = ((hi - lo) / (2 * 1.96)) * Math.sqrt(n);
+  }
+  if (!Number.isFinite(Number(ns))) return null;
+  return Number(ns) / 1000;
+}
+
+export function sortRows(rows) {
+  return [...rows].sort((a, b) => {
+    const as = isShapeSkip(a) ? 1 : 0;
+    const bs = isShapeSkip(b) ? 1 : 0;
+    if (as !== bs) return as - bs;
+    return (Number(a.total_median_ns) || 1e18) - (Number(b.total_median_ns) || 1e18);
+  });
+}
+
+export function exportStem({ id, lang, io, extra } = {}) {
+  return [id, lang, io, extra].filter((t) => t != null && String(t) !== '').join('-');
+}
+
+function nsToUs(ns) {
+  const n = Number(ns);
+  return Number.isFinite(n) ? n / 1000 : '';
+}
+
+function escapeField(value, delimiter) {
+  if (value == null) return '';
+  const s = typeof value === 'boolean' ? String(value) : String(value);
+  if (s.includes('"') || s.includes(delimiter) || s.includes('\n') || s.includes('\r')) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+function rowFields(row, rows) {
+  const std = totalStdUs(row);
+  return {
+    library: row.library ?? '',
+    version: row.version ?? '',
+    io: row.io ?? '',
+    write_us: nsToUs(row.write_median_ns),
+    read_us: nsToUs(row.read_median_ns),
+    total_us: nsToUs(row.total_median_ns),
+    spread_std_us: std == null ? '' : std,
+    size_bytes: row.size_bytes == null ? '' : row.size_bytes,
+    size_gzip_bytes: row.size_gzip_bytes == null ? '' : row.size_gzip_bytes,
+    trials: row.runs == null ? '' : row.runs,
+    trials_raw: row.runs_raw == null ? '' : row.runs_raw,
+    vs_fastest: compareLabel(row, rows),
+    in_comparison: row.in_comparison === false ? false : true,
+  };
+}
+
+export function rowsToDelimited(rows, { delimiter = ',' } = {}) {
+  const sorted = sortRows(rows);
+  const lines = [CSV_COLUMNS.join(delimiter)];
+  for (const row of sorted) {
+    const fields = rowFields(row, sorted);
+    lines.push(CSV_COLUMNS.map((k) => escapeField(fields[k], delimiter)).join(delimiter));
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+export function downloadText(filename, text, mime = 'text/csv;charset=utf-8') {
+  const blob = new Blob([text], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+export function downloadDataUrl(dataUrl, filename) {
+  const a = document.createElement('a');
+  a.href = dataUrl;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+}
+
+export async function copyText(text) {
+  if (!navigator.clipboard?.writeText) {
+    throw new Error('Clipboard unavailable');
+  }
+  await navigator.clipboard.writeText(text);
+}
+

--- a/dashboard/experiments.css
+++ b/dashboard/experiments.css
@@ -233,3 +233,93 @@ tr.exp-row-skip {
     flex-basis: 100%;
   }
 }
+
+.exp-figure {
+  margin: 0 0 1rem;
+  padding: 0.85rem 1rem 1rem;
+}
+
+.exp-figure .chart-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.exp-figure-help {
+  margin: 0.15rem 0 0.55rem;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}
+
+.exp-figure-help .exp-chip {
+  vertical-align: middle;
+  margin-left: 0.2rem;
+}
+
+.exp-chip.exp-series-write,
+.exp-chip.exp-series-read {
+  color: var(--exp-series-ink, var(--exp-series));
+  background: color-mix(in srgb, var(--exp-series) 18%, #fff);
+}
+
+.exp-swatch {
+  display: inline-block;
+  width: 0.65rem;
+  height: 0.65rem;
+  margin-right: 0.3rem;
+  border-radius: 2px;
+  vertical-align: -0.1rem;
+  background: var(--exp-series);
+}
+
+.exp-figure-plot {
+  position: relative;
+  width: 100%;
+}
+
+.exp-size-callout {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin: 0 0 0.85rem;
+}
+
+.exp-download {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0 0 0.75rem;
+}
+
+.exp-numbers {
+  margin: 0 0 1.25rem;
+}
+
+.exp-numbers summary {
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.exp-shape-note {
+  margin-top: 0.55rem;
+}
+
+.exp-legend {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.45rem 0.75rem;
+  margin: 0.15rem 0 0.85rem;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+#exp-status:empty {
+  display: none;
+}
+
+#exp-status {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}

--- a/dashboard/experiments.js
+++ b/dashboard/experiments.js
@@ -7,6 +7,26 @@
  */
 import './experiments.css';
 import { formatSig, formatRelativeCell, formatIntGrouped } from './format.js';
+import {
+  compareLabel,
+  competingRows,
+  copyText,
+  displayTier,
+  downloadDataUrl,
+  downloadText,
+  exportStem,
+  isShapeSkip,
+  rowsToDelimited,
+  skipReason,
+  totalStdUs,
+} from './exp-export.js';
+import {
+  destroyExperimentFigures,
+  figuresToPng,
+  mountExperimentFigures,
+  sizeTreatment,
+  usesExperimentGraphs,
+} from './exp-charts.js';
 
 const CATALOG_URL = 'data/experiments/index.json';
 const LANG_LABELS = {
@@ -27,13 +47,6 @@ const KIND_LABELS = {
   event: 'one event',
   strings: 'list of words',
 };
-const COMPARE_LABEL = {
-  fastest: 'Fastest',
-  reference: 'Fastest',
-  similar: 'About the same',
-  close: 'A bit slower',
-  slower: 'Clearly slower',
-};
 const LATENCY_SCALE = { latency: { unit: 'µs', divisor: 1e3, header: 'µs' } };
 
 function langLabel(id) {
@@ -46,32 +59,14 @@ function kindLabel(value) {
   return KIND_LABELS[value] || String(value);
 }
 
-function compareLabel(row) {
-  if (row.in_comparison === false) return 'Not compared';
-  const key = row.tier || row.cliffs_label || '';
-  return COMPARE_LABEL[key] || COMPARE_LABEL[row.cliffs_label] || '—';
-}
-
-function compareClass(row) {
-  if (row.in_comparison === false) return 'exp-row-skip';
-  if (row.tier === 'fastest' || row.cliffs_label === 'reference') return 'exp-row-fastest';
-  if (row.tier === 'similar') return 'exp-row-similar';
-  if (row.tier === 'close') return 'exp-row-close';
-  if (row.tier === 'slower') return 'exp-row-slower';
+function compareClass(row, rows) {
+  const tier = displayTier(row, rows);
+  if (tier === 'skip') return 'exp-row-skip';
+  if (tier === 'fastest') return 'exp-row-fastest';
+  if (tier === 'similar') return 'exp-row-similar';
+  if (tier === 'close') return 'exp-row-close';
+  if (tier === 'slower') return 'exp-row-slower';
   return '';
-}
-
-function totalStdUs(row) {
-  let ns = row.total_std_ns;
-  if (ns == null) {
-    const lo = Number(row.total_ci_low_ns);
-    const hi = Number(row.total_ci_high_ns);
-    const n = Number(row.runs);
-    if (!Number.isFinite(lo) || !Number.isFinite(hi) || !n || n < 2) return null;
-    ns = ((hi - lo) / (2 * 1.96)) * Math.sqrt(n);
-  }
-  if (!Number.isFinite(Number(ns))) return null;
-  return Number(ns) / 1000;
 }
 
 function ratioCell(valueNs, bestNs, key) {
@@ -172,10 +167,15 @@ function matchingTopGroup(langBlock, filters) {
   const hit = groups.find((g) => {
     if (filters.kind && g.kind != null && String(g.kind) !== filters.kind) return false;
     if (filters.n && g.n != null && String(g.n) !== filters.n) return false;
-    if (filters.io && g.io != null && String(g.io) !== filters.io) return false;
+    if (filters.io) {
+      const gio = g.io == null || g.io === '' ? 'memory' : String(g.io);
+      if (gio !== String(filters.io)) return false;
+    }
     return true;
   });
-  return hit || groups[0];
+  if (hit) return hit;
+  if (filters.io) return null;
+  return groups[0];
 }
 
 let catalog = null;
@@ -287,7 +287,37 @@ function renderWhyExperiments() {
     </details>`;
 }
 
-function renderHowToRead() {
+function renderHowToRead({ mode } = { mode: 'table' }) {
+  if (mode === 'list') {
+    return `
+    <details class="exp-howto glass-panel">
+      <summary>How to read the numbers</summary>
+      <ul>
+        <li>Times are the <strong>middle</strong> value (median), in microseconds. Smaller is better.</li>
+        <li>Most experiments still show a <strong>table</strong>. Experiment 1 shows <strong>graphs</strong> of the same numbers.</li>
+        <li>On a graph page, <strong>Download CSV</strong> or <strong>Show numbers as a table</strong> gives you the grid.</li>
+        <li><strong>Vs fastest</strong> is Fastest · About the same · A bit slower · Clearly slower — not simply Winner / Loser.</li>
+        <li>Compare libraries <strong>inside one language</strong>.</li>
+      </ul>
+      <p><a href="../experiments/">Full experiment notes</a></p>
+    </details>`;
+  }
+  if (mode === 'graphs') {
+    return `
+    <details class="exp-howto glass-panel">
+      <summary>How to read these graphs</summary>
+      <ul>
+        <li>The <strong>bar</strong> is the middle time (median), in microseconds. Smaller is faster.</li>
+        <li>The <strong>whisker</strong> is <strong>approximate spread</strong>, reconstructed from the published confidence interval of the mean — the same reconstruction the table’s Spread column uses. It is not yet the sample standard deviation. After results publish <code>total_std_ns</code>, we will draw that.</li>
+        <li>A cell-style <code>15.9 (1.2×)</code> still appears in the tooltip and in the table: 15.9 µs, 1.2 times the fastest compared library.</li>
+        <li><strong>Vs fastest</strong> is still Fastest · About the same · A bit slower · Clearly slower — same chips as today, also encoded as color + glyph.</li>
+        <li>Compare libraries <strong>inside one language</strong>.</li>
+        <li>This experiment shows only libraries that write <strong>named JSON</strong> — an object like <code>{"id": 1, "status": "ok"}</code>. A library that writes a JSON list is not the same public-API payload, so it is not on this page.</li>
+        <li><strong>Download CSV</strong> or open <strong>Show numbers as a table</strong> for the grid.</li>
+      </ul>
+      <p><a href="../experiments/">Full experiment notes</a></p>
+    </details>`;
+  }
   return `
     <details class="exp-howto glass-panel">
       <summary>How to read this table</summary>
@@ -342,11 +372,12 @@ function chips(names, cls) {
 
 function renderTopGroup(group, rows) {
   if (!group && !rows.length) return '';
-  const similar = group?.similar || rows.filter((r) => r.tier === 'similar' || r.tier === 'fastest').map((r) => r.library);
-  const close = group?.close || rows.filter((r) => r.tier === 'close').map((r) => r.library);
-  const slower = rows.filter((r) => r.tier === 'slower').map((r) => r.library);
+  const similar = group?.similar || rows.filter((r) => displayTier(r, rows) === 'similar' || displayTier(r, rows) === 'fastest').map((r) => r.library);
+  const close = group?.close || rows.filter((r) => displayTier(r, rows) === 'close').map((r) => r.library);
+  const slower = rows.filter((r) => displayTier(r, rows) === 'slower').map((r) => r.library);
   const front = group?.time_size_front || rows.filter((r) => r.on_time_size_front).map((r) => r.library);
-  const fastest = group?.reference || rows.find((r) => r.tier === 'fastest')?.library;
+  const fastest = group?.reference || rows.find((r) => displayTier(r, rows) === 'fastest')?.library;
+  const skipped = rows.filter((r) => isShapeSkip(r));
   return `
     <div class="exp-groups glass-panel">
       <p class="section-help">
@@ -376,6 +407,18 @@ function renderTopGroup(group, rows) {
             </div>`
           : ''
       }
+      ${
+        skipped.length
+          ? `<p class="section-help exp-shape-note">
+              Hollow bar${skipped.length === 1 ? '' : 's'}
+              (${skipped.map((r) => escapeHtml(r.library)).join(', ')}):
+              timed OK, but ${skipped.length === 1 ? 'this library writes' : 'these libraries write'} a JSON
+              <em>list</em> <code>[…]</code>, not a named object <code>{"id": …}</code>.
+              That is not what <strong>Stream</strong> means — Stream is only “write as if to a file.”
+              We do not rank the list against named JSON.
+            </p>`
+          : ''
+      }
     </div>`;
 }
 
@@ -386,12 +429,12 @@ function renderTable(rows) {
   const showGzip = rows.some((r) => r.size_gzip_bytes != null);
   const showZstd = rows.some((r) => r.size_zstd_bytes != null);
   const sorted = [...rows].sort((a, b) => {
-    const ac = a.in_comparison === false ? 1 : 0;
-    const bc = b.in_comparison === false ? 1 : 0;
+    const ac = isShapeSkip(a) ? 1 : 0;
+    const bc = isShapeSkip(b) ? 1 : 0;
     if (ac !== bc) return ac - bc;
     return (Number(a.total_median_ns) || 1e18) - (Number(b.total_median_ns) || 1e18);
   });
-  const compared = sorted.filter((r) => r.in_comparison !== false);
+  const compared = competingRows(sorted);
   const minOf = (key) => {
     const nums = compared.map((r) => Number(r[key])).filter(Number.isFinite);
     return nums.length ? Math.min(...nums) : null;
@@ -421,14 +464,14 @@ function renderTable(rows) {
     </tr>`;
   const body = sorted
     .map((row) => {
-      const skipped = row.in_comparison === false;
+      const skipped = isShapeSkip(row);
       const std = totalStdUs(row);
       const trials =
         row.runs != null
           ? `${formatIntGrouped(row.runs)}${row.runs_raw ? ` of ${formatIntGrouped(row.runs_raw)}` : ''}`
           : '—';
       return `
-        <tr class="${compareClass(row)}">
+        <tr class="${compareClass(row, sorted)}">
           <td class="str">${escapeHtml(row.library)}${row.version ? `<span class="exp-ver">${escapeHtml(row.version)}</span>` : ''}</td>
           ${showKind ? `<td class="str">${escapeHtml(kindLabel(row.kind))}</td>` : ''}
           ${showN ? `<td class="num">${escapeHtml(row.n ?? '')}</td>` : ''}
@@ -441,7 +484,7 @@ function renderTable(rows) {
           ${showGzip ? (skipped ? `<td class="num">${formatIntGrouped(row.size_gzip_bytes)}</td>` : sizeCell(row.size_gzip_bytes, bestGzip)) : ''}
           ${showZstd ? (skipped ? `<td class="num">${formatIntGrouped(row.size_zstd_bytes)}</td>` : sizeCell(row.size_zstd_bytes, bestZstd)) : ''}
           <td class="num">${trials}</td>
-          <td class="str">${escapeHtml(compareLabel(row))}</td>
+          <td class="str">${escapeHtml(compareLabel(row, sorted))}</td>
         </tr>`;
     })
     .join('');
@@ -454,9 +497,73 @@ function renderTable(rows) {
     </div>`;
 }
 
+function replaceExperimentsHtml(root, html) {
+  destroyExperimentFigures();
+  root.innerHTML = html;
+}
+
+function renderFiguresMount() {
+  return `<div id="exp-figures"></div>`;
+}
+
+function renderDownloadBar() {
+  return `
+    <div class="exp-download">
+      <button type="button" class="tab-btn chart-tool-btn" id="exp-dl-csv">Download CSV</button>
+      <button type="button" class="tab-btn chart-tool-btn" id="exp-copy-tsv">Copy TSV</button>
+      <span id="exp-status" role="status"></span>
+    </div>`;
+}
+
+function renderNumbersDetails(rows) {
+  return `
+    <details class="exp-numbers glass-panel">
+      <summary>Show numbers as a table</summary>
+      ${renderTable(rows)}
+    </details>`;
+}
+
+function setExpStatus(root, msg) {
+  const el = root.querySelector('#exp-status');
+  if (el) el.textContent = msg || '';
+}
+
+function wireExportControls(root, ctx) {
+  const stem = (extra) => exportStem({ id: ctx.id, lang: ctx.lang, io: ctx.io, extra });
+  root.querySelector('#exp-dl-csv')?.addEventListener('click', () => {
+    try {
+      downloadText(`${stem()}.csv`, rowsToDelimited(ctx.rows, { delimiter: ',' }), 'text/csv;charset=utf-8');
+      setExpStatus(root, '');
+    } catch (err) {
+      setExpStatus(root, 'Download failed');
+    }
+  });
+  root.querySelector('#exp-copy-tsv')?.addEventListener('click', () => {
+    copyText(rowsToDelimited(ctx.rows, { delimiter: '\t' }))
+      .then(() => setExpStatus(root, 'Table copied'))
+      .catch(() => setExpStatus(root, 'Clipboard unavailable'));
+  });
+  const pngClick = (which) => () => {
+    const url = figuresToPng(which);
+    if (!url) {
+      setExpStatus(root, 'Download failed');
+      return;
+    }
+    downloadDataUrl(url, `${stem(which)}.png`);
+    setExpStatus(root, '');
+  };
+  root.querySelector('#exp-png-latency')?.addEventListener('click', pngClick('latency'));
+  root.querySelector('#exp-png-split')?.addEventListener('click', pngClick('split'));
+  const pngSize = root.querySelector('#exp-png-size');
+  if (pngSize) {
+    if (sizeTreatment(ctx.rows).kind !== 'S1') pngSize.hidden = true;
+    else pngSize.addEventListener('click', pngClick('size'));
+  }
+}
+
 function renderList(root) {
   const items = catalog?.experiments || [];
-  root.innerHTML = `
+  replaceExperimentsHtml(root, `
     <div class="exp-header">
       <h2 class="chart-title">Experiments</h2>
       <p class="section-help">
@@ -465,7 +572,7 @@ function renderList(root) {
       </p>
     </div>
     ${renderWhyExperiments()}
-    ${renderHowToRead()}
+    ${renderHowToRead({ mode: 'list' })}
     <div class="exp-list" role="list">
       ${items
         .map((exp) => {
@@ -486,7 +593,7 @@ function renderList(root) {
         .join('')}
     </div>
     ${!items.length ? `<p class="section-help">No experiment folders found.</p>` : ''}
-  `;
+  `);
   root.querySelectorAll('.exp-card[data-exp-id]').forEach((btn) => {
     btn.addEventListener('click', () => {
       if (btn.getAttribute('data-planned') === '1') return;
@@ -496,33 +603,43 @@ function renderList(root) {
 }
 
 async function renderDetail(root, id) {
+  destroyExperimentFigures();
   const meta = (catalog?.experiments || []).find((e) => e.id === id);
   if (!meta) {
-    root.innerHTML = `
+    replaceExperimentsHtml(
+      root,
+      `
       <p class="section-help">Unknown experiment <code>${escapeHtml(id)}</code>.</p>
-      <button type="button" class="tab-btn" id="exp-back">All experiments</button>`;
+      <button type="button" class="tab-btn" id="exp-back">All experiments</button>`
+    );
     root.querySelector('#exp-back')?.addEventListener('click', () => setHash(null));
     return;
   }
   if (!meta.has_results) {
-    root.innerHTML = `
+    replaceExperimentsHtml(
+      root,
+      `
       <div class="exp-header">
         <button type="button" class="tab-btn exp-back" id="exp-back">All experiments</button>
         <h2 class="chart-title">${escapeHtml(meta.title || meta.question)}</h2>
         ${renderStory(meta)}
         <p class="section-help">No results yet.</p>
-      </div>`;
+      </div>`
+    );
     root.querySelector('#exp-back')?.addEventListener('click', () => setHash(null));
     return;
   }
-  root.innerHTML = `<p class="section-help">Loading ${escapeHtml(id)}…</p>`;
+  replaceExperimentsHtml(root, `<p class="section-help">Loading ${escapeHtml(id)}…</p>`);
   let data;
   try {
     data = await loadPayload(id, meta.payload);
   } catch (err) {
-    root.innerHTML = `
+    replaceExperimentsHtml(
+      root,
+      `
       <button type="button" class="tab-btn exp-back" id="exp-back">All experiments</button>
-      <p class="section-help">Could not load results: ${escapeHtml(err.message)}</p>`;
+      <p class="section-help">Could not load results: ${escapeHtml(err.message)}</p>`
+    );
     root.querySelector('#exp-back')?.addEventListener('click', () => setHash(null));
     return;
   }
@@ -541,10 +658,19 @@ async function renderDetail(root, id) {
     n: ns.length > 1 ? ui.n : '',
     io: ios.length > 1 ? ui.io : '',
   };
-  const filtered = rowsFor(langBlock, filters);
+  const filtered = rowsFor(langBlock, filters).filter((row) =>
+    id === '01-json-library-bakeoff' ? !isShapeSkip(row) : true
+  );
   const group = matchingTopGroup(langBlock, filters);
+  const graphs = usesExperimentGraphs(id);
+  const howToMode = graphs ? 'graphs' : 'table';
+  const resultsHtml = graphs
+    ? `${renderFiguresMount()}${renderDownloadBar()}${renderNumbersDetails(filtered)}`
+    : renderTable(filtered);
 
-  root.innerHTML = `
+  replaceExperimentsHtml(
+    root,
+    `
     <div class="exp-header">
       <button type="button" class="tab-btn exp-back" id="exp-back">All experiments</button>
       <p class="exp-kicker">Experiment ${meta.number != null ? meta.number : ''}</p>
@@ -553,7 +679,7 @@ async function renderDetail(root, id) {
       <p class="section-help">This is a fair slice of the main Dashboard for one decision, not extra clocks. <a href="#experiments">Why we keep experiments separate</a></p>
     </div>
     ${renderStory(meta)}
-    ${renderHowToRead()}
+    ${renderHowToRead({ mode: howToMode })}
     ${renderSample(meta)}
     <div class="exp-lang-tabs tabs" role="tablist" aria-label="Language">
       ${langIds
@@ -569,8 +695,24 @@ async function renderDetail(root, id) {
       ${selectHtml('exp-io', 'How written', ios, ui.io, (v) => (v === 'memory' ? 'in memory' : v))}
     </div>
     ${renderTopGroup(group, filtered)}
-    ${renderTable(filtered)}
-  `;
+    ${resultsHtml}
+  `
+  );
+  if (graphs) {
+    const exportCtx = { id, lang: ui.lang, io: filters.io, rows: filtered };
+    if (typeof globalThis.Chart === 'undefined') {
+      root.querySelector('.exp-numbers')?.setAttribute('open', '');
+      setExpStatus(root, 'Graphs need Chart.js (CDN). The table below has the same numbers.');
+    }
+    mountExperimentFigures(root.querySelector('#exp-figures'), {
+      id,
+      meta,
+      rows: filtered,
+      lang: ui.lang,
+      io: filters.io,
+    });
+    wireExportControls(root, exportCtx);
+  }
   root.querySelector('#exp-back')?.addEventListener('click', () => setHash(null));
   root.querySelectorAll('[data-exp-lang]').forEach((btn) => {
     btn.addEventListener('click', () => {
@@ -596,6 +738,7 @@ async function renderDetail(root, id) {
 }
 
 async function render() {
+  destroyExperimentFigures();
   const root = document.getElementById('experiments');
   if (!root) return;
   const loc = parseHash();
@@ -603,7 +746,9 @@ async function render() {
   if (loc.view === 'suite') return;
   await loadCatalog();
   if (catalogError) {
-    root.innerHTML = `
+    replaceExperimentsHtml(
+      root,
+      `
       <div class="exp-header">
         <h2 class="chart-title">Experiments</h2>
         <p class="section-help">
@@ -611,7 +756,8 @@ async function render() {
           <code>python3 dashboard/scripts/sync-experiments.py</code>
           (${escapeHtml(catalogError.message)}).
         </p>
-      </div>`;
+      </div>`
+    );
     return;
   }
   if (loc.view === 'list') {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -7,7 +7,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "sync-data": "python3 scripts/sync-data.py",
-    "sync-experiments": "python3 scripts/sync-experiments.py"
+    "sync-experiments": "python3 scripts/sync-experiments.py",
+    "test": "node --test test/exp-graphs.test.js"
   },
   "devDependencies": {
     "vite": "^5.0.0"

--- a/dashboard/public/data/experiments/index.json
+++ b/dashboard/public/data/experiments/index.json
@@ -10,7 +10,7 @@
       "number": 1,
       "slug": "json-library-bakeoff",
       "title": "Which JSON library is fastest?",
-      "question": "We have to send JSON (the usual web text). On one small order, which JSON library is fastest?",
+      "question": "We have to send JSON (the usual web text). Each timed call is one shop order — an id, a status, and eight line items, about 450 bytes — not a file of many orders. Which JSON library is fastest?",
       "story": {
         "why": "Most websites already speak JSON. Changing that format is expensive. First we ask whether a faster JSON library is enough.",
         "example": "A shop\u2019s public API sends one order as JSON. Partners and browsers already expect that text.",

--- a/dashboard/test/exp-graphs.test.js
+++ b/dashboard/test/exp-graphs.test.js
@@ -1,0 +1,170 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { compareLabel, displayTier, rowsToDelimited, skipReason, totalStdUs } from '../exp-export.js';
+import { sizeTreatment, wrapYTick } from '../exp-charts.js';
+
+test('totalStdUs reconstructs from mean CI', () => {
+  const std = totalStdUs({
+    total_ci_low_ns: 3788,
+    total_ci_high_ns: 4088,
+    runs: 92,
+  });
+  assert.ok(std != null);
+  assert.ok(Math.abs(std - 0.734) < 0.002);
+});
+
+test('totalStdUs prefers published total_std_ns', () => {
+  assert.equal(
+    totalStdUs({
+      total_std_ns: 1000,
+      total_ci_low_ns: 3788,
+      total_ci_high_ns: 4088,
+      runs: 92,
+    }),
+    1
+  );
+});
+
+test('totalStdUs is null without std or usable CI', () => {
+  assert.equal(totalStdUs({ runs: 1, total_ci_low_ns: 1, total_ci_high_ns: 2 }), null);
+  assert.equal(totalStdUs({}), null);
+});
+
+test('sizeTreatment Python memory is S0 with gzip and msgspec', () => {
+  const rows = [
+    { library: 'orjson', size_bytes: 448, size_gzip_bytes: 229, in_comparison: true },
+    { library: 'json', size_bytes: 448, size_gzip_bytes: 229, in_comparison: true },
+    { library: 'msgspec', size_bytes: 192, size_gzip_bytes: 165, in_comparison: false, writes_named_fields: false },
+  ];
+  const t = sizeTreatment(rows);
+  assert.equal(t.kind, 'S0');
+  assert.equal(
+    t.text,
+    'Named JSON 448 B (229 after gzip). msgspec also ran (192 B). By design it writes a JSON list, not {"id": …}, so we do not rank it here.'
+  );
+});
+
+test('skipReason explains msgspec is timed, not failed', () => {
+  const skip = skipReason({
+    library: 'msgspec',
+    in_comparison: false,
+    writes_named_fields: false,
+  });
+  assert.equal(skip.short, 'writes […] on purpose');
+  assert.equal(skip.label, 'By design — JSON list');
+  assert.match(skip.detail, /By design/i);
+  assert.match(skip.detail, /list/);
+  assert.equal(compareLabel({ in_comparison: false, writes_named_fields: false }), 'By design — JSON list');
+  assert.equal(skipReason({ in_comparison: true, writes_named_fields: true }), null);
+});
+
+test('displayTier does not paint a 2% median gap as clearly slower', () => {
+  const rows = [
+    { library: 'IkigaJSON', total_median_ns: 54370, tier: 'fastest', in_comparison: true, writes_named_fields: true },
+    {
+      library: 'Foundation.JSONEncoder',
+      total_median_ns: 55748,
+      tier: 'slower',
+      cliffs_delta_vs_fastest: 0.4554,
+      in_comparison: true,
+      writes_named_fields: true,
+    },
+  ];
+  assert.equal(displayTier(rows[0], rows), 'fastest');
+  assert.equal(displayTier(rows[1], rows), 'similar');
+});
+
+test('displayTier colors stream rows even when in_comparison is false', () => {
+  const rows = [
+    { library: 'fast', total_median_ns: 1000, in_comparison: false, writes_named_fields: true, io: 'stream' },
+    { library: 'mid', total_median_ns: 1100, in_comparison: false, writes_named_fields: true, io: 'stream' },
+    { library: 'slow', total_median_ns: 3000, in_comparison: false, writes_named_fields: true, io: 'stream' },
+  ];
+  assert.equal(displayTier(rows[0], rows), 'fastest');
+  assert.equal(displayTier(rows[1], rows), 'similar');
+  assert.equal(displayTier(rows[2], rows), 'slower');
+  assert.equal(skipReason(rows[0]), null);
+});
+
+test('sizeTreatment JavaScript is S0 without gzip', () => {
+  const rows = [
+    { library: 'JSON.stringify', size_bytes: 448, size_gzip_bytes: null, in_comparison: true },
+    { library: 'fast-json-stringify', size_bytes: 448, in_comparison: true },
+  ];
+  const t = sizeTreatment(rows);
+  assert.equal(t.kind, 'S0');
+  assert.equal(t.text, 'Named JSON 448 B.');
+});
+
+test('sizeTreatment C# is S1', () => {
+  const rows = [
+    { library: 'SpanJson', size_bytes: 440, in_comparison: true },
+    { library: 'System.Text.Json', size_bytes: 588, in_comparison: true },
+    { library: 'Json.Net', size_bytes: 972, in_comparison: true },
+    { library: 'FsPicklerJson', size_bytes: 1024, in_comparison: true },
+  ];
+  assert.equal(sizeTreatment(rows).kind, 'S1');
+});
+
+test('rowsToDelimited includes skipped rows and empty gzip', () => {
+  const csv = rowsToDelimited(
+    [
+      {
+        library: 'orjson',
+        version: '3.11.9',
+        io: 'memory',
+        write_median_ns: 1522,
+        read_median_ns: 2362,
+        total_median_ns: 3894,
+        total_ci_low_ns: 3788,
+        total_ci_high_ns: 4088,
+        size_bytes: 448,
+        size_gzip_bytes: 229,
+        runs: 92,
+        runs_raw: 100,
+        tier: 'fastest',
+        in_comparison: true,
+      },
+      {
+        library: 'msgspec',
+        version: '0.19.0',
+        io: 'memory',
+        write_median_ns: 1000,
+        read_median_ns: 2000,
+        total_median_ns: 3000,
+        size_bytes: 192,
+        runs: 90,
+        in_comparison: false,
+        writes_named_fields: false,
+      },
+    ],
+    { delimiter: ',' }
+  );
+  const lines = csv.trim().split('\n');
+  assert.equal(
+    lines[0],
+    'library,version,io,write_us,read_us,total_us,spread_std_us,size_bytes,size_gzip_bytes,trials,trials_raw,vs_fastest,in_comparison'
+  );
+  assert.match(lines[1], /^orjson,3\.11\.9,memory,/);
+  assert.match(lines[1], /,true$/);
+  const skip = lines.find((l) => l.startsWith('msgspec,'));
+  assert.ok(skip);
+  assert.match(skip, /By design — JSON list/);
+  assert.match(skip, /,false$/);
+  const skipCols = skip.split(',');
+  const gzipIdx = lines[0].split(',').indexOf('size_gzip_bytes');
+  assert.equal(skipCols[gzipIdx], '');
+});
+
+test('wrapYTick keeps short names on one line', () => {
+  assert.deepEqual(wrapYTick({ library: 'orjson', tier: 'fastest' }), ['● orjson']);
+  assert.deepEqual(wrapYTick({ library: 'System.Text.Json', tier: 'slower' }), ['× System.Text.Json']);
+});
+
+test('wrapYTick splits slash names and prefixes only the first line', () => {
+  const tick = wrapYTick({ library: 'segmentio/encoding/json', tier: 'slower' });
+  assert.equal(tick[0].startsWith('× '), true);
+  assert.equal(tick.length, 2);
+  assert.equal(tick[0], '× segmentio/');
+  assert.equal(tick[1], 'encoding/json');
+});

--- a/docs/experiments/index.md
+++ b/docs/experiments/index.md
@@ -64,7 +64,22 @@ If you only want to look around, use the main Dashboard. If you have to choose a
 
 ---
 
-## How to read a table
+## How to read the graphs
+
+Only **Experiment 1** is graphed so far. The other experiments still use a table. The numbers mean the same thing.
+
+Open them in the [Dashboard → Experiments](../dashboard/#experiments) tab.
+
+- The **bar** is the middle time (median), in **microseconds**. Smaller is faster.
+- The **whisker** is **approximate spread**, reconstructed from the published confidence interval of the **mean**. It is the same reconstruction the table’s Spread column uses. It is not yet the sample standard deviation of the trials.
+- Hover a bar for the same `15.9 (1.2×)` style numbers as the table.
+- **Vs fastest** is still Fastest / About the same / A bit slower / Clearly slower — also shown as color + a glyph on the axis.
+- Compare libraries **inside one language**.
+- Experiment 1 shows only libraries that write **named JSON** (`{"id": 1, "status": "ok"}`). A JSON list is a different public-API payload, so it is not on that chart.
+
+Use **Download CSV** or **Show numbers as a table** when you want the grid. Experiments 2–13 stay on the table until they are opted in.
+
+### The downloadable table
 
 Times are the **middle** value (the median), in **microseconds**. Smaller is better for time and for size.
 
@@ -104,7 +119,9 @@ We have to send JSON (the usual web text). Changing that format is expensive. Fi
 
 **Trade-off:** A faster library can help a lot. A library that checks types is slower on purpose — that extra time buys safety.
 
-**Sample:** one small order (an id, a status, eight line items).
+**What counts:** only libraries that write named JSON (`{"id": …}`). A JSON list is a different payload, so it is not in this contest.
+
+**Sample:** one shop order (an id, a status, eight line items, about 450 bytes). Not a file of many orders.
 
 [Dashboard](../dashboard/#experiments/01-json-library-bakeoff) · [Folder](https://github.com/leo-gan/GLD.SerializerBenchmark/tree/master/experiments/01-json-library-bakeoff)
 

--- a/experiments/01-json-library-bakeoff/experiment.yaml
+++ b/experiments/01-json-library-bakeoff/experiment.yaml
@@ -7,7 +7,7 @@
 schema: gld.experiment.config/1
 id: 01-json-library-bakeoff
 title: Which JSON library is fastest?
-question: We have to send JSON (the usual web text). On one small order, which JSON library is fastest?
+question: We have to send JSON (the usual web text). Each timed call is one shop order — an id, a status, and eight line items, about 450 bytes — not a file of many orders. Which JSON library is fastest?
 story:
   why: Most websites already speak JSON. Changing that format is expensive. First we ask whether a faster JSON library is enough.
   example: A shop’s public API sends one order as JSON. Partners and browsers already expect that text.


### PR DESCRIPTION
## Summary
- Experiment 1 detail view is graph-first: horizontal write+read ranking with visible spread whiskers, a write-vs-read split, and a size callout (or size ranking when sizes differ).
- Table remains as Download CSV, Copy TSV, and a collapsed “Show numbers as a table.” Other experiments stay on today’s table.
- Experiment 1 shows only named JSON (msgspec list JSON is omitted). Stream is ranked inside that filter, not treated as a skip. A 2% median gap is not painted “clearly slower.”

## Validation
- `cd dashboard && npm test` — 12 tests pass
- No benchmark-runner language source changed; no re-bench

## Notes
- Prototype valve is `GRAPH_PROTOTYPE_IDS` (`01-json-library-bakeoff` only).
- Question copy now names the sample: one shop order (~450 bytes), not a file of many orders.