### PR TITLE
Add All tab for cross-language experiment view

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ Compare 100+ serialization libraries across **nine languages**.
 | Start here | |
 |------------|--|
 | **Home** | [Documentation](https://leo-gan.github.io/GLD.SerializerBenchmark/) |
-| **Numbers** | [Live dashboard](https://leo-gan.github.io/GLD.SerializerBenchmark/dashboard/) · [Method overview](https://leo-gan.github.io/GLD.SerializerBenchmark/analysis/) |
-| **Learn** | [Serialization 101–401](https://leo-gan.github.io/GLD.SerializerBenchmark/theory/101/) — students through systems engineers |
+| **Numbers** | [Live dashboard](https://leo-gan.github.io/GLD.SerializerBenchmark/dashboard/) |
+| **Experiments** | [One-question tests](https://leo-gan.github.io/GLD.SerializerBenchmark/experiments/) |
+| **Learn** | [Serialization 101–401](https://leo-gan.github.io/GLD.SerializerBenchmark/theory/101/) |
 | **Method** | [How we measure](https://leo-gan.github.io/GLD.SerializerBenchmark/analysis/ANALYSIS_METHODOLOGY/) · [Metrics](https://leo-gan.github.io/GLD.SerializerBenchmark/analysis/METRICS/) |
 
 <p align="center">

--- a/dashboard/exp-charts.js
+++ b/dashboard/exp-charts.js
@@ -8,6 +8,8 @@ import {
   competingRows,
   displayTier,
   isShapeSkip,
+  mixedLanguages,
+  peerRows,
   skipReason,
   sortRows,
   totalStdUs,
@@ -133,6 +135,27 @@ function uniqueValues(rows, key) {
   return seen;
 }
 
+function seriesKey(row) {
+  if (row?.language) return `${row.language}\0${row.library || ''}`;
+  return String(row?.library || '');
+}
+
+function seriesLabel(row) {
+  return row?.label || (row?.language ? `${langAxis(row.language)} · ${row.library}` : String(row?.library || ''));
+}
+
+function uniqueSeriesKeys(rows) {
+  const seen = [];
+  const have = new Set();
+  for (const row of rows || []) {
+    const key = seriesKey(row);
+    if (!key || have.has(key)) continue;
+    have.add(key);
+    seen.push({ key, label: seriesLabel(row), language: row.language, library: row.library });
+  }
+  return seen;
+}
+
 function rowsMatching(rows, match = {}, ignore = {}) {
   return (rows || []).filter((r) => {
     if (!ignore.io && match.io && String(r.io ?? '') !== String(match.io)) return false;
@@ -146,7 +169,7 @@ function rowsMatching(rows, match = {}, ignore = {}) {
  * Which figures to draw. Special experiments get a story-specific hero;
  * the rest reuse L1 / W1 / S0 / S1.
  */
-export function figureTypesFor(id, rows, allRows) {
+export function figureTypesFor(id, rows, allRows, _opts = {}) {
   const view = rows || [];
   const types = [];
   if (id === '07-write-once-read-many') {
@@ -237,7 +260,7 @@ function splitLibraryName(name) {
 
 export function wrapYTick(row, rows) {
   const prefix = `${glyphFor(row, rows)} `;
-  const name = String(row.library || '');
+  const name = String(row.label || row.library || '');
   if ((prefix + name).length <= 22) return [prefix + name];
   const parts = splitLibraryName(name).map(clipTickPiece).slice(0, 2);
   if (!parts.length) return [prefix.trim()];
@@ -245,8 +268,8 @@ export function wrapYTick(row, rows) {
   return parts;
 }
 
-function plotHeight(n) {
-  return Math.max(280, n * 36 + 48);
+function plotHeight(n, compact = false) {
+  return Math.max(280, n * (compact ? 26 : 36) + 48);
 }
 
 function escapeHtml(s) {
@@ -262,6 +285,32 @@ function bestCompared(rows, key) {
     .map((r) => Number(r[key]))
     .filter(Number.isFinite);
   return nums.length ? Math.min(...nums) : null;
+}
+
+function bestComparedPeers(row, rows, key) {
+  return bestCompared(peerRows(row, rows), key);
+}
+
+const LANG_AXIS = {
+  csharp: 'C#',
+  rust: 'Rust',
+  go: 'Go',
+  python: 'Python',
+  javascript: 'JavaScript',
+  c: 'C',
+  java: 'Java',
+  cpp: 'C++',
+  swift: 'Swift',
+};
+
+function langAxis(id) {
+  return LANG_AXIS[id] || String(id || '');
+}
+
+function rowTitle(row) {
+  if (!row) return '';
+  const name = row.label || row.library || '';
+  return row.version ? `${name}  ${row.version}` : name;
 }
 
 function createHatch(color = '#b06000') {
@@ -451,11 +500,12 @@ function commonScaleX(title, tickFmt) {
 }
 
 function commonScaleY(rows) {
+  const wide = mixedLanguages(rows) || (rows || []).some((r) => r.label);
   return {
     stacked: false,
     grid: { display: false },
     afterFit(scale) {
-      scale.width = Math.max(scale.width, 148);
+      scale.width = Math.max(scale.width, wide ? 188 : 148);
     },
     ticks: {
       color: tickColor,
@@ -481,7 +531,8 @@ function l1TooltipLines(row, bestTotal, rows) {
   const lines = [];
   const skip = skipReason(row);
   if (skip) lines.push(skip.detail);
-  lines.push(`Write + read   ${ratioText(row.total_median_ns, bestTotal, 'total_median_ns')}`);
+  const best = bestTotal ?? bestComparedPeers(row, rows, 'total_median_ns');
+  lines.push(`Write + read   ${ratioText(row.total_median_ns, best, 'total_median_ns')}`);
   const std = totalStdUs(row);
   lines.push(std == null ? 'Spread unknown (not enough trials to reconstruct).' : `Spread (std)   ${formatSig(std)} µs`);
   const w = Number(row.write_median_ns);
@@ -533,9 +584,73 @@ function suggestedMax(values, stds = []) {
   return m > 0 ? m * 1.12 : undefined;
 }
 
+function mountRelative(canvas, rows) {
+  const values = rows.map((r) => {
+    const best = bestComparedPeers(r, rows, 'total_median_ns');
+    const v = Number(r.total_median_ns);
+    if (!Number.isFinite(v) || !Number.isFinite(best) || best <= 0) return null;
+    return v / best;
+  });
+  const stds = rows.map((r) => {
+    const std = totalStdUs(r);
+    const best = bestComparedPeers(r, rows, 'total_median_ns');
+    if (std == null || !Number.isFinite(best) || best <= 0) return null;
+    return std / (best / 1000);
+  });
+  return makeBarChart(
+    canvas,
+    {
+      type: 'bar',
+      plugins: [
+        makeErrorBarsPlugin(stds, 0),
+        makeValueLabelsPlugin({ rows, stds, format: (v) => `${formatSig(v, 2)}×`, datasetIndex: 0 }),
+      ],
+      data: {
+        labels: rows.map((r) => r.label || r.library),
+        datasets: [
+          {
+            data: values,
+            backgroundColor: rows.map((r) => l1Fill(r, rows)),
+            borderColor: rows.map((r) => l1Stroke(r, rows)),
+            borderWidth: 1.5,
+            borderDash: (ctx) => l1BorderDash(rows[ctx.dataIndex] || {}),
+            borderRadius: 3,
+            barPercentage: 0.72,
+            categoryPercentage: 0.8,
+          },
+        ],
+      },
+      options: {
+        indexAxis: 'y',
+        responsive: true,
+        maintainAspectRatio: false,
+        animation: false,
+        layout: { padding: { right: 72, left: 4, top: 4, bottom: 4 } },
+        plugins: {
+          legend: { display: false },
+          tooltip: {
+            ...tooltipChrome,
+            callbacks: {
+              title: (items) => rowTitle(rows[items[0]?.dataIndex]),
+              label: (item) => l1TooltipLines(rows[item.dataIndex], null, rows),
+            },
+          },
+        },
+        scales: {
+          x: {
+            ...commonScaleX('× that language’s fastest', (v) => `${formatSig(v, 2)}×`),
+            suggestedMax: suggestedMax(values, stds),
+          },
+          y: commonScaleY(rows),
+        },
+      },
+    },
+    'relative'
+  );
+}
+
 function mountLatency(canvas, rows, lang) {
   const stds = rows.map(totalStdUs);
-  const bestTotal = bestCompared(rows, 'total_median_ns');
   const values = rows.map((r) => Number(r.total_median_ns) / 1000);
   return makeBarChart(
     canvas,
@@ -571,12 +686,8 @@ function mountLatency(canvas, rows, lang) {
         tooltip: {
           ...tooltipChrome,
           callbacks: {
-            title: (items) => {
-              const row = rows[items[0]?.dataIndex];
-              if (!row) return '';
-              return row.version ? `${row.library}  ${row.version}` : row.library;
-            },
-            label: (item) => l1TooltipLines(rows[item.dataIndex], bestTotal, rows),
+            title: (items) => rowTitle(rows[items[0]?.dataIndex]),
+            label: (item) => l1TooltipLines(rows[item.dataIndex], null, rows),
           },
         },
       },
@@ -596,7 +707,7 @@ function mountSplit(canvas, rows) {
     {
     type: 'bar',
     data: {
-      labels: rows.map((r) => r.library),
+      labels: rows.map((r) => seriesLabel(r)),
       datasets: [
         {
           label: 'Write',
@@ -629,10 +740,7 @@ function mountSplit(canvas, rows) {
         tooltip: {
           ...tooltipChrome,
           callbacks: {
-            title: (items) => {
-              const row = rows[items[0]?.dataIndex];
-              return row?.library || '';
-            },
+            title: (items) => rowTitle(rows[items[0]?.dataIndex]),
             label: (item) => {
               const name = item.dataset.label;
               const v = item.parsed.x;
@@ -669,7 +777,7 @@ function mountSize(canvas, rows) {
     type: 'bar',
     plugins: [makeValueLabelsPlugin({ rows: sorted, stds: [], format: formatIntGrouped, datasetIndex: 0 })],
     data: {
-      labels: sorted.map((r) => r.library),
+      labels: sorted.map((r) => r.label || r.library),
       datasets: [
         {
           data: sorted.map((r) => Number(r.size_bytes)),
@@ -694,7 +802,7 @@ function mountSize(canvas, rows) {
         tooltip: {
           ...tooltipChrome,
           callbacks: {
-            title: (items) => sorted[items[0]?.dataIndex]?.library || '',
+            title: (items) => rowTitle(sorted[items[0]?.dataIndex]),
             label: (item) => {
               const row = sorted[item.dataIndex];
               const rel = formatRelativeCell(row.size_bytes, bestSize, false, {}, 'size_bytes');
@@ -754,7 +862,7 @@ function mountCompress(canvas, rows) {
     canvas,
     {
       type: 'bar',
-      data: { labels: sorted.map((r) => r.library), datasets },
+      data: { labels: sorted.map((r) => r.label || r.library), datasets },
       options: {
         indexAxis: 'y',
         responsive: true,
@@ -766,7 +874,7 @@ function mountCompress(canvas, rows) {
           tooltip: {
             ...tooltipChrome,
             callbacks: {
-              title: (items) => sorted[items[0]?.dataIndex]?.library || '',
+              title: (items) => rowTitle(sorted[items[0]?.dataIndex]),
               label: (item) => {
                 const v = item.parsed.x;
                 return `${item.dataset.label}  ${Number.isFinite(v) ? formatIntGrouped(v) : '—'} B`;
@@ -784,16 +892,24 @@ function mountCompress(canvas, rows) {
   );
 }
 
-function mountSizeVsPoints(canvas, rows) {
+function mountSizeVsPoints(canvas, rows, { byLanguage = false } = {}) {
   const points = uniqueValues(rows, 'points')
     .map(Number)
     .filter(Number.isFinite)
     .sort((a, b) => a - b);
-  const libs = uniqueValues(rows, 'library');
-  const datasets = libs.map((lib, i) => ({
-    label: String(lib),
+  const seriesIds = byLanguage ? uniqueValues(rows, 'language') : uniqueValues(rows, 'library');
+  const datasets = seriesIds.map((id, i) => ({
+    label: byLanguage ? langAxis(id) : String(id),
     data: points.map((p) => {
-      const row = rows.find((r) => String(r.library) === String(lib) && Number(r.points) === p);
+      if (byLanguage) {
+        const slice = rows.filter(
+          (r) => r.language === id && Number(r.points) === p && Number.isFinite(Number(r.size_bytes))
+        );
+        const pool = competingRows(slice);
+        const sizes = (pool.length ? pool : slice).map((r) => Number(r.size_bytes));
+        return sizes.length ? Math.min(...sizes) : null;
+      }
+      const row = rows.find((r) => String(r.library) === String(id) && Number(r.points) === p);
       const v = Number(row?.size_bytes);
       return Number.isFinite(v) ? v : null;
     }),
@@ -843,30 +959,33 @@ function mountSizeVsPoints(canvas, rows) {
 }
 
 function mountLatencyVsN(canvas, rows) {
-  const libs = [];
-  const byLib = new Map();
+  const keys = [];
+  const byKey = new Map();
   for (const row of rows) {
-    const name = String(row.library || '');
-    if (!byLib.has(name)) {
-      byLib.set(name, {});
-      libs.push(name);
+    const key = seriesKey(row);
+    if (!byKey.has(key)) {
+      byKey.set(key, {});
+      keys.push(key);
     }
-    byLib.get(name)[String(row.n)] = row;
+    byKey.get(key)[String(row.n)] = row;
   }
-  const sorted = [...libs].sort((a, b) => {
-    const ta = Number(byLib.get(a)['1']?.total_median_ns) || 1e18;
-    const tb = Number(byLib.get(b)['1']?.total_median_ns) || 1e18;
+  const sorted = [...keys].sort((a, b) => {
+    const ta = Number(byKey.get(a)['1']?.total_median_ns) || 1e18;
+    const tb = Number(byKey.get(b)['1']?.total_median_ns) || 1e18;
     return ta - tb;
   });
-  const proxy = sorted.map((name) => byLib.get(name)['1'] || byLib.get(name)['100'] || { library: name });
+  const proxy = sorted.map((key) => {
+    const row = byKey.get(key)['1'] || byKey.get(key)['100'] || { library: key };
+    return { ...row, label: seriesLabel(row) };
+  });
   const series = [
     { n: '1', label: '1 record', color: SERIES_N1 },
     { n: '100', label: '100 records', color: SERIES_N100 },
   ];
   const datasets = series.map((s) => ({
     label: s.label,
-    data: sorted.map((name) => {
-      const v = Number(byLib.get(name)[s.n]?.total_median_ns);
+    data: sorted.map((key) => {
+      const v = Number(byKey.get(key)[s.n]?.total_median_ns);
       return Number.isFinite(v) ? v / 1000 : null;
     }),
     backgroundColor: s.color,
@@ -878,7 +997,7 @@ function mountLatencyVsN(canvas, rows) {
     canvas,
     {
       type: 'bar',
-      data: { labels: sorted, datasets },
+      data: { labels: proxy.map((r) => r.label || r.library), datasets },
       options: {
         indexAxis: 'y',
         responsive: true,
@@ -890,7 +1009,7 @@ function mountLatencyVsN(canvas, rows) {
           tooltip: {
             ...tooltipChrome,
             callbacks: {
-              title: (items) => sorted[items[0]?.dataIndex] || '',
+              title: (items) => rowTitle(proxy[items[0]?.dataIndex]),
               label: (item) => {
                 const v = item.parsed.x;
                 return `${item.dataset.label}  ${Number.isFinite(v) ? formatSig(v) : '—'} µs`;
@@ -910,20 +1029,27 @@ function mountLatencyVsN(canvas, rows) {
 
 function mountRankSlope(canvas, rows) {
   const kinds = uniqueValues(rows, 'kind');
-  const libs = uniqueValues(rows, 'library');
+  const series = uniqueSeriesKeys(rows);
+  const byLang = mixedLanguages(rows);
   const rankByKind = new Map();
   for (const kind of kinds) {
-    const slice = rows
-      .filter((r) => String(r.kind) === String(kind) && Number.isFinite(Number(r.total_median_ns)))
-      .sort((a, b) => Number(a.total_median_ns) - Number(b.total_median_ns));
     const ranks = new Map();
-    slice.forEach((r, i) => ranks.set(String(r.library), i + 1));
+    const timed = rows.filter(
+      (r) => String(r.kind) === String(kind) && Number.isFinite(Number(r.total_median_ns))
+    );
+    const groups = byLang ? uniqueValues(timed, 'language') : [null];
+    for (const lang of groups) {
+      const slice = timed
+        .filter((r) => (lang == null ? true : r.language === lang))
+        .sort((a, b) => Number(a.total_median_ns) - Number(b.total_median_ns));
+      slice.forEach((r, i) => ranks.set(seriesKey(r), i + 1));
+    }
     rankByKind.set(String(kind), ranks);
   }
   const labels = kinds.map((k) => KIND_AXIS[k] || String(k));
-  const datasets = libs.map((lib, i) => ({
-    label: String(lib),
-    data: kinds.map((kind) => rankByKind.get(String(kind))?.get(String(lib)) ?? null),
+  const datasets = series.map((s, i) => ({
+    label: s.label,
+    data: kinds.map((kind) => rankByKind.get(String(kind))?.get(s.key) ?? null),
     borderColor: paletteAt(i).fill,
     backgroundColor: paletteAt(i).fill,
     tension: 0.1,
@@ -972,13 +1098,14 @@ function mountRankSlope(canvas, rows) {
 
 /**
  * @param {HTMLElement} mount
- * @param {{ id: string, meta: object, lang: string, io: string, kind: string, n: string, rows: object[], allRows?: object[] }} ctx
+ * @param {{ id: string, meta: object, lang: string, io: string, kind: string, n: string, rows: object[], allRows?: object[], crossLang?: boolean }} ctx
  */
 export function mountExperimentFigures(mount, ctx) {
   if (!mount) return;
   const rows = sortRows(ctx.rows || []);
   const allRows = ctx.allRows || rows;
   const match = { io: ctx.io, kind: ctx.kind, n: ctx.n };
+  const crossLang = Boolean(ctx.crossLang);
 
   if (!rows.length && !allRows.length) {
     mount.innerHTML = `
@@ -996,13 +1123,16 @@ export function mountExperimentFigures(mount, ctx) {
     return;
   }
 
-  const types = figureTypesFor(ctx.id, rows, allRows);
-  const lang = ctx.lang || 'this language';
-  const h = plotHeight(Math.max(rows.length, 4));
+  const types = figureTypesFor(ctx.id, rows, allRows, { crossLang });
+  const lang = crossLang ? 'every language' : ctx.lang || 'this language';
+  const h = plotHeight(Math.max(rows.length, 4), crossLang);
   const parts = [];
   const builders = [];
 
   const writeReadHelp = `${seriesChip('Write', SERIES_WRITE, '#1565c0', '#e3f2fd')} ${seriesChip('Read', SERIES_READ, '#4a148c', '#f3e5f5')}`;
+  const allAxisNote = crossLang
+    ? ' Every language shares this <strong>microsecond</strong> axis, so you can compare runtimes. Color is still vs that language’s fastest.'
+    : '';
 
   for (const type of types) {
     if (type === 'L1') {
@@ -1010,7 +1140,7 @@ export function mountExperimentFigures(mount, ctx) {
       parts.push(
         figureHtml({
           title: 'Write + read (µs)',
-          helpHtml: `${L1_CAPTION}${allSkipped ? ' Nothing in this filter is in the comparison.' : ''}`,
+          helpHtml: `${L1_CAPTION}${allAxisNote}${allSkipped ? ' Nothing in this filter is in the comparison.' : ''}`,
           pngId: 'exp-png-latency',
           height: h,
           canvasLabel: `Horizontal bar chart of write-plus-read time in microseconds for ${lang}, whiskers show spread`,
@@ -1055,39 +1185,44 @@ export function mountExperimentFigures(mount, ctx) {
       builders.push((canvas) => mountCompress(canvas, rows));
     } else if (type === 'C1') {
       const curveRows = rowsMatching(allRows, match, { n: true, kind: true });
-      const nLib = uniqueValues(curveRows, 'library').length;
+      const byLanguage = crossLang && uniqueValues(curveRows, 'language').length > 1;
+      const series = byLanguage ? uniqueValues(curveRows, 'language').map(langAxis) : uniqueValues(curveRows, 'library');
       parts.push(
         figureHtml({
-          title: 'Size vs how many sensor readings',
-          helpHtml: `Each line is one library. Smaller is more compact. The 128-byte and 512-byte marks are common packet limits.<br>${libraryChips(uniqueValues(curveRows, 'library'))}`,
+          title: byLanguage ? 'Smallest size vs how many sensor readings' : 'Size vs how many sensor readings',
+          helpHtml: byLanguage
+            ? `Each line is one language’s <strong>smallest</strong> payload. Size is the fair number across languages. The 128-byte and 512-byte marks are common packet limits.<br>${libraryChips(series)}`
+            : `Each line is one library. Smaller is more compact. The 128-byte and 512-byte marks are common packet limits.<br>${libraryChips(series)}`,
           pngId: 'exp-png-curve',
-          height: Math.max(320, 160 + nLib * 12),
-          canvasLabel: `Line chart of payload size versus number of sensor readings for ${lang}`,
+          height: Math.max(320, 160 + series.length * 12),
+          canvasLabel: byLanguage
+            ? 'Line chart of smallest payload size versus number of sensor readings in each language'
+            : `Line chart of payload size versus number of sensor readings for ${lang}`,
         })
       );
-      builders.push((canvas) => mountSizeVsPoints(canvas, curveRows));
+      builders.push((canvas) => mountSizeVsPoints(canvas, curveRows, { byLanguage }));
     } else if (type === 'C2') {
       const pairRows = rowsMatching(allRows, match, { n: true });
-      const nLib = uniqueValues(pairRows, 'library').length;
+      const nSeries = uniqueSeriesKeys(pairRows).length;
       parts.push(
         figureHtml({
           title: 'One record vs one hundred (µs)',
-          helpHtml: `${seriesChip('1 record', SERIES_N1, '#1565c0', '#e3f2fd')} ${seriesChip('100 records', SERIES_N100, '#3e2723', '#efebe9')}`,
+          helpHtml: `${seriesChip('1 record', SERIES_N1, '#1565c0', '#e3f2fd')} ${seriesChip('100 records', SERIES_N100, '#3e2723', '#efebe9')}${crossLang ? ' Every language shares this microsecond axis.' : ''}`,
           pngId: 'exp-png-vsn',
-          height: plotHeight(nLib),
+          height: plotHeight(nSeries, crossLang),
           canvasLabel: `Grouped bar chart of write-plus-read time at n=1 and n=100 for ${lang}`,
         })
       );
       builders.push((canvas) => mountLatencyVsN(canvas, pairRows));
     } else if (type === 'R1') {
       const rankRows = rowsMatching(allRows, match, { kind: true });
-      const nLib = uniqueValues(rankRows, 'library').length;
+      const series = uniqueSeriesKeys(rankRows);
       parts.push(
         figureHtml({
           title: 'Does the rank hold if the record changes?',
-          helpHtml: `Each line is one library. Rank 1 is fastest. Lines that cross mean the winner depends on the record shape.<br>${libraryChips(uniqueValues(rankRows, 'library'))}`,
+          helpHtml: `Each line is one library${crossLang ? ' in one language' : ''}. Rank 1 is fastest <em>in that language</em>. Lines that cross mean the winner depends on the record shape.<br>${libraryChips(series.map((s) => s.label))}`,
           pngId: 'exp-png-ranks',
-          height: Math.max(340, 140 + nLib * 16),
+          height: Math.max(340, 140 + series.length * 16),
           canvasLabel: `Slopegraph of library rank across record shapes for ${lang}`,
         })
       );

--- a/dashboard/exp-export.js
+++ b/dashboard/exp-export.js
@@ -12,6 +12,8 @@ const COMPARE_LABEL = {
   slower: 'Clearly slower',
 };
 
+export const ALL_LANG = 'all';
+
 const CSV_COLUMNS = [
   'library',
   'version',
@@ -27,6 +29,46 @@ const CSV_COLUMNS = [
   'vs_fastest',
   'in_comparison',
 ];
+
+export function isAllLang(lang) {
+  return lang === ALL_LANG;
+}
+
+/** True when the current rows cover more than one tagged language. */
+export function mixedLanguages(rows) {
+  const langs = new Set();
+  for (const row of rows || []) {
+    if (row?.language == null || row.language === '') continue;
+    langs.add(String(row.language));
+    if (langs.size > 1) return true;
+  }
+  return false;
+}
+
+/**
+ * Rows that share this row’s language. Untagged lists stay one contest.
+ * Used so All-tab colors and “vs fastest” never rank Rust against Java.
+ */
+export function peerRows(row, rows) {
+  const list = rows || [];
+  const lang = row?.language;
+  if (lang == null || lang === '') return list;
+  const peers = list.filter((r) => r.language === lang);
+  return peers.length ? peers : list;
+}
+
+/** Flatten ok language blocks, tagging every row with `language`. */
+export function flattenLanguageRows(languages, langIds) {
+  const rows = [];
+  for (const id of langIds || []) {
+    const block = languages?.[id];
+    if (!block || (block.status && block.status !== 'ok')) continue;
+    for (const row of block.rows || []) {
+      rows.push({ ...row, language: id });
+    }
+  }
+  return rows;
+}
 
 /** True skip: different JSON shape. Stream rows are not skips — they are a different filter. */
 export function isShapeSkip(row) {
@@ -70,9 +112,10 @@ function tierFromMedianRatio(row, rows) {
  * median-ratio band (≤1.15× similar, ≤1.5× close).
  */
 export function displayTier(row, rows) {
+  const peers = peerRows(row, rows);
   if (isShapeSkip(row)) return 'skip';
   if (row.tier === 'fastest' || row.cliffs_label === 'reference') return 'fastest';
-  const fromRatio = tierFromMedianRatio(row, rows);
+  const fromRatio = tierFromMedianRatio(row, peers);
   if (fromRatio === 'fastest') return 'fastest';
   const fromCliffs =
     row.tier === 'similar' || row.tier === 'close' || row.tier === 'slower' ? row.tier : '';
@@ -142,9 +185,18 @@ function escapeField(value, delimiter) {
   return s;
 }
 
+function rowHasLanguage(rows) {
+  return (rows || []).some((r) => r?.language != null && r.language !== '');
+}
+
+function csvColumns(rows) {
+  return rowHasLanguage(rows) ? ['language', ...CSV_COLUMNS] : CSV_COLUMNS;
+}
+
 function rowFields(row, rows) {
   const std = totalStdUs(row);
   return {
+    language: row.language ?? '',
     library: row.library ?? '',
     version: row.version ?? '',
     io: row.io ?? '',
@@ -163,10 +215,11 @@ function rowFields(row, rows) {
 
 export function rowsToDelimited(rows, { delimiter = ',' } = {}) {
   const sorted = sortRows(rows);
-  const lines = [CSV_COLUMNS.join(delimiter)];
+  const cols = csvColumns(sorted);
+  const lines = [cols.join(delimiter)];
   for (const row of sorted) {
     const fields = rowFields(row, sorted);
-    lines.push(CSV_COLUMNS.map((k) => escapeField(fields[k], delimiter)).join(delimiter));
+    lines.push(cols.map((k) => escapeField(fields[k], delimiter)).join(delimiter));
   }
   return `${lines.join('\n')}\n`;
 }

--- a/dashboard/experiments.js
+++ b/dashboard/experiments.js
@@ -8,6 +8,7 @@
 import './experiments.css';
 import { formatSig, formatRelativeCell, formatIntGrouped } from './format.js';
 import {
+  ALL_LANG,
   compareLabel,
   competingRows,
   copyText,
@@ -15,9 +16,12 @@ import {
   downloadDataUrl,
   downloadText,
   exportStem,
+  flattenLanguageRows,
+  isAllLang,
   isShapeSkip,
+  mixedLanguages,
+  peerRows,
   rowsToDelimited,
-  skipReason,
   totalStdUs,
 } from './exp-export.js';
 import {
@@ -296,7 +300,8 @@ function renderHowToRead({ mode, id } = { mode: 'table' }) {
         <li>Each experiment page shows <strong>graphs</strong> of the same numbers, plus <strong>Download CSV</strong> or <strong>Show numbers as a table</strong> for the grid.</li>
         <li>On a graph page, <strong>Download CSV</strong> or <strong>Show numbers as a table</strong> gives you the grid.</li>
         <li><strong>Vs fastest</strong> is Fastest · About the same · A bit slower · Clearly slower — not simply Winner / Loser.</li>
-        <li>Compare libraries <strong>inside one language</strong>.</li>
+        <li>The <strong>All</strong> tab puts every language on the same microsecond axis so you can compare runtimes. Color is still vs that language’s fastest.</li>
+        <li>A single-language tab is one contest inside that runtime.</li>
       </ul>
       <p><a href="../experiments/">Full experiment notes</a></p>
     </details>`;
@@ -310,7 +315,8 @@ function renderHowToRead({ mode, id } = { mode: 'table' }) {
         <li>The <strong>whisker</strong> is <strong>approximate spread</strong>, reconstructed from the published confidence interval of the mean — the same reconstruction the table’s Spread column uses. It is not yet the sample standard deviation. After results publish <code>total_std_ns</code>, we will draw that.</li>
         <li>A cell-style <code>15.9 (1.2×)</code> still appears in the tooltip and in the table: 15.9 µs, 1.2 times the fastest compared library.</li>
         <li><strong>Vs fastest</strong> is still Fastest · About the same · A bit slower · Clearly slower — same chips as today, also encoded as color + glyph.</li>
-        <li>Compare libraries <strong>inside one language</strong>.</li>
+        <li>On the <strong>All</strong> tab the bars use the same <strong>microsecond</strong> axis as a language tab, so you can compare languages. Color and “Vs fastest” stay vs that language’s fastest.</li>
+        <li>A single-language tab is one contest inside that runtime.</li>
         ${
           id === '01-json-library-bakeoff'
             ? '<li>This experiment shows only libraries that write <strong>named JSON</strong> — an object like <code>{"id": 1, "status": "ok"}</code>.</li>'
@@ -332,7 +338,8 @@ function renderHowToRead({ mode, id } = { mode: 'table' }) {
           <strong>Fastest</strong> · <strong>About the same</strong> · <strong>A bit slower</strong> · <strong>Clearly slower</strong>.</li>
         <li><strong>Good trade-off</strong> means nobody is both faster and smaller.</li>
         <li><strong>Trials</strong> is how many timed runs we kept. <strong>Spread (std)</strong> is how much those times bounced around.</li>
-        <li>Compare libraries <strong>inside one language</strong>. Do not compare write times across languages.</li>
+        <li>On the <strong>All</strong> tab, times are on one microsecond scale so you can compare languages. <strong>Vs fastest</strong> in the table is still vs that language’s fastest.</li>
+        <li>A single-language tab is one contest inside that runtime.</li>
       </ul>
       <p><a href="../experiments/">Full experiment notes</a></p>
     </details>`;
@@ -372,6 +379,13 @@ function renderSample(meta) {
 function chips(names, cls) {
   if (!names || !names.length) return '<span class="exp-chip exp-chip-empty">—</span>';
   return names.map((n) => `<span class="exp-chip ${cls}">${escapeHtml(n)}</span>`).join('');
+}
+
+function bestAmong(row, rows, key) {
+  const nums = competingRows(peerRows(row, rows))
+    .map((r) => Number(r[key]))
+    .filter(Number.isFinite);
+  return nums.length ? Math.min(...nums) : null;
 }
 
 function renderTopGroup(group, rows) {
@@ -425,31 +439,26 @@ function renderTopGroup(group, rows) {
 }
 
 function renderTable(rows) {
+  const showLang = mixedLanguages(rows) || rows.some((r) => r.language);
   const showKind = unique(rows, 'kind').length > 1;
   const showN = unique(rows, 'n').length > 1;
   const showIo = unique(rows, 'io').length > 1;
   const showGzip = rows.some((r) => r.size_gzip_bytes != null);
   const showZstd = rows.some((r) => r.size_zstd_bytes != null);
   const sorted = [...rows].sort((a, b) => {
+    if (showLang && a.language !== b.language) {
+      const langs = unique(rows, 'language').map(String);
+      return langs.indexOf(String(a.language || '')) - langs.indexOf(String(b.language || ''));
+    }
     const ac = isShapeSkip(a) ? 1 : 0;
     const bc = isShapeSkip(b) ? 1 : 0;
     if (ac !== bc) return ac - bc;
     return (Number(a.total_median_ns) || 1e18) - (Number(b.total_median_ns) || 1e18);
   });
-  const compared = competingRows(sorted);
-  const minOf = (key) => {
-    const nums = compared.map((r) => Number(r[key])).filter(Number.isFinite);
-    return nums.length ? Math.min(...nums) : null;
-  };
-  const bestTotal = minOf('total_median_ns');
-  const bestWrite = minOf('write_median_ns');
-  const bestRead = minOf('read_median_ns');
-  const bestSize = minOf('size_bytes');
-  const bestGzip = minOf('size_gzip_bytes');
-  const bestZstd = minOf('size_zstd_bytes');
 
   const head = `
     <tr>
+      ${showLang ? '<th class="str">Language</th>' : ''}
       <th class="str">Library</th>
       ${showKind ? '<th class="str">Record</th>' : ''}
       ${showN ? '<th class="num">How many</th>' : ''}
@@ -462,7 +471,7 @@ function renderTable(rows) {
       ${showGzip ? '<th class="num">After gzip</th>' : ''}
       ${showZstd ? '<th class="num">After zstd</th>' : ''}
       <th class="num">Trials</th>
-      <th class="str" title="Fastest, about the same, a bit slower, or clearly slower — on this sample. Not simply Winner / Loser.">Vs fastest</th>
+      <th class="str" title="Fastest, about the same, a bit slower, or clearly slower — vs that language’s fastest on this sample. Not simply Winner / Loser.">Vs fastest</th>
     </tr>`;
   const body = sorted
     .map((row) => {
@@ -472,8 +481,20 @@ function renderTable(rows) {
         row.runs != null
           ? `${formatIntGrouped(row.runs)}${row.runs_raw ? ` of ${formatIntGrouped(row.runs_raw)}` : ''}`
           : '—';
+      const bestWrite = bestAmong(row, sorted, 'write_median_ns');
+      const bestRead = bestAmong(row, sorted, 'read_median_ns');
+      const bestTotal = bestAmong(row, sorted, 'total_median_ns');
+      const sizePool = showLang ? competingRows(sorted) : competingRows(peerRows(row, sorted));
+      const minSize = (key) => {
+        const nums = sizePool.map((r) => Number(r[key])).filter(Number.isFinite);
+        return nums.length ? Math.min(...nums) : null;
+      };
+      const bestSize = minSize('size_bytes');
+      const bestGzip = minSize('size_gzip_bytes');
+      const bestZstd = minSize('size_zstd_bytes');
       return `
         <tr class="${compareClass(row, sorted)}">
+          ${showLang ? `<td class="str">${escapeHtml(langLabel(row.language))}</td>` : ''}
           <td class="str">${escapeHtml(row.library)}${row.version ? `<span class="exp-ver">${escapeHtml(row.version)}</span>` : ''}</td>
           ${showKind ? `<td class="str">${escapeHtml(kindLabel(row.kind))}</td>` : ''}
           ${showN ? `<td class="num">${escapeHtml(row.n ?? '')}</td>` : ''}
@@ -554,7 +575,7 @@ function wireExportControls(root, ctx) {
     downloadDataUrl(url, `${stem(which)}.png`);
     setExpStatus(root, '');
   };
-  ['latency', 'split', 'size', 'compress', 'curve', 'vsn', 'ranks'].forEach((which) => {
+  ['latency', 'relative', 'split', 'size', 'compress', 'curve', 'vsn', 'ranks'].forEach((which) => {
     root.querySelector(`#exp-png-${which}`)?.addEventListener('click', pngClick(which));
   });
 }
@@ -566,7 +587,7 @@ function renderList(root) {
       <h2 class="chart-title">Experiments</h2>
       <p class="section-help">
         Each item is <strong>one question</strong> — a fair slice of the big Dashboard, not a second set of clocks.
-        Compare libraries inside one language.
+        Open <strong>All</strong> to see every language on one microsecond axis.
       </p>
     </div>
     ${renderWhyExperiments()}
@@ -642,8 +663,19 @@ async function renderDetail(root, id) {
     return;
   }
   const langIds = Object.keys(data.languages || {}).filter((k) => data.languages[k]?.status === 'ok');
-  if (!ui.lang || !langIds.includes(ui.lang)) ui.lang = langIds[0] || '';
-  const langBlock = data.languages?.[ui.lang] || {};
+  const tabIds = langIds.length ? [...langIds, ALL_LANG] : [];
+  if (!ui.lang || !tabIds.includes(ui.lang)) ui.lang = langIds[0] || '';
+  const crossLang = isAllLang(ui.lang);
+  const langBlock = crossLang
+    ? {
+        status: 'ok',
+        language: ALL_LANG,
+        rows: flattenLanguageRows(data.languages, langIds).map((r) => ({
+          ...r,
+          label: `${langLabel(r.language)} · ${r.library}`,
+        })),
+      }
+    : data.languages?.[ui.lang] || {};
   const allRows = langBlock.rows || [];
   const kinds = unique(allRows, 'kind').map(String);
   const ns = unique(allRows, 'n').map(String);
@@ -659,12 +691,13 @@ async function renderDetail(root, id) {
   const filtered = rowsFor(langBlock, filters).filter((row) =>
     id === '01-json-library-bakeoff' ? !isShapeSkip(row) : true
   );
-  const group = matchingTopGroup(langBlock, filters);
+  const group = crossLang ? null : matchingTopGroup(langBlock, filters);
   const graphs = usesExperimentGraphs(id);
   const howToMode = graphs ? 'graphs' : 'table';
   const resultsHtml = graphs
     ? `${renderFiguresMount()}${renderDownloadBar()}${renderNumbersDetails(filtered)}`
     : renderTable(filtered);
+  const groupHtml = crossLang ? '' : renderTopGroup(group, filtered);
 
   replaceExperimentsHtml(
     root,
@@ -680,11 +713,11 @@ async function renderDetail(root, id) {
     ${renderHowToRead({ mode: howToMode, id })}
     ${renderSample(meta)}
     <div class="exp-lang-tabs tabs" role="tablist" aria-label="Language">
-      ${langIds
-        .map(
-          (idLang) =>
-            `<button type="button" class="tab-btn${idLang === ui.lang ? ' active' : ''}" data-exp-lang="${escapeHtml(idLang)}">${escapeHtml(langLabel(idLang))}</button>`
-        )
+      ${tabIds
+        .map((idLang) => {
+          const label = isAllLang(idLang) ? 'All' : langLabel(idLang);
+          return `<button type="button" class="tab-btn${idLang === ui.lang ? ' active' : ''}" data-exp-lang="${escapeHtml(idLang)}">${escapeHtml(label)}</button>`;
+        })
         .join('')}
     </div>
     <div class="filter-group exp-filters">
@@ -692,7 +725,7 @@ async function renderDetail(root, id) {
       ${selectHtml('exp-n', 'How many', ns, ui.n)}
       ${selectHtml('exp-io', 'How written', ios, ui.io, (v) => (v === 'memory' ? 'in memory' : v))}
     </div>
-    ${renderTopGroup(group, filtered)}
+    ${groupHtml}
     ${resultsHtml}
   `
   );
@@ -711,6 +744,7 @@ async function renderDetail(root, id) {
       io: filters.io || ui.io,
       kind: filters.kind || ui.kind,
       n: filters.n || ui.n,
+      crossLang,
     });
     wireExportControls(root, exportCtx);
   }

--- a/dashboard/test/exp-graphs.test.js
+++ b/dashboard/test/exp-graphs.test.js
@@ -1,6 +1,18 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { compareLabel, displayTier, rowsToDelimited, skipReason, totalStdUs } from '../exp-export.js';
+import {
+  ALL_LANG,
+  compareLabel,
+  displayTier,
+  flattenLanguageRows,
+  isAllLang,
+  mixedLanguages,
+  peerRows,
+  rowsToDelimited,
+  skipReason,
+  sortRows,
+  totalStdUs,
+} from '../exp-export.js';
 import { figureTypesFor, sizeTreatment, usesExperimentGraphs, wrapYTick } from '../exp-charts.js';
 
 test('totalStdUs reconstructs from mean CI', () => {
@@ -173,6 +185,98 @@ test('usesExperimentGraphs is on for every experiment id', () => {
   assert.equal(usesExperimentGraphs('01-json-library-bakeoff'), true);
   assert.equal(usesExperimentGraphs('13-ranking-accident'), true);
   assert.equal(usesExperimentGraphs('unknown'), false);
+});
+
+test('All tab flattens languages and keeps vs-fastest inside each language', () => {
+  assert.equal(isAllLang(ALL_LANG), true);
+  assert.equal(isAllLang('python'), false);
+  const languages = {
+    rust: {
+      status: 'ok',
+      rows: [
+        { library: 'sonic-rs', total_median_ns: 1300, tier: 'fastest', in_comparison: true },
+        { library: 'serde_json', total_median_ns: 4000, tier: 'slower', in_comparison: true },
+      ],
+    },
+    java: {
+      status: 'ok',
+      rows: [
+        { library: 'jsoniter', total_median_ns: 42700, tier: 'fastest', in_comparison: true },
+        { library: 'jackson', total_median_ns: 92800, tier: 'slower', in_comparison: true },
+      ],
+    },
+    go: { status: 'missing', rows: [] },
+  };
+  const flat = flattenLanguageRows(languages, ['rust', 'java', 'go']);
+  assert.equal(flat.length, 4);
+  assert.equal(mixedLanguages(flat), true);
+  assert.deepEqual(
+    peerRows(flat[2], flat).map((r) => r.library),
+    ['jsoniter', 'jackson']
+  );
+  assert.equal(displayTier(flat[2], flat), 'fastest');
+  assert.equal(displayTier(flat[3], flat), 'slower');
+  assert.equal(displayTier(flat[0], flat), 'fastest');
+  const ordered = sortRows(flat).map((r) => `${r.language}:${r.library}`);
+  assert.deepEqual(ordered, ['rust:sonic-rs', 'rust:serde_json', 'java:jsoniter', 'java:jackson']);
+});
+
+test('rowsToDelimited prefixes language on All-tab rows', () => {
+  const csv = rowsToDelimited(
+    [
+      {
+        language: 'python',
+        library: 'orjson',
+        io: 'memory',
+        write_median_ns: 1522,
+        read_median_ns: 2362,
+        total_median_ns: 3894,
+        size_bytes: 448,
+        runs: 92,
+        tier: 'fastest',
+        in_comparison: true,
+      },
+      {
+        language: 'go',
+        library: 'goccy/go-json',
+        io: 'memory',
+        write_median_ns: 1000,
+        read_median_ns: 2000,
+        total_median_ns: 3000,
+        size_bytes: 448,
+        runs: 90,
+        tier: 'fastest',
+        in_comparison: true,
+      },
+    ],
+    { delimiter: ',' }
+  );
+  const header = csv.trim().split('\n')[0];
+  assert.equal(header.startsWith('language,library,'), true);
+  assert.match(csv, /^python,orjson,/m);
+  assert.match(csv, /^go,goccy\/go-json,/m);
+});
+
+test('wrapYTick prefers the All-tab language · library label', () => {
+  assert.deepEqual(wrapYTick({ library: 'orjson', label: 'Python · orjson', tier: 'fastest' }), [
+    '● Python · orjson',
+  ]);
+});
+
+test('figureTypesFor All tab uses the same microsecond figures as a language tab', () => {
+  const timed = [
+    { library: 'a', language: 'rust', write_median_ns: 1, read_median_ns: 2, total_median_ns: 3, size_bytes: 10, in_comparison: true },
+    { library: 'b', language: 'java', write_median_ns: 20, read_median_ns: 40, total_median_ns: 60, size_bytes: 20, in_comparison: true },
+  ];
+  const all = figureTypesFor('01-json-library-bakeoff', timed, timed, { crossLang: true });
+  const one = figureTypesFor('01-json-library-bakeoff', timed, timed);
+  assert.deepEqual(all, one);
+  assert.ok(all.includes('L1'));
+  assert.ok(!all.includes('A1'));
+  assert.deepEqual(figureTypesFor('04-sensor-list-size', timed, timed, { crossLang: true }), ['C1']);
+  assert.deepEqual(figureTypesFor('09-compression-size', timed, timed, { crossLang: true }), ['S2']);
+  assert.ok(figureTypesFor('10-one-vs-hundred', timed, timed, { crossLang: true }).includes('C2'));
+  assert.ok(figureTypesFor('10-one-vs-hundred', timed, timed, { crossLang: true }).includes('L1'));
 });
 
 test('figureTypesFor picks a story-specific hero', () => {

--- a/docs/experiments/index.md
+++ b/docs/experiments/index.md
@@ -4,11 +4,11 @@ title: Experiments
 
 # Experiments
 
+[Dashboard → Experiments](../dashboard/#experiments){ .md-button .md-button--primary }
+
 Each experiment answers **one everyday question**, such as “which JSON library is fastest?” or “is YAML too slow for a live request?”
 
-Open the numbers in the [Dashboard → Experiments](../dashboard/#experiments) tab. This page is the same story in words.
-
-Compare libraries **inside one language**. A Python time and a Java time are not the same contest. Size (how many bytes) is the only number that is roughly fair across languages.
+Each experiment opens on a language tab. The **All** tab (last on the right) puts every language on one microsecond axis so you can compare runtimes. Color is still vs that language’s fastest. Size (how many bytes) is also fair across languages.
 
 ---
 
@@ -66,13 +66,12 @@ If you only want to look around, use the main Dashboard. If you have to choose a
 
 ## How to read the graphs
 
-Open the numbers in the [Dashboard → Experiments](../dashboard/#experiments) tab.
-
 - The **bar** is the middle time (median), in **microseconds**. Smaller is faster.
 - The **whisker** is **approximate spread**, reconstructed from the published confidence interval of the **mean**. It is the same reconstruction the table’s Spread column uses. It is not yet the sample standard deviation of the trials.
 - Hover a bar for the same `15.9 (1.2×)` style numbers as the table.
 - **Vs fastest** is still Fastest / About the same / A bit slower / Clearly slower — also shown as color + a glyph on the axis. A 2% gap is not “clearly slower.”
-- Compare libraries **inside one language**.
+- The **All** tab uses the same **microsecond** axis as a language tab, so you can compare languages. Color is still vs that language’s fastest.
+- A single-language tab is one contest inside that runtime.
 - Some experiments add a size, compression, or rank chart when that is the question.
 - Experiment 1 shows only libraries that write **named JSON** (`{"id": 1, "status": "ok"}`).
 

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -6,7 +6,7 @@ A laboratory notebook of narrow questions this benchmark can run.
 
 Each experiment is one question. Edit that folder’s **`experiment.yaml`** to change it (sample, languages, libraries). The sample is shared. Each language run is a subfolder. Combined numbers for a dashboard live in that experiment’s `results.json`.
 
-Plain-language pages: [docs/experiments](../docs/experiments/index.md). The interactive **Dashboard → Experiments** tab lists every folder that has `experiment.yaml`. After you add a folder or refresh `results.json`, run `python3 dashboard/scripts/sync-experiments.py` (also invoked at the end of `sync-data.py`). No dashboard file needs a hardcoded experiment name.
+Plain-language pages: [docs/experiments](../docs/experiments/index.md). The interactive **Dashboard → Experiments** tab lists every folder that has `experiment.yaml`. Each experiment has a tab per language, plus **All** on the right (the same question in every language). After you add a folder or refresh `results.json`, run `python3 dashboard/scripts/sync-experiments.py` (also invoked at the end of `sync-data.py`). No dashboard file needs a hardcoded experiment name.
 
 - Experiment 1: [`01-json-library-bakeoff/`](01-json-library-bakeoff/) · [`results.md`](01-json-library-bakeoff/results.md) · [`results.json`](01-json-library-bakeoff/results.json)
 - Experiment 2: [`02-flat-record-formats/`](02-flat-record-formats/) · [`results.md`](02-flat-record-formats/results.md) · [`results.json`](02-flat-record-formats/results.json)


### PR DESCRIPTION
## Summary
- Add an **All** tab (last on the right) on every experiment so every language shares one microsecond axis.
- Color and “Vs fastest” stay vs that language’s fastest. The All-tab glance chip table is omitted.
- README Start here: add Experiments, drop Method overview from Numbers, drop the Learn audience clause.
- Experiments docs page: **Dashboard → Experiments** button at the top, not in the body text.

## Validation
- Tests: analysis (85 passed) / python (29 passed) / javascript (10 passed) / dashboard (18 passed)
- Benchmarks: skipped (no benchmark-runner language changes)
- Error CSVs: skipped
- Analysis: not regenerated
- Dashboard: `sync-data.py` ran; gzip recompressions discarded (no payload content change for this PR)

## Notes
- Times on All are comparable on the µs axis; chips/colors remain per-language.