### PR TITLE
docs(401): compare leading serializers from timed call sites

### DIFF
--- a/docs/theory/401/c-custom-binary-vs-ubj.md
+++ b/docs/theory/401/c-custom-binary-vs-ubj.md
@@ -1,0 +1,124 @@
+# C: why custom-binary outruns the UBJSON envelope on Document
+
+## Why this article exists
+
+On this suite’s **document** fixture, one instance, in-memory buffer mode, the C entry named **custom-binary** finishes about **1.4 times** as many encode-and-decode cycles per second as **ubj**, and it writes 37 fewer bytes. Both paths are ordinary C. There is no garbage collector and no visitor framework. The gap is visible in a few dozen lines.
+
+This page places those lines side by side. After reading it you should be able to say what extra stores the UBJSON wrapper performs, and why that wrapper exists at all.
+
+Numbers are from the committed C **Results** snapshot. See [C Results](../../c/results.md).
+
+## Short answer
+
+**ubj does not use a third-party UBJSON library.** It writes the *same* packed record that custom-binary writes, then wraps that record in a small UBJSON map with two keys, `"kind"` and `"payload"`. Custom-binary skips the wrap. That is the entire race.
+
+| | custom-binary | ubj |
+|--|---------------|-----|
+| Mean encode + decode, document, *n* = 1 | **3.78 million / s** | 2.62 million / s |
+| Encode | **157 ns** | 239 ns |
+| Decode | **108 ns** | 143 ns |
+| Encoded size | **196 B** | 233 B |
+
+196 + 37 = 233. The 37 extra bytes are the envelope. The extra time is a second copy plus type tags and big-endian integers.
+
+## The winning encode: copy fields in order
+
+`c/src/serializers/ser_custom_binary.c` is a one-function wrapper:
+
+```c
+static int ser(const test_fixture_t *fx, uint8_t *buf, size_t cap, size_t *ol) {
+    return bin_write_fixture(fx, buf, cap, ol);
+}
+```
+
+`bin_write_fixture` in `c/src/ser_common.h` writes a kind byte and then the document fields with `memcpy`. Strings carry a two-byte little-endian length. There are no field names.
+
+```c
+/* c/src/ser_common.h — document case (abbreviated) */
+case TD_DOCUMENT: {
+    const document_t *d = &fx->document;
+    if (bin_wr_str(buf, cap, &o, d->id)) return -1;
+    BIN_WR_I32(buf, cap, &o, d->status);
+    if (bin_wr_str(buf, cap, &o, d->meta.region)) return -1;
+    BIN_WR_I32(buf, cap, &o, d->meta.version);
+    BIN_WR_I32(buf, cap, &o, d->item_count);
+    for (int i = 0; i < d->item_count; i++) {
+        if (bin_wr_str(buf, cap, &o, d->items[i].sku)) return -1;
+        BIN_WR_I32(buf, cap, &o, d->items[i].qty);
+        BIN_WR_I64(buf, cap, &o, d->items[i].price_minor);
+    }
+}
+```
+
+An `i32` is four host bytes:
+
+```c
+#define BIN_WR_I32(buf, cap, o, v) do { \
+    if (*(o) + 4 > (cap)) return -1; \
+    int32_t _v = (v); memcpy((buf) + *(o), &_v, 4); *(o) += 4; \
+} while (0)
+```
+
+Decode is the inverse into a `document_t` that already contains a fixed array of items (`items[V2_MAX_CHILDREN]`). There is no heap allocation on this path.
+
+**History.** This is the packed record of [Serialization 101](../101/historical_perspective.md): declare the order and the widths, then copy. Sun’s XDR (1987) did the same with big-endian integers and alignment. The C baseline here uses host byte order and two-byte lengths because the runner and the reader are the same process. It is a measurement baseline, not a public contract.
+
+## The runner-up: the same bytes, then an envelope
+
+`c/src/serializers/ser_ubj.c` first calls that same function into a 64 KiB stack buffer, then writes a UBJSON object:
+
+```c
+static int ser(const test_fixture_t *fx, uint8_t *buf, size_t cap, size_t *ol) {
+    uint8_t raw[65536]; size_t n = 0;
+    if (bin_write_fixture(fx, raw, sizeof raw, &n)) return -1;
+    uint8_t *p = buf, *end = buf + cap;
+    if (w_char(&p, end, '{')) return -1;
+    if (w_key(&p, end, "kind") || w_i32(&p, end, (int32_t)fx->kind)) return -1;
+    if (w_key(&p, end, "payload") || w_bytes(&p, end, raw, n)) return -1;
+    if (w_char(&p, end, '}')) return -1;
+    *ol = (size_t)(p - buf);
+    return 0;
+}
+```
+
+A UBJSON integer is a type letter plus a **big-endian** four-byte value:
+
+```c
+static int w_i32(uint8_t **p, uint8_t *end, int32_t v) {
+    if (w_char(p, end, 'l')) return -1;   /* type tag: int32 */
+    uint32_t uv = (uint32_t)v;
+    (*p)[0] = (uint8_t)((uv >> 24) & 0xff);
+    (*p)[1] = (uint8_t)((uv >> 16) & 0xff);
+    (*p)[2] = (uint8_t)((uv >> 8) & 0xff);
+    (*p)[3] = (uint8_t)(uv & 0xff);
+    *p += 4;
+    return 0;
+}
+```
+
+A key is that integer (the length) plus the letters of the name. The payload is a typed byte array: `[ $ U #` plus a length plus the 196 inner bytes.
+
+## Side-by-side: where the 37 bytes and the extra nanoseconds go
+
+| Extra work in ubj | What the CPU does |
+|-------------------|-------------------|
+| First `bin_write_fixture` into `raw[65536]` | The *entire* winning encode, before the envelope starts |
+| `{` `"kind"` integer `"payload"` array `}` | Type letters, two English keys, big-endian lengths |
+| `memcpy` of the 196-byte payload into the envelope | A second copy of every field |
+| Decode: scan keys with `strcmp`, then `bin_read_fixture` | The winning decode, after a parse |
+
+On a little-endian host, custom-binary’s `memcpy` of an `i32` is one unaligned store. ubj’s `w_i32` is a type byte plus four shifts. It does that for every length in the envelope, not for the inner document fields — those were already written the fast way.
+
+## What you give up
+
+custom-binary is **not** an interchange format. Another language, or another C compiler with a different `int` width, cannot be assumed to read it. The kind byte is the only self-description.
+
+ubj, even in this minimal form, is closer to a document: a reader can see that a map contains `kind` and `payload`. [UBJSON](https://ubjson.org/) (late 2000s, a binary cousin of JSON) was designed for that inspectability. The suite’s wrapper is a teaching envelope, not a full UBJSON implementation of the document fields.
+
+If you want compactness *and* a real schema in C, look at **nanopb** and **protobuf-c** on the same Results page (154 bytes, about 1.3 million cycles per second). Those paths are compared as engines in [nanopb versus protobuf-c](protobuf-c-nanopb-compare.md). They lose the stopwatch to custom-binary because they write tags and variable-length integers instead of host `memcpy`. They win as a contract.
+
+## Self-check
+
+1. Count the envelope: `{` + key `kind` + int32 + key `payload` + typed array header + 196 payload bytes + `}`. Why is the total 233, not “196 plus a few”?
+2. Why would switching `w_i32` to `memcpy` of a little-endian value *not* close most of the gap?
+3. Name one reason a production service should still prefer nanopb to custom-binary.

--- a/docs/theory/401/cpp-bitsery-vs-yas.md
+++ b/docs/theory/401/cpp-bitsery-vs-yas.md
@@ -1,0 +1,127 @@
+# C++: why Bitsery outruns YAS on Document
+
+## Why this article exists
+
+On this suite’s **document** fixture, one instance, in-memory buffer mode, **Bitsery** finishes about **1.3 times** as many encode-and-decode cycles per second as **YAS**, and it writes 84 fewer bytes. Both libraries omit field names. Both store integers at fixed width. The gap is not “binary versus text.” It is how each library writes *lengths*, whether it emits a header, and whether it reuses a buffer.
+
+This page compares the two C++ call sites and the library code they invoke.
+
+Numbers are from the committed C++ **Results** snapshot. See [C++ Results](../../cpp/results.md).
+
+## Short answer
+
+Bitsery writes a positional little-endian image with **one-byte length prefixes** for short strings and lists, into a **reused** `std::vector`. YAS writes the same fields with **eight-byte lengths** and a **seven-byte archive header**, and it constructs a fresh 20 KiB stream on every encode.
+
+| | Bitsery 5.2.4 | YAS (binary) |
+|--|---------------|--------------|
+| Mean encode + decode, document, *n* = 1 | **1.10 million / s** | 0.83 million / s |
+| Encode | **396 ns** | 598 ns |
+| Decode | **515 ns** | 601 ns |
+| Encoded size | **190 B** | 274 B |
+
+190 + 84 = 274. Eleven short lengths that Bitsery stores in one byte each cost eight bytes in YAS (11 × 7 extra) plus a seven-byte header.
+
+## The two timed call sites
+
+**Bitsery** (`cpp/src/serializers/ser_bitsery.cpp`) declares the layout as a sequence of fixed-width operations. There is no name in the output:
+
+```cpp
+template <typename S>
+void serialize(S& s, bench::DocumentItem& m) {
+  s.text1b(m.sku, 256); s.value4b(m.qty); s.value8b(m.price_minor);
+}
+template <typename S>
+void serialize(S& s, bench::Document& m) {
+  s.text1b(m.id, 256); s.value4b(m.status); s.object(m.meta); s.container(m.items, 10000);
+}
+```
+
+The timed encode clears a member buffer and writes into it:
+
+```cpp
+buf_.clear();
+bitsery::Serializer<OutputAdapter> ser{OutputAdapter{buf_}};
+ser.object(v);
+auto written = ser.adapter().writtenBytesCount();
+return {buf_.begin(), buf_.begin() + written};
+```
+
+**YAS** (`cpp/src/serializers/ser_yas.cpp`) uses `YAS_OBJECT_NVP`. In binary mode the names are *not* written — they exist so the same macro can also speak JSON — but every `yas::save` builds a new stream:
+
+```cpp
+constexpr auto kFlags = yas::mem | yas::binary;
+auto buf = yas::save<kFlags>(YAS_OBJECT_NVP(
+    "document", ("id", v.id), ("status", v.status), ("region", v.meta.region),
+    ("version", v.meta.version), ("items", v.items)));
+return {buf.data.get(), buf.data.get() + buf.size};
+```
+
+Inside `yas::save` (library header `yas/serialize.hpp`) that is:
+
+```cpp
+yas::mem_ostream os;                    // default reserve: 20 KiB
+yas::binary_oarchive<...> oa(os);
+oa(std::forward<Types>(args)...);
+return os.get_shared_buffer();
+```
+
+## What Bitsery stores
+
+`value4b` / `value8b` copy four or eight bytes. On a little-endian host there is no swap (`bitsery/details/adapter_common.h`). A string is a **compact size** plus the characters:
+
+```cpp
+// bitsery/details/adapter_common.h
+void writeSize(Writer& w, const size_t size)
+{
+  if (size < 0x80u) {
+    w.template writeBytes<1>(static_cast<uint8_t>(size));
+  } else if (size < 0x4000u) { /* two bytes */ }
+    else { /* four bytes */ }
+}
+```
+
+For this document every string and the items list is shorter than 128, so each count is **one byte**. Integers stay full width. There is no archive banner.
+
+**History.** Bitsery (M. Pusz / bitsery authors, late 2010s) is a C++ take on the packed record: you state the widths in the `serialize` function, the compiler inlines them, and the adapter copies. It is closer to Speedy in Rust than to Protocol Buffers.
+
+## What YAS stores
+
+Without the `compacted` flag, every sequence length is a `uint64_t`:
+
+```cpp
+// yas/detail/io/binary_streams.hpp
+void write_seq_size(std::size_t size) {
+    const auto tsize = __YAS_SCAST(std::uint64_t, size);
+    write(tsize);
+}
+```
+
+Every archive also writes a seven-byte header (`"yas"` plus flags) unless `no_header` is set. The wrapper does not set that flag.
+
+This document has eleven sizes (id, region, items, and eight SKUs). Bitsery: 11 bytes. YAS: 88 bytes. Plus 7 bytes of header. That is the 84-byte gap.
+
+YAS (niXman, mid-2010s) is a general archive library in the Boost.Serialization tradition: one set of macros, several backends (binary, JSON, text). Generality shows up as a header, fat lengths, and a new stream object. The binary backend is not slow because it prints text. It is slower because it was built as an *archive*, not as a one-record dump.
+
+## Side-by-side
+
+| Step | Bitsery | YAS binary as configured here |
+|------|---------|-------------------------------|
+| Header | None | 7 bytes every message |
+| `status` (`int32`) | 4 bytes | 4 bytes |
+| Length of `id` | 1 byte if `< 128` | 8 bytes |
+| Buffer | `buf_.clear()` on a member `vector` | New 20 KiB `mem_ostream` |
+| Dispatch | One argument-dependent `serialize()` | `operator&` on a generated tuple of named values |
+
+## What you give up
+
+Bitsery’s layout is a private contract. There are no field numbers. Adding a field in the middle breaks old readers. YAS can grow into JSON with the same macros; Bitsery cannot. If you need evolution, the C++ Results page’s **protobuf** and **Avro** rows are the relevant comparison, not this pair.
+
+A fairer YAS configuration would add `yas::compacted` and `yas::no_header`. This suite does not. The measured gap is therefore “Bitsery’s defaults versus YAS’s archive defaults,” which is how both libraries are commonly first used.
+
+A JSON row on the same Results page is a different lesson: [what the simdjson row times](cpp-simdjson-wrapper.md).
+
+## Self-check
+
+1. Why does `value4b` for `qty` not explain the 84-byte size gap?
+2. If every SKU were 200 characters long, which part of Bitsery’s `writeSize` would change, and would YAS change at all?
+3. Name one wrapper change that would shrink YAS’s time without changing Bitsery.

--- a/docs/theory/401/cpp-simdjson-wrapper.md
+++ b/docs/theory/401/cpp-simdjson-wrapper.md
@@ -1,0 +1,104 @@
+# C++: what the simdjson row is actually timing
+
+## Why this article exists
+
+simdjson is famous for parsing JSON at very high speed (Geoff Langdale and Daniel Lemire, papers 2018–2019). On this suite’s **document** fixture, one instance, the row named **simdjson** reports encode at **217 nanoseconds** and decode at **12.6 microseconds**. Glaze, a C++ JSON library that really encodes and decodes the document, sits at 706 ns encode and 1.94 µs decode, and finishes about **4.8 times** as many total cycles per second.
+
+A results table invites the wrong sentence: “simdjson is slow to decode.” This page opens the wrapper. After reading it you should be able to say what those 217 ns copy, why decode calls **two** JSON parsers, and how to read any row that sets `native_kind` to `dom`.
+
+Numbers are from the committed C++ **Results** snapshot. See [C++ Results](../../cpp/results.md).
+
+## Short answer
+
+The simdjson wrapper does **not** time simdjson encode. It does **not** time “simdjson parse into a `Document`.”
+
+1. **Encode** copies a `std::string` that `prepare` built with **nlohmann::json** (`value_to_json(...).dump()`). 217 ns is a `vector` construction from that cache.
+2. **Decode** runs simdjson’s DOM parse, then `simdjson::minify`, then **nlohmann::json::parse** on the minified text, then `json_to_value`. The famous parser is the first third of a longer pipeline.
+
+Glaze writes JSON from the C++ struct on the clock and reads JSON back into that struct. That is why Glaze wins the total while “losing” the encode column.
+
+| | simdjson (this wrapper) | Glaze 2.9.5 | nlohmann |
+|--|-------------------------|-------------|----------|
+| Mean encode + decode, document, *n* = 1 | 78 thousand / s | **378 thousand / s** | 83 thousand / s |
+| Encode | **217 ns** (copy of cached text) | 706 ns (real JSON write) | 3.22 µs |
+| Decode | **12.6 µs** (parse + minify + parse + map) | **1.94 µs** | 8.84 µs |
+| Encoded size | **458 B** | **458 B** | **458 B** |
+
+Equal size: all three emit compact JSON. Unequal clocks: only Glaze and nlohmann time a full codec.
+
+## The timed functions
+
+`cpp/src/serializers/ser_json.cpp`, class `SimdjsonSer`:
+
+```cpp
+void prepare(const Fixture& fx) override {
+    type_id_ = fx.type_id;
+    n_ = fx.instance_count;
+    cached_json_ = value_to_json(fx.value).dump();   // nlohmann, untimed
+}
+
+std::vector<uint8_t> serialize_bytes(const Fixture&) override {
+    return std::vector<uint8_t>(cached_json_.begin(), cached_json_.end());
+}
+
+Value deserialize_bytes(const std::vector<uint8_t>& data) override {
+    simdjson::padded_string ps(
+        reinterpret_cast<const char*>(data.data()), data.size());
+    simdjson::dom::element el = parser_.parse(ps);   // simdjson — real
+    std::string minified = simdjson::minify(el);     // extra pass
+    auto j = nlohmann::json::parse(minified);        // second parser
+    return json_to_value(j, type_id_, n_);           // DOM → domain
+}
+```
+
+The comment above the class states the intent: “DOM parse (library strength); ser = prepared minified JSON.” The leaderboard does not repeat that sentence. Students who only read the table will mis-rank the library.
+
+**Glaze**, for contrast (`cpp/src/serializers/ser_glaze.cpp`), writes on the clock:
+
+```cpp
+std::vector<uint8_t> serialize_bytes(const Fixture&) override {
+    std::visit([&](const auto& v) { write_json_into(v, buf_); }, value_);
+    return std::vector<uint8_t>(buf_.begin(), buf_.end());
+}
+```
+
+`write_json_into` is Glaze’s compile-time walk of the struct. Decode is `decode_json` into the suite `Value`. No second parser.
+
+## Why decode is 12.6 µs
+
+Four stages sit inside one timed function:
+
+| Stage | What it does | Why it is there |
+|-------|----------------|-----------------|
+| `parser_.parse` | simdjson builds a DOM | The library’s advertised strength |
+| `minify` | Walk that DOM back to compact text | Adapter: nlohmann wants a string |
+| `nlohmann::json::parse` | Parse the same JSON **again** | Adapter: suite mapping is written for nlohmann |
+| `json_to_value` | Copy DOM fields into `bench::Document` | Fidelity: the suite compares domain values |
+
+simdjson is doing its job in stage one. Stages two and three exist because this wrapper treats simdjson as a **front end** to the nlohmann document model. That is a legitimate integration pattern. It is not a measurement of simdjson decode into an application struct.
+
+nlohmann alone (8.84 µs decode) parses once and maps once. Glaze (1.94 µs) never builds a generic document tree.
+
+## How this happens in other languages
+
+JavaScript’s row `simdjson-parse+JSON.stringify` is the same shape: a parse-focused library plus a second tool to produce suite values. Decode there is about 15 µs. The lesson travels.
+
+The [google-protobuf encode cache](javascript-json-vs-protobuf.md) is the sibling warning on the encode side: if `prepare` does the real work, the encode column measures a copy.
+
+## How to read any “DOM” row
+
+When `native_kind` is `dom` (this wrapper reports exactly that), ask:
+
+1. Is encode a real write, or a copy of text built in `prepare`?
+2. Does decode stop at the library’s document model, or does it parse again into another model?
+3. Is there a struct-backed JSON row (here: Glaze) that times the path an application would actually write?
+
+If the answers are “copy,” “parse again,” and “yes,” do not use the row to rank the famous library against Glaze.
+
+**History.** simdjson answered a 2010s question: can we find `{`, `}`, and `"` in a JSON byte stream with one processor instruction on many bytes? The papers are about **parse**. They are not about “replace nlohmann in a benchmark runner.” Using the parse as a stage in a longer pipeline is normal. Reporting that pipeline under the name `simdjson` is what this page exists to unpack.
+
+## Self-check
+
+1. What does the 217 ns encode allocate, and what library produced the characters it copies?
+2. List the two `parse` calls inside `deserialize_bytes`. Which one is simdjson?
+3. You want to measure “simdjson into `bench::Document`.” Which two stages would you delete or replace, and what would you expect to happen to the 12.6 µs?

--- a/docs/theory/401/csharp-binarypack-vs-bond.md
+++ b/docs/theory/401/csharp-binarypack-vs-bond.md
@@ -1,0 +1,111 @@
+# C#: why BinaryPack outruns Bond Fast on Document
+
+## Why this article exists
+
+On this suite’s **document** fixture, one instance, **BinaryPack** finishes more encode-and-decode cycles per second than **Microsoft Bond Fast**. Both omit JSON field names. Both compile a specialized writer once. The remaining difference is what that writer *puts on the wire* and how the runner calls it.
+
+This page compares the two timed wrappers and the library code they invoke. After reading it you should be able to point at Bond’s per-field type-and-identifier prefix and at BinaryPack’s positional stores.
+
+Numbers are from the committed C# **Results** snapshot. The C# “string” path Base64-encodes binary codecs; compare ranks, not raw byte sizes against other languages. See [C# Results](../../c-sharp/results.md).
+
+## Short answer
+
+BinaryPack emits **raw fields in declaration order**. Bond Fast emits **a type byte and a 16-bit field identifier in front of every value**. Both specialize the encode function ahead of time. Bond pays extra stores (and extra reads) on every field in exchange for a skip rule: a reader can ignore an unknown identifier.
+
+| | BinaryPack | Bond Fast |
+|--|------------|-----------|
+| Mean encode + decode, document, *n* = 1 (string path) | **about 190–210 thousand / s** | about 160–190 thousand / s |
+| Wire idea | Positional, no identifiers | Tagged: type + id + value |
+| Specialization | Dynamic IL, once per `T` | Expression trees, once per type |
+| Evolution | Breaks if you reorder fields | Unknown ids can be skipped |
+
+## The two timed call sites
+
+**BinaryPack** binds a closed generic once and, on the clock, serializes then Base64-encodes (`c-sharp/src/Serializers/BinaryPackSerializerSer.cs`):
+
+```csharp
+public override string Serialize(object serializable)
+    => Convert.ToBase64String(_serBytes(serializable));
+```
+
+`_serBytes` is `BinaryConverter.Serialize<T>` for the prepared `T`.
+
+**Bond Fast** builds `Serializer<FastBinaryWriter<OutputBuffer>>` once, then allocates a 2 KiB `OutputBuffer` on every encode (`c-sharp/src/Serializers/BondFastSerializer.cs`):
+
+```csharp
+public override string Serialize(object serializable)
+{
+    Ensure();
+    var output = new OutputBuffer(2 * 1024);
+    _serializer.Serialize(serializable, new FastBinaryWriter<OutputBuffer>(output));
+    return Convert.ToBase64String(output.Data.Array, output.Data.Offset, output.Data.Count);
+}
+```
+
+Both pay Base64. That cost is shared. It does not explain the rank.
+
+## What BinaryPack generates
+
+[BinaryPack](https://github.com/Sergio0694/BinaryPack) (Sergio Pedri) emits IL for `ObjectProcessor<T>`. Unmanaged members become a store of the bits. There is no field number.
+
+```csharp
+// ObjectProcessor<T> — conceptual form of the generated write
+// writer.Write(obj.Property);
+il.EmitLoadArgument(Arguments.Write.RefBinaryWriter);
+il.EmitLoadArgumentForMemberRead(Arguments.Write.T, memberInfo);
+il.EmitReadMember(memberInfo);
+il.EmitCall(KnownMembers.BinaryWriter.WriteT(memberInfo.GetMemberType()));
+```
+
+The public entry constructs a pooled writer and copies the span out (`BinaryConverter.Serialize<T>`). After the first call, encode is a specialized delegate, not reflection.
+
+The README is explicit: the format is **not** version-resilient. That is the Speedy / Bitsery / custom-binary idea in a .NET setting.
+
+## What Bond Fast writes
+
+[Microsoft Bond](https://github.com/microsoft/bond) (open-sourced 2015, after internal use at Microsoft) is a schema-driven stack in the Protocol Buffers family. **Fast binary** is the simpler of Bond’s two binary protocols: little-endian values, no variable-length integers. Compact binary adds those. This runner uses Fast.
+
+Every field on the wire is:
+
+```text
+.------.----.----------.
+| type | id |  value   |
+```
+
+The writer is three stores before the payload:
+
+```csharp
+// cs/src/core/protocols/FastBinary.cs
+public void WriteFieldBegin(BondDataType type, ushort id, Metadata metadata)
+{
+    output.WriteUInt8((byte) type);
+    output.WriteUInt16(id);
+}
+```
+
+The serializer itself is specialized. `Serializer<W>` compiles an `Action<object, W>` from expression trees (`cs/src/core/Serializer.cs`). The runner skips Bond’s code generator (`BondSkipCodegen=true`) and uses that runtime compile. So Bond is *not* reflecting on every call. It is still writing three extra bytes per field, and it still allocates a fresh `OutputBuffer` in this wrapper.
+
+**History.** Bond exists because Microsoft needed a schema that many languages could share, with a defined way to add fields. The type-and-id prefix is the same pressure that produced ASN.1 tags in 1984 and Protocol Buffers field numbers in the 2000s. BinaryPack exists because some .NET services only ever talk to themselves and want the processor to store, not to tag.
+
+## Side-by-side: one `int` field
+
+| Step | BinaryPack | Bond Fast |
+|------|------------|-----------|
+| How the field is found | Generated IL reads the property | Compiled action reads the property |
+| Bytes before the value | None | 1 (type) + 2 (id) |
+| The value | 4 bytes, little-endian | 4 bytes, little-endian |
+| Unknown-field rule | None | Reader can skip by type |
+
+Eight line items, each with three fields, plus the document header: the tag tax is tens of bytes and a comparable number of extra stores.
+
+## Honesty
+
+1. **Base64 is on the clock** for both. Do not compare these sizes to Rust or C byte counts.
+2. **MemoryPack** is also specialized (source-generated formatters on the models). This runner calls the non-generic `MemoryPackSerializer.Serialize(Type, object)` API, so the measured MemoryPack row is not the fastest MemoryPack path. That is why this page uses Bond Fast as the schema-driven counterpart.
+3. Bond Compact would change the integer encoding. It is a different row on the Results page.
+
+## Self-check
+
+1. If you removed Base64 from both wrappers, would you expect the *rank* to change? Why or why not?
+2. Why can a Bond reader skip an unknown field, and why can a BinaryPack reader not?
+3. Which historical format does Bond Fast most resemble, and which does BinaryPack most resemble?

--- a/docs/theory/401/go-kelindar-vs-avro.md
+++ b/docs/theory/401/go-kelindar-vs-avro.md
@@ -1,0 +1,110 @@
+# Go: why kelindar/binary edges hamba/avro on Document
+
+## Why this article exists
+
+On this suite’s **document** fixture, one instance, in-memory buffer mode, **kelindar/binary** and **hamba/avro** finish within about **10 percent** of each other. Their messages are almost the same size (113 bytes versus 116). Both omit field names. Both cache a per-type encode plan. This pair is useful because the *idea* is the same and the remaining difference is visible in the walk each library performs.
+
+This page compares the two timed wrappers and the library code they invoke.
+
+Numbers are from the committed Go **Results** snapshot. See [Go Results](../../go/results.md).
+
+## Short answer
+
+Both libraries write **values in a fixed order** with variable-length integers. kelindar/binary walks a cached list of field codecs. hamba/avro walks a cached list of field encoders that is *keyed by an Avro schema* as well as by the Go type. The extra schema match, and Avro’s rules for defaults, are the small time gap. The extra Avro metadata that is *not* on the wire is why the sizes stay within three bytes.
+
+| | kelindar/binary | hamba/avro |
+|--|-----------------|------------|
+| Mean encode + decode, document, *n* = 1 | **476 thousand / s** | 436 thousand / s |
+| Encoded size | **113 B** | 116 B |
+| Plan | Cached `reflect` codecs | Cached `reflect2` encoders + schema |
+| Names on the wire | No | No |
+
+Neither path generates Go source. “Code generation” in the 201 sense is not what these two packages do.
+
+## The two timed call sites
+
+**kelindar/binary** (`go/serializers/kelindar_binary.go`) reuses an `Encoder` and a `bytes.Buffer`. Timed encode resets both, writes `fx.Value`, then copies the bytes out:
+
+```go
+func (s *kelindarBinary) SerializeBytes(fx model.Fixture) ([]byte, error) {
+	s.buf.Reset()
+	s.enc.Reset(&s.buf)
+	if err := s.enc.Encode(fx.Value); err != nil {
+		return nil, err
+	}
+	out := make([]byte, s.buf.Len())
+	copy(out, s.buf.Bytes())
+	return out, nil
+}
+```
+
+**hamba/avro** (`go/serializers/avro.go`) parses the schema once (untimed cache) and then:
+
+```go
+func (s *hambaAvro) SerializeBytes(fx model.Fixture) ([]byte, error) {
+	return s.api.Marshal(s.schema, fx.Value)
+}
+```
+
+`Marshal` borrows a writer from a pool, encodes, and copies the result out (hamba `config.go`). Both wrappers therefore pay one copy into a fresh `[]byte`. That cost is shared.
+
+## What kelindar walks
+
+[kelindar/binary](https://github.com/kelindar/binary) (Roman Atachiants) scans a Go type once into a `sync.Map` of codecs (`scanner.go`). A struct codec is a slice of field index plus child codec. Encode is a loop:
+
+```go
+// codecs.go — reflectStructCodec.EncodeTo
+func (c reflectStructCodec) EncodeTo(e *Encoder, rv reflect.Value) (err error) {
+	for _, i := range c {
+		if err = i.Codec.EncodeTo(e, rv.Field(i.Index)); err != nil {
+			return
+		}
+	}
+	return
+}
+```
+
+There is no field name and no field number. Integers are zigzag variable-length integers. Strings are `uvarint(length)` plus bytes. The README states the format is Go-only and has no versioning story.
+
+## What hamba walks
+
+[hamba/avro](https://github.com/hamba/avro) implements [Apache Avro](https://avro.apache.org/) (Doug Cutting and colleagues, 2009). The data bytes of a record are the fields in **schema** order. The schema itself lives beside the file or in a registry, not in every message.
+
+`Writer.WriteVal` looks up an encoder by **schema fingerprint and Go type**, compiling one on the first use:
+
+```go
+// codec.go
+func (w *Writer) WriteVal(schema Schema, val any) {
+	encoder := w.cfg.getEncoderFromCache(schema.Fingerprint(), reflect2.RTypeOf(val))
+	if encoder == nil {
+		encoder = w.cfg.EncoderOf(schema, reflect2.TypeOf(val))
+	}
+	encoder.Encode(reflect2.PtrOf(val), w)
+}
+```
+
+A record encoder is a fixed slice of unsafe field accessors. Integers are Avro zigzag varints, the same family kelindar uses. That is why 113 and 116 bytes sit together: both layouts are “values only, compact integers.” The three extra bytes are Avro’s slightly different integer and array-block rules, not field names.
+
+The extra *time* is the schema-shaped walk: fingerprint lookup, per-field Avro encoders, and the rules Avro needs so that a later reader can apply a *different* schema. kelindar has no such rules.
+
+## Side-by-side
+
+| Step | kelindar/binary | hamba/avro |
+|------|-----------------|------------|
+| First call | `scan(t)` into a codec list | `EncoderOf(schema, typ)` into a field list |
+| Later calls | `EncodeTo` on that list | `Encode` on that list |
+| Integer | Zigzag varint | Avro zigzag varint |
+| Who knows the field order | The Go struct | The Avro schema (must match the struct) |
+| Another language | No | Yes, if it has the schema |
+
+## What you give up
+
+kelindar/binary is the faster private dump. It is not a contract you can hand to Java or Python.
+
+hamba/avro is three percent larger and about ten percent slower on this fixture, and it is a format with twenty years of data-platform use. If the document will sit in a log for years, Avro’s schema resolution is the reason to pay those nanoseconds. See [201 schema evolution](../201/schema-evolution.md) and [301 schema registries](../301/schema-registries.md).
+
+## Self-check
+
+1. Why does “both omit names” predict similar sizes but not identical times?
+2. kelindar is sometimes described as “generated.” What does the source actually generate, and when?
+3. Which library would you pick if a Python reader must consume the same bytes next year?

--- a/docs/theory/401/index.md
+++ b/docs/theory/401/index.md
@@ -1,6 +1,6 @@
 # Serialization 401: Implementing Contemporary Serializers
 
-This course teaches how Protocol Buffers works at the byte level. You will also learn how three language libraries turn those bytes into ordinary values and back again.
+This course teaches how Protocol Buffers works at the byte level. You will also learn how three language libraries turn those bytes into ordinary values and back again. A later set of articles then opens the **timed call sites** of the libraries that lead on this suite’s **document** fixture, one language at a time, and follows those calls into the library source.
 
 | Jump | |
 |------|--|
@@ -8,9 +8,9 @@ This course teaches how Protocol Buffers works at the byte level. You will also 
 | **Sibling** | [301 production judgment](../301/index.md) — *whether / which*, not *how bytes* |
 | **Suite** | [Add a serializer](../../analysis/ADDING_A_SERIALIZER.md) · [Dashboard](../../dashboard/) |
 
-**Protocol Buffers** is a popular schema-driven binary format. You describe message shapes in a `.proto` file. Tools then generate code that can encode and decode those messages. This elective walks through that wire format first. It then follows the paths taken by Python, Rust, and C libraries. A small hands-on lab connects the theory to code you write yourself.
+**Protocol Buffers** is a popular schema-driven binary format. You describe message shapes in a `.proto` file. Tools then generate code that can encode and decode those messages. This elective walks through that wire format first. It then follows the paths taken by Python, Rust, and C libraries. A small hands-on lab connects the theory to code you write yourself. After that, nine language articles compare the libraries that lead on this suite’s document fixture by reading their timed functions, not by repeating the 201 format essays.
 
-The course is for people who want to implement, debug, or deeply integrate codecs. It is not only for people who choose a format from a list of options. You do not need to have written a serializer from scratch already. You do need intermediate reading comfort in at least one of Python, Rust, or C. You also need a working memory of schema-dependent binary ideas from Serialization 201.
+The course is for people who want to implement, debug, or deeply integrate codecs. It is not only for people who choose a format from a list of options. You do not need to have written a serializer from scratch already. You do need intermediate reading comfort in at least one of the languages used in this suite. You also need a working memory of schema-dependent binary ideas from Serialization 201.
 
 ## Who this is for
 
@@ -37,6 +37,7 @@ By the end of this course you should be able to:
 3. **Contrast** the classic C runtime (protobuf-c) with the embedded-oriented design of **nanopb**. Nanopb is a C library that prefers static size budgets over free-form heap trees.
 4. **Build** a mini subset encoder/decoder. **Validate** it against golden byte sequences and at least one official parser.
 5. **State** deliberate omissions honestly. This lab is a teaching subset. It is not a full production Protocol Buffers implementation.
+6. **Read two library call paths in one language** and explain, from the source, why one finishes more encode-and-decode cycles per second (or writes fewer bytes) on this suite’s **document** fixture.
 
 ## How this course fits the program
 
@@ -63,6 +64,30 @@ The table below lists every article in this course. For each article, it states 
 | [C: nanopb vs protobuf-c](protobuf-c-nanopb-compare.md) | Choose a heap-friendly C engine versus a static-budget C engine for a deployment |
 | [Same bytes, three runtimes](protobuf-cross-language-fidelity.md) | Design interop matrix tests; separate bit-identical encodings from logical fidelity |
 
+### Language winners in code
+
+These articles do not repeat the 201 “text versus binary” essays. Each one opens two **timed call sites** in this repository, then follows those calls into the library. The fixture is **document**, one instance, unless the article says otherwise. Measured numbers live on language **Results** pages.
+
+The first nine pages take the speed or size leader in each language and ask why it leads. The later pages hold one variable still: same library and two encodings, same JSON and two engines, same Protocol Buffers bytes and three JavaScript runtimes, an in-place crate used as a classical decoder, and a Results row whose timer does not measure the famous library.
+
+| Article | You should be able to… |
+|---------|------------------------|
+| [Python: msgspec-msgpack vs orjson](python-msgspec-vs-orjson.md) | Show why a positional MessagePack Struct decodes faster than Rust JSON over dictionaries |
+| [Python: msgspec JSON vs MessagePack](python-msgspec-json-vs-msgpack.md) | Hold the library still and isolate JSON tokens from MessagePack tags |
+| [Python: orjson vs json](python-orjson-vs-json.md) | Show why the same 448-byte JSON can differ by a factor of five |
+| [Rust: Speedy vs Bincode](rust-speedy-vs-bincode.md) | Show why generated `write_to` plus fixed-width integers beats Serde plus variable-length integers |
+| [Rust: Speedy vs Postcard](rust-speedy-vs-postcard.md) | Show compactness as a width choice that can stay on Serde |
+| [Rust: rkyv vs Speedy](rust-rkyv-vs-speedy.md) | Show that in-place access only helps if the timed path uses it |
+| [C: custom-binary vs ubj](c-custom-binary-vs-ubj.md) | Show that ubj is the same packed record plus a 37-byte envelope and a second copy |
+| [C++: Bitsery vs YAS](cpp-bitsery-vs-yas.md) | Show why one-byte lengths and a reused buffer beat eight-byte lengths and a 20 KiB stream |
+| [C++: the simdjson row](cpp-simdjson-wrapper.md) | Read a Results row whose encode is a cache copy and whose decode parses twice |
+| [C#: BinaryPack vs Bond Fast](csharp-binarypack-vs-bond.md) | Show positional IL stores versus a type-and-identifier prefix on every field |
+| [Go: kelindar/binary vs hamba/avro](go-kelindar-vs-avro.md) | Show two cached positional plans, and why the Avro schema walk costs a little more |
+| [Java: Protostuff vs protobuf-java](java-protostuff-vs-protobuf.md) | Show why equal 155-byte messages still differ: POJO merge versus generated `parseFrom` |
+| [JavaScript: JSON vs google-protobuf](javascript-json-vs-protobuf.md) | Show that timed protobuf encode is a cached `Buffer`, and that `JSON.parse` beats a JS tag loop |
+| [JavaScript: three Protobuf engines](javascript-three-protobufs.md) | Compare google-protobuf, protobufjs, and protobuf-es on the same 155 bytes |
+| [Swift: FlatBuffers vs SwiftProtobuf](swift-flatbuffers-vs-protobuf.md) | Show why vtable loads can beat a smaller tag stream |
+
 **Suggested path.** This order matches the self-check below. The side navigation lists the same pages.
 
 1. [Wire format](protobuf-wire-format.md)
@@ -70,6 +95,7 @@ The table below lists every article in this course. For each article, it states 
 3. [Python](protobuf-python.md) → [Rust](protobuf-rust-prost.md) → [C protobuf-c](protobuf-c-protobuf-c.md)
 4. [nanopb compare](protobuf-c-nanopb-compare.md)
 5. [Cross-language fidelity](protobuf-cross-language-fidelity.md)
+6. One language-winner article in a language you read fluently (table above)
 
 The flagship schema in this benchmark suite is `schemas/v2/protobuf/benchmark_v2.proto`. Teaching pages intentionally use a much smaller message called **MiniUser**. MiniUser is not the suite schema. It exists so you can study hex dumps without drowning in fields.
 
@@ -107,7 +133,7 @@ The program-wide rules still apply. There are no universal winners. Implementati
 1. **Wire truth is shared; runtimes differ.** Python, Rust, and C can all speak the same binary layout. They can still own buffers differently.
 2. **The subset lab labels its omissions.** Packed repeated fields, zigzag signed integers, maps, oneofs, and full production hardening are out of scope on purpose.
 3. **Suite benchmark runners illustrate integration.** They are not the reference design for how you should structure production Protocol Buffers.
-4. **Results are optional cost context.** Speed tables are not the focus of this course.
+4. **Results are optional cost context.** Speed tables are not the focus of the Protocol Buffers sequence. The language-winner articles use one Results snapshot so you can attach a number to a line of code. They do not crown a universal library.
 5. **Hostile input is a 301 topic.** For operational controls on untrusted payloads, see [301 untrusted input](../301/untrusted-input.md). Codec-side bounds still belong in every decoder. Examples include truncated varints and overlong lengths.
 6. **Language tours are parallel, not ranked.** This course does not crown “Rust wins.”
 
@@ -119,6 +145,7 @@ Use the following checklist to test yourself after you finish the modules.
 2. Explain pack/unpack **ownership** in one of Python, Rust, or C. Who allocates? Who frees? What must stay valid during the call?
 3. State when **nanopb** is preferable to **protobuf-c**, and when the reverse is true. See [nanopb compare](protobuf-c-nanopb-compare.md).
 4. Design a three-language encode/decode **matrix test**. Say when bit-identity (`memcmp` of encodings) is required. Say when logical equality is enough. See [cross-language fidelity](protobuf-cross-language-fidelity.md).
+5. Open one language-winner article. Quote the two timed functions. State whether the speed gap is a **format** difference, an **implementation** difference, or a **runner** difference (work moved into `prepare`).
 
 ## Where to go next
 

--- a/docs/theory/401/java-protostuff-vs-protobuf.md
+++ b/docs/theory/401/java-protostuff-vs-protobuf.md
@@ -1,0 +1,119 @@
+# Java: why Protostuff outruns protobuf-java on Document
+
+## Why this article exists
+
+On this suite’s **document** fixture, one instance, in-memory buffer mode, **Protostuff** and **protobuf-java** write the **same number of bytes** (155). Protostuff still finishes more encode-and-decode cycles per second. When two libraries emit the same size, the gap cannot be “compact versus verbose.” It has to be the object they build and the path they take to build it.
+
+This page compares the two timed wrappers and the write/parse loops they call.
+
+Numbers are from the committed Java **Results** snapshot. See [Java Results](../../java/results.md).
+
+## Short answer
+
+**Encode:** protobuf-java is often *faster*. The runner converts the domain object to a generated message in untimed `prepare`, then times `toByteArray()` on that prepared message.
+
+**Decode:** Protostuff is much faster. It allocates a plain suite `Document` with public fields and fills those fields. protobuf-java’s `parseFrom` builds an immutable generated graph (builders, bit fields, UTF-8 checks). The runner does **not** time the later copy back to the domain type.
+
+Protostuff wins the *total* because decode dominates.
+
+| | Protostuff | protobuf-java | jsoniter |
+|--|------------|---------------|----------|
+| Mean encode + decode, document, *n* = 1 | **59 thousand / s** | 36 thousand / s | 49 thousand / s |
+| Encoded size | **155 B** | **155 B** | 440 B |
+| Timed encode input | Domain POJO | Prepared generated message | Domain POJO |
+| Timed decode output | Domain POJO | Generated message | Domain POJO |
+
+jsoniter is second on this fixture because a generated JSON encoder is fast — and then it writes 440 bytes of names. It loses as the payload grows.
+
+## The two timed call sites
+
+**Protostuff** (`java/src/main/java/benchmark/serializers/ProtostuffSer.java`) caches a `RuntimeSchema` and a `LinkedBuffer`:
+
+```java
+public void prepare(Fixture fx) {
+    schema = (Schema<Object>) (Schema<?>) RuntimeSchema.getSchema(elementClass);
+    buffer.clear();
+}
+public byte[] serializeBytes(Fixture fx) {
+    buffer.clear();
+    return ProtostuffIOUtil.toByteArray(fx.value, schema, buffer);
+}
+public Object deserializeBytes(byte[] data) {
+    Object msg = schema.newMessage();
+    ProtostuffIOUtil.mergeFrom(data, msg, schema);
+    return msg;
+}
+```
+
+**protobuf-java** (`java/src/main/java/benchmark/serializers/ProtobufSer.java`) does the domain-to-proto mapping *before* the clock:
+
+```java
+public void prepare(Fixture fx) {
+    prepared = toProto(fx);
+    parser = prepared.getParserForType();
+}
+public byte[] serializeBytes(Fixture fx) {
+    return prepared.toByteArray();
+}
+public Object deserializeBytes(byte[] data) {
+    return parser.parseFrom(data);
+}
+```
+
+There is no `Message.clear()` / reuse of a single builder. Each decode allocates a new generated message.
+
+## Why the sizes match
+
+The suite `.proto` numbers document fields `id = 1`, `status = 2`, `meta = 3`, `items = 4`. Protostuff’s `RuntimeSchema.createFrom` assigns tags in **declaration order**, which on `benchmark.model.v2.Document` is the same order. Both write Protocol-Buffers-style tags and variable-length integers.
+
+The wrapper uses `ProtostuffIOUtil` (Protostuff’s own grouping for nested messages), not `ProtobufIOUtil`. For these small nested lengths a group end-byte and a length prefix happen to occupy one byte each, so the totals land on 155.
+
+Generated protobuf write (length-delimited nested messages):
+
+```java
+// target/generated-sources/.../Document.java
+public void writeTo(CodedOutputStream output) {
+    if (!isStringEmpty(id_)) { writeString(output, 1, id_); }
+    if (status_ != 0) { output.writeInt32(2, status_); }
+    if ((bitField0_ & 1) != 0) { output.writeMessage(3, getMeta()); }
+    for (int i = 0; i < items_.size(); i++) {
+        output.writeMessage(4, items_.get(i));
+    }
+}
+```
+
+Protostuff write is a cached field list:
+
+```java
+// RuntimeSchema.writeTo
+public final void writeTo(Output output, T message) {
+    for (Field<T> f : getFields())
+        f.writeTo(output, message);
+}
+```
+
+## Why encode favours protobuf-java here
+
+`toByteArray()` on a prepared immutable message uses a memoized size and writes once into `new byte[size]` (`AbstractMessageLite`). Protostuff must walk public fields of a live POJO through runtime accessors, even with a cached schema. The `LinkedBuffer` avoids some allocation; it does not make the walk cheaper than a generated `writeTo`.
+
+So if you only looked at encode nanoseconds, you might crown protobuf-java. The suite reports encode **plus** decode.
+
+## Why decode favours Protostuff
+
+Protostuff’s `newMessage()` is a plain `new Document()`. `mergeFrom` writes `id`, `status`, `meta`, and `items` as ordinary Java fields.
+
+protobuf-java’s `parseFrom` constructs generated types. Those types track presence bits, validate UTF-8, and keep unknown fields. They are the right objects for a long-lived public API. They are heavier than a POJO when all you need is the suite’s fidelity check.
+
+The runner copies protobuf messages back to domain objects **after** the clock (`toDomain`). The decode gap is therefore still codec work, not the mapping.
+
+**History.** Protocol Buffers (Google, open-sourced 2008) generated the immutable message class so that many languages would share one contract. [Protostuff](https://github.com/protostuff/protostuff) (David Yu and contributors, late 2000s) asked a different question: can we speak a Protobuf-like tag stream from an existing POJO, without `protoc`? `RuntimeSchema` is that answer. The speed you see is “fill the object you already have,” not “a denser encoding.”
+
+## What you give up
+
+Protostuff’s runtime schema follows Java declaration order. A `.proto` that numbers fields differently will not interoperate. The official Java runtime follows the `.proto` file and the published evolution rules. If the bytes leave this process, protobuf-java is the contract. If the bytes stay inside a JVM cache, Protostuff’s POJO path is why it wins this fixture.
+
+## Self-check
+
+1. Why is equal size evidence that the *format* is not the speed story?
+2. Which library would pull ahead if the runner timed `toProto` + `toByteArray` together?
+3. Why is jsoniter faster than protobuf-java on this one-instance document and still the wrong winner to copy into a multi-language log?

--- a/docs/theory/401/javascript-json-vs-protobuf.md
+++ b/docs/theory/401/javascript-json-vs-protobuf.md
@@ -1,0 +1,116 @@
+# JavaScript: why `JSON.stringify` beats google-protobuf on Document
+
+## Why this article exists
+
+On this suite’s **document** fixture, one instance, in-memory buffer mode, **`JSON.stringify`** finishes more encode-and-decode cycles per second than **google-protobuf**, even though JSON is 448 bytes and Protocol Buffers is 155. That result surprises people who have just read that binary encodings are smaller and therefore faster.
+
+This page looks at the actual timed functions. After reading it you should be able to say why the protobuf *encode* number is 431 nanoseconds, why decode is 5648, and why V8’s JSON path still wins the total.
+
+Numbers are from the committed JavaScript **Results** snapshot. See [JavaScript Results](../../javascript/results.md).
+
+## Short answer
+
+Two facts, both in the wrapper, explain the table.
+
+1. **Timed protobuf encode is not an encode.** `prepare` (untimed) writes the Protocol Buffers bytes once. The timed `serialize` only wraps those bytes in a Node `Buffer`. 431 ns is a buffer view, not `serializeBinary`.
+2. **Timed protobuf decode is a JavaScript field loop.** It allocates a reader per nested message, walks tags, and builds plain objects. `JSON.parse` is native C++ inside V8. 3196 ns of native parse beats 5648 ns of user-land tag walking.
+
+JSON still writes every field name. That costs size. It does not cost enough *time*, on this small document, to lose to a JavaScript protobuf decoder.
+
+| | `JSON.stringify` | google-protobuf (as timed) | fast-json-stringify |
+|--|------------------|----------------------------|---------------------|
+| Mean encode + decode, document, *n* = 1 | **174 thousand / s** | 164 thousand / s | 107 thousand / s |
+| Encode | 2538 ns | **431 ns** (cached bytes → `Buffer`) | slower JS stringify |
+| Decode | **3196 ns** (`JSON.parse`) | 5648 ns (JS `BinaryReader`) | `JSON.parse` (same) |
+| Encoded size | 448 B | **155 B** | 448 B |
+
+## The two timed call sites
+
+**JSON** (`javascript/src/serializers/json.js`) is one native call each way, plus a UTF-8 `Buffer`:
+
+```javascript
+serialize(value) {
+  return Buffer.from(JSON.stringify(value), 'utf8');
+},
+deserialize(buf) {
+  return JSON.parse(bufToUtf8(buf));
+},
+```
+
+**google-protobuf** (`javascript/src/serializers/modern.js`) encodes in `prepare`:
+
+```javascript
+prepare(dataName, value) {
+  jspbDataName = dataName;
+  jspbIsBatch = Array.isArray(value);
+  jspbBytes = jspbEncode(dataName, value);   // untimed
+},
+serialize(_value) {
+  const u8 = jspbBytes;
+  return Buffer.from(u8.buffer, u8.byteOffset, u8.byteLength);
+},
+deserialize(buf) {
+  const u8 = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
+  return jspbDecode(jspbDataName, u8, jspbIsBatch);
+},
+```
+
+The runner times `serialize` / `deserialize` after `prepare` (`javascript/src/runner_v2.js`). Generated `Document.serializeBinary` exists in `javascript/src/generated/google/js_fixtures_pb.cjs`. This wrapper does not call it on the clock.
+
+## What decode actually does
+
+`jspbReadDocument` builds a literal, then for every field calls `nextField()` and a typed read. Nested `meta` and each of the **eight** items allocate another `BinaryReader` over a copied slice:
+
+```javascript
+// javascript/src/serializers/modern.js — document decode (abbreviated)
+function jspbReadDocument(r) {
+  const o = { id: '', status: 0, meta: { region: '', version: 0 }, items: [] };
+  while (r.nextField()) {
+    switch (r.getFieldNumber()) {
+      case 1: o.id = r.readString(); break;
+      case 2: o.status = r.readInt32(); break;
+      case 3: {
+        const ir = new BinaryReader(r.readBytes());
+        while (ir.nextField()) { /* region, version */ }
+        break;
+      }
+      case 4: {
+        const ir = new BinaryReader(r.readBytes());
+        const it = { sku: '', qty: 0, price_minor: 0 };
+        while (ir.nextField()) { /* sku, qty, price_minor */ }
+        o.items.push(it);
+        break;
+      }
+    }
+  }
+  return o;
+}
+```
+
+`nextField` in `google-protobuf` is a JavaScript variable-length integer parse of `(field << 3) | wireType`. Ten reader loops and ten object allocations later, you have the same logical document that `JSON.parse` produced in C++.
+
+The official generated decoder is the same algorithm with setters (`deserializeBinaryFromReader`). Switching to it would not make decode native.
+
+## Why `fast-json-stringify` loses to `JSON.stringify`
+
+`fast-json-stringify` compiles a JavaScript function in `prepare`, then concatenates strings in user land. Short strings even fall back to `JSON.stringify` for escaping. Decode is still `JSON.parse`. So this row measures **generated JavaScript encode versus V8’s C++ encode**, with the same parse. V8 wins. That is implementation quality inside one format, the third idea on the [Rust comparison](rust-speedy-vs-bincode.md) (specialize the path — here the specialized path is already inside the engine).
+
+## History
+
+JSON is the web default because browsers already spoke it ([Douglas Crockford](https://en.wikipedia.org/wiki/Douglas_Crockford), early 2000s). V8’s `JSON.parse` / `JSON.stringify` have been tuned for more than a decade. Protocol Buffers in JavaScript is a port of a binary tag machine into the language that also hosts that tuned parser. On a 448-byte document, the native parser is the faster machine, even though it reads more bytes.
+
+[Serialization 201](../201/encode-decode-cost.md) warned that “binary versus text” is not one cost. This page is that warning in one language’s source.
+
+The same 155-byte encoding in **protobufjs** and **protobuf-es**, with encode actually on the clock, is [three Protocol Buffers engines](javascript-three-protobufs.md).
+
+## Honesty
+
+1. **Do not quote 431 ns as protobuf encode speed.** A fair encode would call `jspbEncode` or `serializeBinary` inside the timer. The `protobuf-es` row on the same Results page does time `toBinary` and is much slower.
+2. The 155-byte size is real. Tags and variable-length integers do omit names.
+3. A larger document, or a native addon decoder, would change the rank. This page explains *this* runner.
+
+## Self-check
+
+1. Add the two protobuf times: 431 + 5648. Add the two JSON times: 2538 + 3196. Which half of the protobuf total is “not really encode”?
+2. Why does `fast-json-stringify` sharing `JSON.parse` with `JSON.stringify` predict that it cannot win on decode?
+3. What would you change in `googleProtobufSer.serialize` to make the encode column honest, and what would you expect to happen to ops/s?

--- a/docs/theory/401/javascript-three-protobufs.md
+++ b/docs/theory/401/javascript-three-protobufs.md
@@ -1,0 +1,109 @@
+# JavaScript: three engines, one Protocol Buffers document
+
+## Why this article exists
+
+The [JSON versus google-protobuf](javascript-json-vs-protobuf.md) page showed that this runner’s google-protobuf **encode** is a cached `Buffer`. A fair question follows: what happens when two other JavaScript libraries speak the **same 155-byte** encoding and actually run encode on the clock?
+
+This page places **google-protobuf**, **protobufjs**, and **protobuf-es** side by side. After reading it you should be able to say which functions are timed, why the three totals differ by a factor of five, and how this extends [Same bytes, three runtimes](protobuf-cross-language-fidelity.md) without leaving JavaScript.
+
+Numbers are from the committed JavaScript **Results** snapshot (document, one instance). See [JavaScript Results](../../javascript/results.md).
+
+## Short answer
+
+All three emit **155 bytes** of proto3 binary: field numbers 1–4, variable-length integers, no names. The stopwatch is not measuring the format. It is measuring three different machines that write and read those tags, and three different decisions about `prepare`.
+
+| | google-protobuf (as timed) | protobufjs | protobuf-es |
+|--|----------------------------|------------|-------------|
+| Mean encode + decode | **164 thousand / s** | 41 thousand / s | 29 thousand / s |
+| Encode | **431 ns** | 7.3 µs | 21 µs |
+| Decode | **5648 ns** | 17 µs | 13 µs |
+| Encoded size | **155 B** | **155 B** | **155 B** |
+
+google-protobuf’s encode is **not** an encode. protobufjs times `Type.encode(...).finish()`. protobuf-es times `toBinary`. Decode is a JavaScript tag loop in every row. None of these is V8-native.
+
+## The three timed call sites
+
+**google-protobuf** (`javascript/src/serializers/modern.js`) encodes in untimed `prepare`:
+
+```javascript
+prepare(dataName, value) {
+  jspbBytes = jspbEncode(dataName, value);   // untimed
+},
+serialize(_value) {
+  const u8 = jspbBytes;
+  return Buffer.from(u8.buffer, u8.byteOffset, u8.byteLength);
+},
+deserialize(buf) {
+  return jspbDecode(jspbDataName, u8, jspbIsBatch);
+},
+```
+
+`jspbEncode` uses `BinaryWriter` primitives (`writeString`, `writeInt32`, `writeMessage`). Those calls are real Protocol Buffers writes. They run once, before the clock.
+
+**protobufjs** (`javascript/src/serializers/schema.js`) builds a message in `prepare` and times encode:
+
+```javascript
+prepare(dataName, value) {
+  pbType = pbRoot.lookupType(typeName);
+  pbMsg = pbType.create(payload);          // untimed
+},
+serialize(_value) {
+  return pbType.encode(pbMsg).finish();    // timed
+},
+deserialize(buf) {
+  const decoded = pbType.decode(u8);
+  return fromPbValue(pbDataName, decoded, pbIsBatch);
+},
+```
+
+**protobuf-es** (`@bufbuild/protobuf` in `modern.js`) builds a typed message in `prepare` and times `toBinary`:
+
+```javascript
+prepare(dataName, value) {
+  esMsg = create(esSchema, input);         // untimed
+},
+serialize(_value) {
+  const u8 = toBinary(esSchema, esMsg);    // timed
+  return Buffer.from(u8.buffer, u8.byteOffset, u8.byteLength);
+},
+deserialize(buf) {
+  const msg = fromBinary(esSchema, u8);
+  return fromEsItem(esDataName, msg);      // domain copy is on the clock
+},
+```
+
+So the encode column is three different quantities:
+
+1. copy an existing `Uint8Array` into a Node `Buffer`;
+2. walk a protobufjs message and emit tags;
+3. walk a protobuf-es message and emit tags.
+
+Only (2) and (3) answer “how expensive is JavaScript Protocol Buffers encode?”
+
+## Why decode is the honest half
+
+Every decode walks tags in JavaScript.
+
+google-protobuf’s `jspbReadDocument` allocates a `BinaryReader` for the document, another for `meta`, and one per line item. Eight items means ten reader loops. Details are on the JSON comparison page.
+
+protobufjs `Type.decode` is a generated-or-reflected field loop that fills a protobufjs message, then `fromPbValue` copies it to a plain object (`toJSON` or a spread). That second copy is on the clock and is part of the 17 µs.
+
+protobuf-es `fromBinary` fills a protobuf-es message, then `fromEsItem` copies fields into a suite object. That copy is also on the clock (13 µs total). It is still faster than protobufjs here because the decode core is newer and typed, not because the bytes differ.
+
+**History.** Protocol Buffers (Google, open-sourced 2008) specified the tags. `protoc --js_out` and the `google-protobuf` runtime brought that specification into browsers as `BinaryWriter` / `BinaryReader`. [protobufjs](https://github.com/protobufjs/protobuf.js) (Daniel Wirtz and contributors) loaded a `.proto` or a JSON descriptor at run time so teams could skip the compiler. [protobuf-es](https://github.com/bufbuild/protobuf-es) (Buf, early 2020s) generated TypeScript-first types and `toBinary` / `fromBinary`. Three engines, one wire article: [Protocol Buffers wire format](protobuf-wire-format.md).
+
+## How to read the leaderboard
+
+If you rank by ops/s, google-protobuf “wins.” If you add 431 ns + 5648 ns you are adding a buffer copy to a real decode. A fairer encode for that row would call `jspbEncode` inside `serialize`. The total would move toward protobufjs, not toward `JSON.stringify`.
+
+If you rank by encode alone, you are ranking timer placement. protobuf-es looks worst (21 µs) because it does the work the first row deferred.
+
+If you rank by size, all three tie. That is the format.
+
+This is the JavaScript companion to [Same bytes, three runtimes](protobuf-cross-language-fidelity.md): there the languages differ and the bytes should match; here the language is one and the bytes do match, so the remaining story is the engine and the clock.
+
+## Self-check
+
+1. Which of the three `serialize` functions would you show a colleague who asked “how long does Protocol Buffers encode take in JavaScript on this suite?”
+2. Why does equal size (155 B) prove the speed gap is not compactness?
+3. protobuf-es times a domain copy on decode; google-protobuf builds a plain object directly. In which direction does that bias the decode column?

--- a/docs/theory/401/python-msgspec-json-vs-msgpack.md
+++ b/docs/theory/401/python-msgspec-json-vs-msgpack.md
@@ -1,0 +1,96 @@
+# Python: msgspec JSON versus msgspec-msgpack
+
+## Why this article exists
+
+The [msgspec-msgpack versus orjson](python-msgspec-vs-orjson.md) page compares two libraries *and* two layouts at once. A student can fairly ask: how much of that gap is MessagePack, and how much is msgspec?
+
+This page holds the library still. Both rows use the same `array_like` Structs, the same C core, and the same untimed conversion from a dataclass. Only the encoder class changes. After reading it you should be able to say what remains when names are already gone and the implementation is already native.
+
+Numbers are from the committed Python **Results** snapshot (document, one instance, in-memory buffer mode). See [Python Results](../../python/results.md).
+
+## Short answer
+
+Once msgspec already writes a **positional record**, switching from JSON tokens to MessagePack tags saves about **63 bytes** and a little decode time. Encode is a near tie. JSON is even slightly faster to write. The large gap versus orjson on the previous page is therefore mostly **typed slots versus named dictionaries**, not “MessagePack is magic.”
+
+| | msgspec JSON 0.21.1 | msgspec-msgpack 0.21.1 |
+|--|---------------------|------------------------|
+| Mean encode + decode | 247 thousand / s | **272 thousand / s** |
+| Encode | **1.66 µs** | 1.73 µs |
+| Decode | 2.39 µs | **1.95 µs** |
+| Encoded size | 192 B | **129 B** |
+
+Same Struct. Same field order. Different token language.
+
+## The two timed call sites
+
+Both classes share `_MsgspecStructSerializer` in `python/src/benchmark/serializers/json_msgspec.py`. The only difference is which encoder and decoder they construct:
+
+```python
+class MsgspecSerializer(_MsgspecStructSerializer):
+    codec_name = "msgspec"
+
+    def _make_encoder(self) -> msgspec.json.Encoder:
+        return msgspec.json.Encoder()
+
+    def _make_decoder(self, typ: Any) -> msgspec.json.Decoder:
+        return msgspec.json.Decoder(type=typ)
+
+
+class MsgspecMessagePackSerializer(_MsgspecStructSerializer):
+    codec_name = "msgspec-msgpack"
+
+    def _make_encoder(self) -> msgspec.msgpack.Encoder:
+        return msgspec.msgpack.Encoder()
+
+    def _make_decoder(self, typ: Any) -> msgspec.msgpack.Decoder:
+        return msgspec.msgpack.Decoder(type=typ)
+```
+
+Timed work is `self._encoder.encode(obj)` and `self._decoder.decode(data)` in both cases. `prepare` builds a `Decoder(type=MsgspecDocument)`. `prepare_data` builds the Struct. Neither of those steps is on the clock.
+
+The Structs are created once with `array_like=True`:
+
+```python
+_STRUCT_TYPES[cls] = msgspec.defstruct(
+    f"Msgspec{cls.__name__}",
+    struct_fields,
+    module=__name__,
+    array_like=True,
+)
+```
+
+So both encodings are arrays of values, not objects of named fields.
+
+## What the bytes look like
+
+For a teaching record `{ id: 7, name: "Ada" }` the two positional encodings are:
+
+```text
+msgspec JSON:      [7,"Ada"]
+                   5b 37 2c 22 41 64 61 22 5d     (9 bytes)
+
+msgspec-msgpack:   array(2), 7, str "Ada"
+                   92 07 a3 41 64 61              (6 bytes)
+```
+
+The letters of `"id"` and `"name"` appear in neither row. JSON still spends bytes on `[`, `,`, quotes, and the decimal digit `7`. MessagePack spends a one-byte array tag, a one-byte integer, and a one-byte string header.
+
+On the suite document the same arithmetic scales up. Eight line items mean eight copies of quotes around every string and eight decimal integers. That is most of the 192 − 129 = 63 bytes.
+
+**History.** JSON ([Douglas Crockford](https://en.wikipedia.org/wiki/Douglas_Crockford), early 2000s) chose characters a human can type. MessagePack ([Sadayuki Furuhashi](https://en.wikipedia.org/wiki/Sadayuki_Furuhashi), 2008) kept the JSON *data model* and replaced those characters with short binary tags. msgspec (Jim Crist-Harif, early 2020s) applied both encodings to one C Struct type. This page is that history with the library held constant. See [Historical perspective](../101/historical_perspective.md).
+
+## Why encode does not follow size
+
+Writing 192 bytes of JSON in 1.66 µs, versus 129 bytes of MessagePack in 1.73 µs, looks backwards. The JSON writer in msgspec is a tight C loop that emits punctuation and copies UTF-8. The MessagePack writer emits a tag per value. On a small document the tag machine is not cheaper than “write a bracket and a digit.” Size and encode time are different questions. [Encode and decode cost](../201/encode-decode-cost.md) made that distinction; here you can see it in one package.
+
+Decode favours MessagePack because the reader does not scan for quotes or convert decimal digits. It reads a tag and a length. That is the 2.39 µs versus 1.95 µs.
+
+## What this page is for
+
+Use this pair when you need a **control experiment**. If you want the larger story — typed Struct versus a Python dictionary — return to [msgspec-msgpack versus orjson](python-msgspec-vs-orjson.md). If you want “same JSON bytes, two engines,” go to [orjson versus stdlib json](python-orjson-vs-json.md).
+
+## Self-check
+
+1. Why can you not use this pair to claim that “MessagePack is always faster to write than JSON”?
+2. Draw the 63-byte gap as “punctuation and decimal digits,” not as “field names.” Where did the names already go?
+3. What would you expect if `array_like=False` were set on both encoders?

--- a/docs/theory/401/python-msgspec-vs-orjson.md
+++ b/docs/theory/401/python-msgspec-vs-orjson.md
@@ -1,0 +1,173 @@
+# Python: why msgspec-msgpack outruns orjson on Document
+
+## Why this article exists
+
+On this suite’s **document** fixture, one instance, in-memory buffer mode, **msgspec-msgpack** finishes slightly more encode-and-decode cycles per second than **orjson**, and it writes a message about **3.5 times smaller**. Both libraries are native extensions (C and Rust). Both leave the Python interpreter for the inner loop. A results table therefore cannot tell you *which lines of code* create the gap.
+
+This page compares the two timed call sites in this repository and the layouts they emit. After reading it you should be able to say why orjson can still *encode* faster, why msgspec-msgpack *decodes* faster, and why the PyPI `msgpack` package is far slower even though it speaks the same MessagePack format family.
+
+Numbers are from the committed Python **Results** snapshot. See [Python Results](../../python/results.md).
+
+## Short answer
+
+msgspec-msgpack wins the *total* because it encodes a **typed, positional record**, not a dictionary of named fields.
+
+1. Before the clock starts, the runner converts the shared dataclass into a `msgspec.Struct` built with `array_like=True`. Encode then writes a MessagePack **array** of values. Field names never appear.
+2. orjson is given a **plain Python dictionary**. Encode writes a JSON **object**. Every key (`"id"`, `"sku"`, `"price_minor"`, …) is copied on every message. Decode allocates nested dictionaries.
+3. orjson’s Rust encoder is so fast that it still *writes* 448 bytes of JSON in less time than msgspec writes 129 bytes of MessagePack. msgspec wins on **decode** and on **size**, and therefore on total cycles.
+
+| | msgspec-msgpack 0.21.1 | orjson 3.11.9 | PyPI msgpack 1.2.1 |
+|--|------------------------|---------------|---------------------|
+| Mean encode + decode, document, *n* = 1 | **272 thousand / s** | 242 thousand / s | 113 thousand / s |
+| Encode | 1.73 µs | **1.62 µs** | 4.17 µs |
+| Decode | **1.95 µs** | 2.50 µs | 4.72 µs |
+| Encoded size | **129 B** | 448 B | 325 B |
+
+orjson is the encode winner. msgspec-msgpack is the size winner and the total-time winner.
+
+## The two timed call sites
+
+**msgspec-msgpack** (`python/src/benchmark/serializers/json_msgspec.py`) builds one encoder and one typed decoder. Conversion to a Struct is untimed `prepare_data`:
+
+```python
+# Struct types are generated once, with array_like=True (positional).
+_STRUCT_TYPES[cls] = msgspec.defstruct(
+    f"Msgspec{cls.__name__}",
+    struct_fields,
+    module=__name__,
+    array_like=True,
+)
+
+def serialize_bytes(self, obj: Any) -> bytes:
+    return self._encoder.encode(obj)
+
+def deserialize_bytes(self, data: bytes) -> Any:
+    return self._decoder.decode(data)
+```
+
+The MessagePack subclass only swaps the encoder class:
+
+```python
+class MsgspecMessagePackSerializer(_MsgspecStructSerializer):
+    codec_name = "msgspec-msgpack"
+
+    def _make_encoder(self) -> msgspec.msgpack.Encoder:
+        return msgspec.msgpack.Encoder()
+
+    def _make_decoder(self, typ: Any) -> msgspec.msgpack.Decoder:
+        return msgspec.msgpack.Decoder(type=typ)
+```
+
+**orjson** converts the dataclass to a dictionary (untimed) and then calls the Rust extension:
+
+```python
+# python/src/benchmark/serializers/json_orjson.py
+def prepare_data(self, obj, test_data_name, test_data_type):
+    return to_dict(obj)
+
+def serialize_bytes(self, obj):
+    return orjson.dumps(obj)
+
+def deserialize_bytes(self, data):
+    return orjson.loads(data)
+```
+
+So the clock does **not** include “dataclass to Struct” or “dataclass to dict.” It includes only encode and decode of the library-native value.
+
+## What the bytes look like
+
+A document in this suite is an identifier, a status, a small metadata record, and eight line items (`children: 8` in the catalog). Conceptually:
+
+```text
+Document
+  id, status
+  meta: { region, version }
+  items: [ { sku, qty, price_minor }, … eight times ]
+```
+
+**orjson** emits a JSON object. Every name is text:
+
+```text
+{"id":"…","status":1,"meta":{"region":"…","version":1},
+ "items":[{"sku":"…","qty":2,"price_minor":300}, …]}
+```
+
+448 bytes. The letters of `"price_minor"` appear eight times.
+
+**msgspec-msgpack** with `array_like=True` emits a MessagePack array in field order:
+
+```text
+[ id, status, [ region, version ], [ [ sku, qty, price_minor ], … ] ]
+```
+
+129 bytes. The names live in the Struct type, which the decoder already has.
+
+That is the same *idea* as Protocol Buffers field numbers and Avro schema order, taught in [self-describing versus schema-dependent](../201/self-describing-vs-schema-dependent.md). Jim Crist-Harif’s **msgspec** (early 2020s) applied it to Python by generating a compact C type whose fields are slots, not a hash table.
+
+**orjson** (ijl, late 2010s) applied the other idea: keep JSON, but write and parse it in Rust, examining many characters at once. That is the simdjson tradition of Geoff Langdale and Daniel Lemire (2018–2019), brought into CPython as a single `dumps` / `loads` pair.
+
+## Why orjson can encode faster
+
+Writing 448 bytes of JSON in 1.62 µs, versus 129 bytes of MessagePack in 1.73 µs, looks backwards until you look at the inner loop.
+
+orjson’s `dumps` is a Rust function that walks a Python dictionary and writes UTF-8 into a byte buffer. There is no intermediate Python `str`. The standard library, by contrast, builds a Unicode string and then encodes it:
+
+```python
+# python/src/benchmark/serializers/json_stdlib.py (not the winner — the baseline)
+return json.dumps(obj, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+```
+
+That extra `str` plus a new encoder object is why stdlib JSON sits near 47 thousand cycles per second on the same fixture.
+
+msgspec still has to walk eight nested Structs and emit MessagePack tags. The C core (`msgspec._core`) is fast. It is not faster *per byte written* than orjson’s JSON writer on this small document. Encode is therefore a near tie, with orjson slightly ahead.
+
+## Why msgspec-msgpack decodes faster
+
+Decode is where the typed layout pays.
+
+msgspec’s `Decoder(type=MsgspecDocument)` already knows there are four slots, that slot 3 is a list of items, and that each item has three slots. The C decoder fills those slots. It does not hash `"sku"`. It does not allocate a Python `dict` per line item.
+
+orjson’s `loads` has no schema. It must:
+
+1. scan 448 bytes of JSON;
+2. allocate a dictionary for the document, one for `meta`, and one per item;
+3. intern and hash every key.
+
+A key cache in orjson keeps the third step cheap. It cannot avoid the dictionaries. That is the 2.50 µs versus 1.95 µs.
+
+## Why PyPI msgpack is not in the same race
+
+The `msgpack` wrapper also converts to a dictionary and then calls a C packer:
+
+```python
+# python/src/benchmark/serializers/binary_msgpack.py
+return self._packer.pack(obj)          # encode a dict
+return msgpack.unpackb(data, ...)      # decode to a dict
+```
+
+The format is MessagePack, but the **layout** is a map with string keys (325 bytes), not a positional array (129 bytes). Decode is generic. You pay binary tags *and* key hashing, and you still allocate dictionaries. That is why “the same format family” is 2.4 times slower than msgspec-msgpack on this fixture.
+
+## What you give up
+
+| Axis | msgspec-msgpack as timed here | orjson as timed here |
+|------|-------------------------------|----------------------|
+| Public readability | No | Yes (JSON) |
+| Need a shared field order | Yes | No |
+| Encode of this document | Slightly slower | Slightly faster |
+| Decode of this document | Faster (typed slots) | Slower (dictionaries) |
+| Size | 129 B | 448 B |
+| Other languages | MessagePack arrays are readable if they share the order | JSON is universal |
+
+The wrapper is honest about the model: it measures “an application written with msgspec Structs,” not “msgspec encoding a dataclass.” If your service only has dictionaries, orjson is the closer comparison, and JSON size is the price of that flexibility.
+
+## History, in one paragraph
+
+JSON won the web because [Douglas Crockford](https://en.wikipedia.org/wiki/Douglas_Crockford) extracted a format browsers already spoke (early 2000s). MessagePack ([Sadayuki Furuhashi](https://en.wikipedia.org/wiki/Sadayuki_Furuhashi), 2008) kept that data model and dropped decimal text. msgspec’s `array_like` step is older still: it is the packed record — names in the contract, values on the wire — that [Serialization 101](../101/historical_perspective.md) traces from COBOL through Protocol Buffers and Avro. orjson is the other historical thread: keep the popular format, spend engineering on the implementation.
+
+Related control experiments: [msgspec JSON versus MessagePack](python-msgspec-json-vs-msgpack.md) (same library, two encodings) and [orjson versus stdlib json](python-orjson-vs-json.md) (same JSON, two engines).
+
+## Self-check
+
+1. Why is msgspec *JSON* (192 B, 247 thousand / s on this fixture) smaller than orjson but larger than msgspec-msgpack?
+2. Name one change to the orjson wrapper that would *not* be a fair comparison (hint: moving `to_dict` onto the clock).
+3. Why does beating PyPI msgpack not prove that “msgspec’s C is 2.4 times faster than msgpack’s C”?

--- a/docs/theory/401/python-orjson-vs-json.md
+++ b/docs/theory/401/python-orjson-vs-json.md
@@ -1,0 +1,96 @@
+# Python: why orjson outruns the standard library on the same JSON
+
+## Why this article exists
+
+On this suite’s **document** fixture, one instance, **orjson** and the standard library `json` module emit the **same 448 bytes**. orjson finishes about **five times** as many encode-and-decode cycles per second. There is no format lesson here. The bytes are JSON objects with the same keys. The gap is how each library walks a Python dictionary and how it hands bytes back to the caller.
+
+This page compares the two timed wrappers and the library functions they call. After reading it you should be able to point at the extra `str` and the missed cached encoder in the standard-library path.
+
+Numbers are from the committed Python **Results** snapshot. See [Python Results](../../python/results.md).
+
+## Short answer
+
+orjson writes UTF-8 **bytes** in Rust and parses those bytes back into dictionaries. The standard-library wrapper builds a Python **Unicode string**, then encodes it to UTF-8, and it constructs a new `JSONEncoder` on every call because `separators=(",", ":")` misses the cached encoder. Decode first turns bytes back into a `str`. Same JSON. Five times the work.
+
+| | orjson 3.11.9 | stdlib json (Python 3.14) |
+|--|---------------|---------------------------|
+| Mean encode + decode, document, *n* = 1 | **242 thousand / s** | 48 thousand / s |
+| Encode | **1.62 µs** | 12.4 µs |
+| Decode | **2.50 µs** | 8.53 µs |
+| Encoded size | **448 B** | **448 B** |
+
+Equal size is the teaching fact. Speed is implementation.
+
+## The two timed call sites
+
+Both wrappers convert the dataclass to a dictionary in untimed `prepare_data`. Timed work is only dump and load.
+
+```python
+# python/src/benchmark/serializers/json_orjson.py
+def serialize_bytes(self, obj):
+    return orjson.dumps(obj)
+
+def deserialize_bytes(self, data):
+    return orjson.loads(data)
+```
+
+```python
+# python/src/benchmark/serializers/json_stdlib.py
+def serialize_bytes(self, obj):
+    return json.dumps(obj, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+
+def deserialize_bytes(self, data):
+    return json.loads(data)
+```
+
+`separators=(",", ":")` is there so the standard library emits compact JSON, matching orjson’s default. It is also what takes the slow path.
+
+## What the standard library does on every encode
+
+`json.dumps` keeps a single cached encoder for the *default* argument combination. Any other combination builds a new encoder:
+
+```python
+# CPython 3.14, Lib/json/__init__.py
+if (not skipkeys and ensure_ascii and
+    check_circular and allow_nan and
+    cls is None and indent is None and separators is None and
+    default is None and not sort_keys and not kw):
+    return _default_encoder.encode(obj)
+# otherwise:
+return cls(..., separators=separators, ...).encode(obj)
+```
+
+This runner sets `ensure_ascii=False` *and* `separators=...`. Both conditions fail. Every timed encode constructs a `JSONEncoder`, walks the dictionary, and returns a `str`. The wrapper then calls `.encode("utf-8")` and allocates a `bytes` object. Two Python strings’ worth of data for one JSON document.
+
+`json.loads` on a `bytes` object first decodes to `str`:
+
+```python
+# same file
+else:
+    s = s.decode(detect_encoding(s), 'surrogatepass')
+return _default_decoder.decode(s)
+```
+
+The C accelerator `_json` then parses Unicode. orjson never builds that intermediate `str`.
+
+## What orjson does instead
+
+orjson (`dumps` / `loads` in the Rust crate `ijl/orjson`) takes a Python object and writes UTF-8 into a byte buffer. `loads` parses those bytes and allocates dictionaries. There is still a dictionary per nested record — this is not msgspec’s typed Struct path. The win versus the standard library is:
+
+1. no Unicode detour;
+2. no per-call `JSONEncoder` construction;
+3. a Rust inner loop that examines many characters at once (the simdjson tradition of Geoff Langdale and Daniel Lemire, 2018–2019).
+
+**History.** The standard library’s `json` module (Bob Ippolito and contributors, Python 2.6 onward) is the portable, always-there encoder. It was written to be correct and maintainable, not to win a microbenchmark. orjson (late 2010s) exists because web services paid real time for that portability. The format did not change. The path from a `dict` to bytes did.
+
+## What this page is not
+
+It is not “JSON is slow.” jsoniter, Glaze, yyjson, and V8 `JSON.stringify` show that JSON can be fast when the implementation is specialized. It is not “orjson beats msgspec.” [msgspec-msgpack versus orjson](python-msgspec-vs-orjson.md) is a different experiment: positional MessagePack Structs versus named JSON dictionaries.
+
+A fairer stdlib call would keep a long-lived `JSONEncoder(ensure_ascii=False, separators=(",", ":"))` and write with `encode`. That would remove the per-call constructor. It would not remove the `str` then UTF-8 copy. The five-times gap would shrink. It would not vanish.
+
+## Self-check
+
+1. Why is equal size essential to this lesson?
+2. Which two extra allocations does `.dumps(...).encode("utf-8")` perform that `orjson.dumps` does not?
+3. Why does passing `separators=` make CPython skip `_default_encoder`?

--- a/docs/theory/401/rust-rkyv-vs-speedy.md
+++ b/docs/theory/401/rust-rkyv-vs-speedy.md
@@ -1,0 +1,91 @@
+# Rust: why rkyv does not beat Speedy when you rebuild a `Document`
+
+## Why this article exists
+
+rkyv is designed so a reader can use the received buffer **in place**. Product language calls that zero-copy. On this suite’s **document** fixture, one instance, **Speedy** is still faster, and rkyv’s message is **larger**. The Results page already notes that timed rkyv decode **materializes owned values**. This page opens those two call sites and the library functions they invoke, so the note becomes something you can see in code.
+
+After reading it you should be able to say what `rkyv::from_bytes` does that `rkyv::access` would not, and why an in-place layout can lose a stopwatch that demands a `Document`.
+
+Numbers are from the committed Rust **Results** snapshot. See [Rust Results](../../rust/results.md).
+
+## Short answer
+
+In-place access is an **application-programming-interface**, not a prize you collect by choosing a crate. This runner asks both libraries for an owned `Document`. Speedy reads a packed image into that struct. rkyv first builds an archived layout (alignment, relative pointers), then **deserializes that archive into a second owned `Document`**. You pay construction and you pay a classical copy. Decode is not faster. Encode is much slower. Size grows because of padding.
+
+| | Speedy 0.8.7 | rkyv 0.8.17 (as timed) |
+|--|--------------|------------------------|
+| Mean encode + decode, document, *n* = 1 | **2.84 million / s** | 1.64 million / s |
+| Encode | **88 ns** | 314 ns |
+| Decode | **264 ns** | 296 ns |
+| Encoded size | **214 B** | 272 B |
+
+A production reader that only needed `status` could call `rkyv::access` and load one integer from the buffer. This suite does not time that path. It would be faster, and it would not produce a `Document` the fidelity check can compare field by field.
+
+## The two timed call sites
+
+**Speedy** writes the concrete struct into the runner’s `Vec<u8>` (`rust/src/serializers/direct.rs`):
+
+```rust
+fn speedy_ser_document(fx: &Fixture, out: &mut Vec<u8>) -> Result<()> {
+    let Fixture::Document(v) = fx else { bail!("speedy: expected Document"); };
+    v.write_to_stream(&mut *out)?;
+    Ok(())
+}
+// decode:
+Document::read_from_buffer(d)
+```
+
+**rkyv** allocates an aligned buffer, copies it into the runner’s vector, then on decode builds an owned value:
+
+```rust
+fn rkyv_ser_document(fx: &Fixture, out: &mut Vec<u8>) -> Result<()> {
+    let Fixture::Document(v) = fx else { bail!("rkyv: expected Document"); };
+    let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(v)?;
+    out.extend_from_slice(bytes.as_ref());
+    Ok(())
+}
+fn rkyv_de_document(data: &[u8]) -> Result<Document> {
+    rkyv::from_bytes::<Document, rkyv::rancor::Error>(data)
+}
+```
+
+`from_bytes` is not “view the buffer.” In rkyv 0.8 it is access **plus** deserialize into `T` (`rkyv` `src/api/high/mod.rs` / `from_bytes`): validate the archive, then allocate strings and vectors that the `Document` owns.
+
+The path this crate advertises for in-place reads is `access` / `access_unchecked`, which returns `&ArchivedDocument` into the byte slice. The runner does not call it, because the suite’s fidelity check compares owned domain values.
+
+## What Speedy stores
+
+Speedy’s derived `write_to` is a straight sequence of fixed-width stores: a `u32` length, then bytes; an `i32` as four bytes; an `i64` as eight. Details are on [Speedy versus Bincode](rust-speedy-vs-bincode.md). Decode is the inverse: read known widths into a `Document`. There is no archived twin type.
+
+## What rkyv stores
+
+rkyv (David Koloski, early 2020s) builds an **archive**: the on-the-wire layout *is* a relocatable image of the value. Strings and vectors become relative pointers and lengths, placed so that a later load from the buffer is a valid Rust reference after validation. `to_bytes` must:
+
+1. walk the `Document`;
+2. write those relative pointers and the pointed-to bytes;
+3. satisfy alignment (often four or eight bytes), which inserts padding.
+
+That is why encode is 314 ns rather than 88, and why the image is 272 bytes rather than 214. The extra bytes are not field names. They are the directory and padding that make in-place loads legal.
+
+**History.** The idea is the same pressure that produced Cap’n Proto (Kenton Varda, 2013) and FlatBuffers (Wouter van Oortmerssen, 2014): do not build a second object tree if the program will only read a few fields. See [201 in-place access](../201/zero-copy.md) and the [historical perspective](../101/historical_perspective.md). rkyv brings that idea into Rust’s type system. It only helps if the timed path *stops* at the archived view.
+
+## Side-by-side: what the clock includes
+
+| Step | Speedy (timed) | rkyv as timed here | rkyv `access` (not timed) |
+|------|----------------|--------------------|---------------------------|
+| Encode | store fields into `out` | build aligned archive, then `extend_from_slice` | same archive |
+| Decode | fill a `Document` | validate + fill a `Document` | return `&ArchivedDocument` |
+| Read `status` | already in the struct | already in the struct | load four bytes at an offset |
+| Fidelity check | compares two `Document`s | compares two `Document`s | would need a different check |
+
+Decode times are close (264 ns versus 296 ns) because **both fill a `Document`**. rkyv’s extra work is validation and a less dense layout, not a free read.
+
+## What you give up either way
+
+If you use `access`, you must keep the buffer alive, you must validate untrusted bytes, and you must write the rest of the program against archived types. If you use `from_bytes`, you have an ordinary `Document` and you have paid Speedy’s kind of decode, plus archive construction. This suite chose the second path so that rkyv can sit on the same fidelity table as Speedy and Bincode. That is honest for comparison and unfair to rkyv’s advertised read path.
+
+## Self-check
+
+1. Quote the two rkyv calls in `direct.rs`. Which one is the in-place API, and which one does the runner use?
+2. Why can rkyv be both larger and slower than Speedy *and* still be the right crate for a catalogue that is read field-by-field?
+3. The [Swift FlatBuffers page](swift-flatbuffers-vs-protobuf.md) times a domain copy. How is that the same lesson as this page?

--- a/docs/theory/401/rust-speedy-vs-bincode.md
+++ b/docs/theory/401/rust-speedy-vs-bincode.md
@@ -1,0 +1,285 @@
+# Rust: why Speedy outruns Bincode on Document
+
+## Why this article exists
+
+On this suite’s **document** fixture, one instance, in-memory buffer mode, **Speedy** finishes about **2.2 times** as many encode-and-decode cycles per second as **Bincode**. Both libraries write a compact binary image of the same Rust struct. Neither prints JSON. Neither looks up field names at run time. A results table therefore cannot tell you *which lines of code* create the gap.
+
+This page walks through the two call paths as they exist in this repository and in the crates those paths invoke. After reading it you should be able to point at the generated Speedy `write_to` body and at Bincode’s Serde encoder and say what extra work Bincode performs on every integer, every string, and every `Document`.
+
+Numbers below are from the committed Rust **Results** snapshot (`speedy:0.8.7`, `bincode:2.0.1`). They illustrate the gap. They are not a universal ranking. See [Rust Results](../../rust/results.md).
+
+## Short answer
+
+Speedy is faster because it does **less work per field**, not because it has a hidden algorithm.
+
+1. **Speedy writes the concrete `Document`.** The timed function already knows the type. The compiler emits one straight-line `write_to` that stores each field in declaration order.
+2. **Bincode writes through Serde.** The timed function accepts the `Fixture` enumeration and asks Serde to *visit* it. Each field becomes a virtual call into `serialize_i32`, `serialize_str`, and so on. Those methods then encode the value.
+3. **Speedy stores integers at their native width** (four bytes for `i32`, eight for `i64`) and stores every length as a 32-bit count. There is no per-value size test.
+4. **Bincode’s `standard()` configuration uses variable-length integers.** Every number is inspected: “does this fit in one byte? in two? in four?” That saves space (122 bytes versus Speedy’s 214) and costs branches.
+
+The advantage is therefore a pair of engineering choices: **specialize the encode function for one type**, and **never ask “how many bytes does this integer need?”** The cost of the second choice is a larger message.
+
+| | Speedy 0.8.7 | Bincode 2.0.1 |
+|--|--------------|---------------|
+| Mean encode + decode, document, *n* = 1 | **2.84 million / s** | 1.29 million / s |
+| Encode time | 88 ns | 203 ns |
+| Decode time | 264 ns | 573 ns |
+| Encoded size | 214 B | **122 B** |
+
+Speedy is the speed winner. Bincode is the size winner of this pair. **Postcard** (1.73 million / s, 114 B) sits between them and is the size leader among the fast Rust binaries. This page stays with Speedy versus Bincode, as those two make the design contrast sharpest.
+
+## Prerequisites
+
+- Intermediate Rust: traits, `Vec<u8>`, what a `derive` macro emits.
+- [Encode and decode cost](../201/encode-decode-cost.md) (allocation, copying, numeric conversion).
+- Optional: [Rust: prost](protobuf-rust-prost.md) if you want the same “per-type specialized code” idea on Protocol Buffers.
+
+## The two timed call sites
+
+Both libraries are registered in the Rust benchmark runner. They do **not** share a call shape.
+
+**Speedy** binds a per-kind function pointer in untimed `prepare`, then writes the inner struct:
+
+```rust
+// rust/src/serializers/direct.rs — timed encode
+fn speedy_ser_document(fx: &Fixture, out: &mut Vec<u8>) -> Result<()> {
+    use speedy::Writable;
+    let Fixture::Document(v) = fx else {
+        bail!("speedy: expected Document");
+    };
+    v.write_to_stream(&mut *out)?;
+    Ok(())
+}
+```
+
+Decode is equally direct:
+
+```rust
+// rust/src/serializers/direct.rs — timed decode
+Document::read_from_buffer(d)
+```
+
+The `match` that distinguishes `Document` from `Message` runs in `prepare`, outside the timed loop (`rust/src/serializers/kinded.rs`). The timed encode is one indirect call to a function that already knows it has a `Document`.
+
+**Bincode** goes through Serde and through the `Fixture` enumeration:
+
+```rust
+// rust/src/serializers/binary_serde.rs — timed encode and decode
+fn serialize_into(&mut self, fixture: &Fixture, out: &mut Vec<u8>) -> Result<()> {
+    bincode::serde::encode_into_std_write(fixture, out, self.config)?;
+    Ok(())
+}
+fn deserialize_bytes(&mut self, data: &[u8]) -> Result<Fixture> {
+    let (v, _): (Fixture, usize) = bincode::serde::decode_from_slice(data, self.config)?;
+    Ok(v)
+}
+```
+
+`Fixture` is an externally tagged enumeration (`rust/src/data.rs`):
+
+```rust
+pub enum Fixture {
+    Message(Message),
+    Document(Document),
+    Telemetry(Telemetry),
+    Strings(Strings),
+    Event(Event),
+}
+```
+
+So the first thing Bincode writes is a **variant index**, and the first thing it reads is that index plus a full `Fixture`. Speedy never writes that tag. Part of the measured gap is this wrapper difference. The larger part, as the crate sources show, is still inside the two libraries.
+
+The configuration Bincode uses is `bincode::config::standard()`:
+
+```rust
+// rust/src/serializers/binary_serde.rs
+impl Default for BincodeSer {
+    fn default() -> Self {
+        Self {
+            config: bincode::config::standard(),
+        }
+    }
+}
+```
+
+The crate documents what `standard()` means (`bincode` 2.0.1, `src/config.rs`):
+
+```rust
+/// The default config for bincode 2.0. By default this will be:
+/// - Little endian
+/// - Variable int encoding
+pub const fn standard() -> Configuration {
+    generate()
+}
+```
+
+That second bullet is the size/speed fork.
+
+## What Speedy generates for `Document`
+
+`Document` derives Speedy’s `Writable` and `Readable` next to its fields (`rust/src/data.rs`). The derive crate emits an `impl Writable` whose `write_to` is a straight sequence of field writes (`speedy-derive` 0.8.7). For a named struct the skeleton is:
+
+```rust
+// speedy-derive 0.8.7 — generated impl skeleton
+impl<C_: speedy::Context> speedy::Writable<C_> for Document {
+    fn write_to<T_: ?Sized + speedy::Writer<C_>>(
+        &self,
+        _writer_: &mut T_,
+    ) -> Result<(), C_::Error> {
+        // one write per field, in declaration order
+        Ok(())
+    }
+}
+```
+
+Each string or vector is a **fixed 32-bit length** plus the payload. The derive crate hard-codes that default (`speedy-derive` 0.8.7):
+
+```rust
+const DEFAULT_LENGTH_TYPE: BasicType = BasicType::U32;
+// ...
+speedy::private::write_length_u32(name.len(), _writer_)?;
+_writer_.write_slice(name.as_bytes())?;
+```
+
+After expansion, writing one `Document` is conceptually:
+
+```text
+write u32 length of id;           write id bytes
+write i32 status as 4 bytes
+write u32 length of meta.region;  write region bytes
+write i32 meta.version as 4 bytes
+write u32 items.len()
+for each item:
+    write u32 length of sku; write sku bytes
+    write i32 qty as 4 bytes
+    write i64 price_minor as 8 bytes
+```
+
+An `i32` is always four bytes. There is no “is this value small?” test. The writer copies the bits:
+
+```rust
+// speedy 0.8.7, src/writer.rs
+fn write_u32(&mut self, mut value: u32) -> Result<(), C::Error> {
+    self.context().endianness().swap_u32(&mut value);
+    let slice = unsafe {
+        std::slice::from_raw_parts(&value as *const u32 as *const u8, 4)
+    };
+    self.write_bytes(slice)
+}
+```
+
+On a little-endian host the swap is a no-op. A string is the same idea: treat the UTF-8 bytes as a slice and copy them. A `Vec` of primitive values can be copied as one block when no endian conversion is required (`write_slice` in the same file).
+
+The public entry the runner uses is `write_to_stream`, which wraps the `Vec<u8>` in a `std::io::Write` collector and calls `write_to`. After inlining, the timed encode is close to a handful of `memcpy`s.
+
+**History.** Speedy (Koute, mid-2010s) was written for games and tools that already trust the record shape and want the processor to *store* fields, not *interpret* them. That is the same pressure that produced packed records in the 1950s–1960s and Sun’s XDR in 1987: declare the order and the widths, then copy. See [Historical perspective](../101/historical_perspective.md). Speedy is not XDR; it is native-endian by default and is not a public interchange standard. The *idea* — fixed widths, no names — is the old one.
+
+## What Bincode does on the same `Document`
+
+Bincode 2 still has a native `Encode` trait. This suite does **not** call it. The runner uses the **Serde** feature:
+
+```rust
+// bincode 2.0.1, src/features/serde/ser.rs
+pub fn encode_into_std_write<E: Serialize, C: Config, W: std::io::Write>(
+    val: E,
+    dst: &mut W,
+    config: C,
+) -> Result<usize, EncodeError> {
+    let writer = crate::IoWriter::new(dst);
+    let mut encoder = crate::enc::EncoderImpl::<_, C>::new(writer, config);
+    let serializer = SerdeEncoder { enc: &mut encoder };
+    val.serialize(serializer)?;
+    Ok(encoder.into_writer().bytes_written())
+}
+```
+
+Three objects now sit between `Document` and the output bytes:
+
+1. Serde’s `serialize` implementation on `Fixture` (variant index, then the struct).
+2. `SerdeEncoder`, which implements Serde’s `Serializer` trait.
+3. `EncoderImpl`, which finally writes bytes.
+
+A struct does not become a packed image in one step. Serde calls `serialize_struct`, then `serialize_field` for every field. Each integer goes through `serialize_i32` → `i32::encode`. Because the config is `standard()`, `encode` for a 32-bit integer is **not** “write four bytes”:
+
+```rust
+// bincode 2.0.1, src/enc/impls.rs
+impl Encode for u32 {
+    fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        match E::C::INT_ENCODING {
+            IntEncoding::Variable => {
+                crate::varint::varint_encode_u32(encoder.writer(), E::C::ENDIAN, *self)
+            }
+            IntEncoding::Fixed => /* always 4 bytes */,
+        }
+    }
+}
+```
+
+Variable-length encoding tests the magnitude on every value (`src/varint/encode_unsigned.rs`):
+
+```rust
+pub fn varint_encode_u32<W: Writer>(writer: &mut W, endian: Endianness, val: u32)
+    -> Result<(), EncodeError>
+{
+    if val <= SINGLE_BYTE_MAX as _ {
+        writer.write(&[val as u8])
+    } else if val <= u16::MAX as _ {
+        writer.write(&[U16_BYTE])?;
+        // then two bytes
+    } else {
+        writer.write(&[U32_BYTE])?;
+        // then four bytes
+    }
+}
+```
+
+A small `qty` or `status` becomes one byte. A large `price_minor` becomes a tag plus eight bytes. That is why Bincode’s document is **122 bytes** and Speedy’s is **214**. It is also why encode takes more than twice as long: every integer is a chain of comparisons, and every field is a Serde visit, not a store.
+
+Decode is the same pipeline in reverse. Speedy’s `read_from_buffer` walks the known layout and fills a `Document`. Bincode’s `decode_from_slice` reconstructs a `Fixture` through Serde’s visitor, branching on integer width as it goes. That matches the measured 264 ns versus 573 ns.
+
+**History.** [Serde](https://serde.rs/) (Erick Tryzelaar, David Tolnay, and contributors; 2015 onward) gave Rust one data model so that JSON, MessagePack, Bincode, and many other formats could share a single `Serialize` implementation. The benefit is enormous for a language ecosystem. The cost on a tight encode path is exactly what you see here: an intermediate visitor that does not know Bincode’s layout. Bincode itself began as a simple Rust binary format (Ty Overby and contributors, mid-2010s). Version 2 split “native `Encode`” from “Serde front end” and made variable-length integers the default so that typical structs would be small. This suite measures the Serde front end with that default.
+
+## Side-by-side: one `i32` field
+
+Take `Document.status`, an `i32`.
+
+| Step | Speedy | Bincode (Serde + `standard()`) |
+|------|--------|--------------------------------|
+| How the field is reached | Generated `self.status.write_to(writer)` | `serialize_i32` on the Serde encoder |
+| How many bytes | Always 4 | 1, 2+1, or 4+1, depending on magnitude |
+| Branches | Endian swap if the host is not little-endian (none on this machine) | At least two magnitude tests, then a write |
+| What the CPU does | Copy four bytes | Compare, choose a tag, copy one to four bytes |
+
+Repeat that for every integer on every item in `items`. Document fixtures carry a short list of line items. The per-integer tax adds up.
+
+## Side-by-side: the `items` vector
+
+Speedy writes a `u32` count and then each `DocumentItem` with the same fixed layout. If the element type were a primitive, `write_slice` could copy the whole array as one byte block. `DocumentItem` is a struct, so the loop remains, but it is still a specialized loop.
+
+Bincode, through Serde, calls `serialize_seq` with a length, encodes that length as a variable-length integer, then visits each element as a struct of three fields. Three more visitor calls per item (`sku`, `qty`, `price_minor`).
+
+## What you give up to obtain Speedy’s speed
+
+| Axis | Speedy’s choice | Consequence |
+|------|-----------------|-------------|
+| Integer width | Fixed | Faster; **larger** messages (214 B vs 122 B here) |
+| Schema | The Rust type *is* the contract | Another language cannot read the bytes without a matching layout |
+| Evolution | No field numbers, no skip rule | Adding a field in the middle breaks old readers |
+| API surface | Own `Readable` / `Writable` traits | You derive Speedy in addition to (or instead of) Serde |
+| Safety on untrusted input | Bounds-checked reads, not a full verifier | Still your responsibility; see [301 untrusted input](../301/untrusted-input.md) |
+
+Bincode’s Serde path is the better default when the same struct must also speak JSON or MessagePack, or when message size on the network matters more than a few hundred nanoseconds. Postcard in this suite is the reminder that you can stay on Serde, keep variable-length integers, and still be faster than Bincode — it writes the `Fixture` with a tighter encoder (`postcard::to_extend`). Speedy still wins the stopwatch because it leaves Serde entirely. That pair is written out in [Speedy versus Postcard](rust-speedy-vs-postcard.md). In-place archives are a different lesson: [rkyv versus Speedy](rust-rkyv-vs-speedy.md).
+
+## Honesty
+
+1. **The wrapper is not identical.** Speedy encodes a `Document`. Bincode encodes a `Fixture`. A fairer Bincode call would be `encode_into_std_write(document, …)` on the inner struct, or Bincode’s native `Encode` derive without Serde. The suite measures the Serde integration because that is how Bincode is usually used.
+2. **`standard()` is a choice.** `bincode::config::legacy()` uses fixed-width integers and would move Bincode toward Speedy’s size/speed point. It is not what this runner configures.
+3. **Results own the numbers.** Payload shape changes the ratio. A document with huge strings spends most of its time copying UTF-8; the integer tax shrinks as a fraction.
+4. This page does not say “Rust wins.” It says why **one Rust library** outruns **another Rust library** on this fixture.
+
+## Self-check
+
+1. Write the bytes Speedy emits for `DocumentItem { sku: "A", qty: 1, price_minor: 2 }` on a little-endian machine (length as `u32`, then one byte `'A'`, then `i32`, then `i64`). How many bytes is that?
+2. Argue, from the `varint_encode_u32` listing, why the same item is shorter in Bincode and why encoding it is slower.
+3. Name one change to the Bincode wrapper that would shrink the speed gap without changing Speedy. Name one change that would shrink Bincode’s *size* advantage.
+4. Why is Postcard smaller than Speedy and still slower, given that both omit field names?

--- a/docs/theory/401/rust-speedy-vs-postcard.md
+++ b/docs/theory/401/rust-speedy-vs-postcard.md
@@ -1,0 +1,106 @@
+# Rust: Speedy versus Postcard — fixed widths versus compact integers
+
+## Why this article exists
+
+[Speedy versus Bincode](rust-speedy-vs-bincode.md) showed that leaving Serde and writing fixed-width integers makes encode fast and messages **larger**. A student can fairly ask whether compactness requires leaving Serde. **Postcard** stays on Serde, writes variable-length integers, and on this suite’s **document** fixture it is both smaller than Bincode and faster than Bincode. It is still slower than Speedy.
+
+This page holds “no field names” still and compares two compact binaries: Speedy’s native `Writable` with four- and eight-byte integers, versus Postcard’s Serde encoder with postcard-varints.
+
+Numbers are from the committed Rust **Results** snapshot (document, one instance). See [Rust Results](../../rust/results.md).
+
+## Short answer
+
+Both omit names. Speedy copies each integer at its native width and each length as a `u32`. Postcard writes a **variable-length integer** (seven data bits per byte, high bit continues) for integers, lengths, and the `Fixture` variant index. Small numbers become one byte. That is why Postcard is **114 bytes** and Speedy is **214**. Speedy still wins the stopwatch because it never asks “how many bytes does this need?” and it never visits Serde.
+
+| | Speedy 0.8.7 | Postcard 1.1.3 | Bincode 2.0.1 |
+|--|--------------|----------------|---------------|
+| Mean encode + decode | **2.84 million / s** | 1.73 million / s | 1.29 million / s |
+| Encode | **88 ns** | 163 ns | 203 ns |
+| Decode | **264 ns** | 414 ns | 573 ns |
+| Encoded size | 214 B | **114 B** | 122 B |
+
+Postcard is the size winner of the fast Rust binaries. Speedy is the speed winner. Bincode is neither.
+
+## The two timed call sites
+
+**Speedy** writes a `Document` (`rust/src/serializers/direct.rs`):
+
+```rust
+v.write_to_stream(&mut *out)?;
+// decode:
+Document::read_from_buffer(d)
+```
+
+**Postcard** writes the `Fixture` enumeration through Serde (`rust/src/serializers/binary_serde.rs`):
+
+```rust
+fn serialize_into(&mut self, fixture: &Fixture, out: &mut Vec<u8>) -> Result<()> {
+    let filled = postcard::to_extend(fixture, std::mem::take(out))?;
+    *out = filled;
+    Ok(())
+}
+fn deserialize_bytes(&mut self, data: &[u8]) -> Result<Fixture> {
+    Ok(postcard::from_bytes(data)?)
+}
+```
+
+`to_extend` appends into an existing `Vec<u8>` (Postcard 1.1.3, `src/ser/mod.rs`). That is kinder to allocation than “return a new vector.” It is still a Serde visit of `Fixture`, which begins with a variant index. Speedy never writes that index. Part of the time gap is this wrapper. The larger part is integer width.
+
+## What Speedy stores
+
+A derived `write_to` emits, for each string, a **32-bit length** and the bytes; for each `i32`, four bytes; for each `i64`, eight. On a little-endian host those stores are copies. See the Speedy/Bincode page for the generated skeleton and `write_u32`.
+
+## What Postcard stores
+
+Postcard (James Munns and the Ferrous Systems community, late 2010s) was written for **embedded** programs: `no_std`, small messages, no heap required if you encode into a stack buffer. Compactness is the point. Integers use a postcard-varint — the same family as Protocol Buffers varints:
+
+```rust
+// postcard 1.1.3, src/varint.rs
+pub fn varint_u32(n: u32, out: &mut [u8; varint_max::<u32>()]) -> &mut [u8] {
+    let mut value = n;
+    for i in 0..varint_max::<u32>() {
+        out[i] = value.to_le_bytes()[0];
+        if value < 128 {
+            return &mut out[..=i];
+        }
+        out[i] |= 0x80;
+        value >>= 7;
+    }
+    &mut out[..]
+}
+```
+
+The Serde serializer calls that helper for `u16`/`u32`/`u64`, for string lengths, and for sequence lengths (`src/ser/serializer.rs`). A `status` of `1` is one byte. Speedy always writes four. Eight line items, each with a small `qty` and a modest `price_minor`, add up to the 100-byte gap.
+
+Decode walks the same varints in reverse (`try_take_varint_u32`). Each integer is a short loop rather than a four-byte load. That is the 414 ns versus 264 ns.
+
+**History.** Variable-length integers are an old density trick: ASN.1 length octets, then Protocol Buffers varints (Google, 2000s), then Avro zigzag, then Postcard for microcontrollers. Speedy’s fixed widths are the other old trick: XDR and packed records. This pair is those two bets on the same Rust `Document`. See [Historical perspective](../101/historical_perspective.md).
+
+## Side-by-side: one small `i32`
+
+| Step | Speedy | Postcard |
+|------|--------|----------|
+| How the field is reached | Generated `write_to` | Serde `serialize_i32` |
+| Bytes for `qty = 2` | 4 (`02 00 00 00`) | 1 (`02`) |
+| Bytes for a length 3 string | 4 + 3 | 1 + 3 |
+| Branches | Endian swap if needed (none here) | “Is it less than 128?” per integer |
+
+Postcard still beats Bincode because its Serde encoder is thinner (no `standard()` width tags such as “this is a two-byte int”) and because `to_extend` reuses the runner’s vector. The idea — variable-length integers — is the same family as Bincode’s `standard()` config. The engineering is tighter.
+
+## What you give up
+
+| Axis | Speedy | Postcard |
+|------|--------|----------|
+| Size on this document | Larger | Smaller |
+| Encode/decode time | Smaller | Larger |
+| Another language | No public spec | Documented postcard layout, still Rust-first |
+| Embedded / `no_std` | Possible, not the design centre | The design centre |
+| Evolution | Reorder breaks readers | Reorder breaks readers (no field numbers) |
+
+Neither library is a multi-language service contract. For that, this suite’s `prost` row (155 B, 841 thousand / s on this fixture) is the Protocol Buffers answer. Postcard versus Speedy is a lesson about **width**, not about schemas.
+
+## Self-check
+
+1. Using `varint_u32`, how many bytes is `qty = 2`? How many is Speedy’s `i32`?
+2. Name one reason Postcard can stay on Serde and still beat Bincode.
+3. Why is this pair a better “size versus speed” lesson than Speedy versus Bincode alone?

--- a/docs/theory/401/swift-flatbuffers-vs-protobuf.md
+++ b/docs/theory/401/swift-flatbuffers-vs-protobuf.md
@@ -1,0 +1,132 @@
+# Swift: why FlatBuffers outruns SwiftProtobuf on Document
+
+## Why this article exists
+
+On this suite’s **document** fixture, one instance, in-memory buffer mode, **FlatBuffers** finishes more encode-and-decode cycles per second than **SwiftProtobuf**, while writing a **larger** message (440 bytes versus 155). Smaller is not faster. The two libraries are optimizing different moments: FlatBuffers arranges the buffer so a field is an offset plus a load; SwiftProtobuf writes a compact tag stream and must parse that stream to recover a field.
+
+This page compares the two timed wrappers and the generated code they call.
+
+Numbers are from the committed Swift **Results** snapshot. See [Swift Results](../../swift/results.md).
+
+## Short answer
+
+FlatBuffers wins the stopwatch because encode and decode are **table construction and offset arithmetic**. SwiftProtobuf wins the tape measure because encode is **tags plus variable-length integers** and there is no vtable.
+
+The runner is not perfectly symmetric. FlatBuffers *times* the copy into the suite’s domain `Document`. SwiftProtobuf’s timer stops at a generated `Message`; the later domain copy is off the clock. FlatBuffers still wins while doing more of the application’s work.
+
+| | FlatBuffers | SwiftProtobuf |
+|--|-------------|---------------|
+| Mean encode + decode, document, *n* = 1 | **132 thousand / s** | 114 thousand / s |
+| Encode | **3782 ns** | 4510 ns |
+| Decode | **3822 ns** | 4257 ns |
+| Encoded size | 440 B | **155 B** |
+
+## The two timed call sites
+
+**FlatBuffers** (`swift/Sources/SerializerBenchmarkCore/Serializers/FlatBuffersSer.swift`) reuses a builder and calls a bound encode function:
+
+```swift
+public func serializeBytes(_ fixture: Fixture) throws -> Data {
+    guard let encodeFn else { throw BenchError.prepareRequired }
+    builder.clear()
+    return try encodeFn(&builder, fixture)
+}
+```
+
+Document encode (`FlatBuffersBridge.swift`) creates strings, nested tables, a vector of item offsets, then a `FixtureRoot` wrapper:
+
+```swift
+let id = fbb.create(string: d.id)
+let region = fbb.create(string: d.meta.region)
+let meta = benchmark_v2_DocumentMeta.createDocumentMeta(...)
+for it in d.items {
+    let sku = fbb.create(string: it.sku)
+    itemOffs.append(benchmark_v2_DocumentItem.createDocumentItem(...))
+}
+let items = fbb.createVector(ofOffsets: itemOffs)
+return benchmark_v2_Document.createDocument(...)
+```
+
+`endTable` writes a **vtable**: a small table of 16-bit offsets that says where each field lives (`FlatBufferBuilder.endTable`).
+
+**SwiftProtobuf** converts the domain object in untimed `prepare`, then times `serializedData()` / `init(serializedBytes:)` (`Protobuf.swift`):
+
+```swift
+public func serializeBytes(_ fixture: Fixture) throws -> Data {
+    return try native.serializedData()
+}
+public func deserializeBytes(_ data: Data) throws -> Any {
+    return try decodeNative(data)
+}
+```
+
+`serializedData()` first walks the message to compute the size, allocates `Data` of that length, then walks again to write (`Message+BinaryAdditions.swift`). Each present field is a tag plus a payload:
+
+```swift
+// Generated Document.traverse
+if !self.id.isEmpty {
+    try visitor.visitSingularStringField(value: self.id, fieldNumber: 1)
+}
+if self.status != 0 {
+    try visitor.visitSingularInt32Field(value: self.status, fieldNumber: 2)
+}
+```
+
+```swift
+// BinaryEncoder.startField
+mutating func startField(tag: FieldTag) {
+    putVarInt(value: UInt64(tag.rawValue))   // (field << 3) | wire type
+}
+```
+
+## Why 440 bytes versus 155
+
+The information is the same. The layout is not.
+
+| Cost in FlatBuffers | Cost in Protocol Buffers |
+|---------------------|--------------------------|
+| A vtable per table (Document, Meta, each Item, plus `FixtureRoot`) | A one-byte tag for field numbers 1–4 |
+| Four-byte offsets to strings, vectors, and nested tables | A variable-length length plus UTF-8 |
+| `Int32` / `Int64` stored at full width, with alignment padding | Variable-length integers (a small `status` is one byte) |
+| A vector of eight item *offsets* (32 bytes) plus eight item tables | Eight tagged nested messages |
+| An extra 11-slot `FixtureRoot` so one buffer can hold any fixture kind | The root *is* the `Document` |
+
+440 bytes is close to JSON’s 448 on this fixture because both pay a per-field directory (vtables or names) plus padding. 155 bytes is the compact tag stream taught in the [Protocol Buffers wire format](protobuf-wire-format.md) article.
+
+**History.** [Wouter van Oortmerssen](https://en.wikipedia.org/wiki/Wouter_van_Oortmerssen) released FlatBuffers at Google around 2014 so that games and mobile clients could read a field without building a parallel object tree. Kenton Varda’s Cap’n Proto (2013) is the sibling idea. Protocol Buffers (open-sourced 2008) optimized the opposite moment: many small service messages, density, and skip-based evolution. See [201 in-place access](../201/zero-copy.md) and the [historical perspective](../101/historical_perspective.md).
+
+## Why FlatBuffers is still faster here
+
+Decode of a FlatBuffers `status` is: look up a 16-bit slot in the vtable, then load a little-endian `Int32`. There is no variable-length integer loop.
+
+```swift
+// generated accessor
+public var status: Int32 {
+    let o = _accessor.offset(VTOFFSET.status.v)
+    return o == 0 ? 0 : _accessor.readBuffer(of: Int32.self, at: o)
+}
+```
+
+SwiftProtobuf decode is `nextFieldNumber()` (a variable-length integer) in a loop, then a `switch` that fills properties. Encode pays *two* visits (size, then write) and a tag per field.
+
+On a document with eight items, eight vtables plus padding still cost less processor time in this runner than eight nested tag loops. The extra bytes are sequential and cheap. The extra branches are not.
+
+This suite does **not** stop at a FlatBuffers view. `documentDomain` copies strings and items into the suite `Document`, and that copy is on the clock. A production reader that only needed `status` could skip that copy. The comparison is therefore conservative toward SwiftProtobuf.
+
+## What you give up
+
+| Axis | FlatBuffers | SwiftProtobuf |
+|------|-------------|---------------|
+| Size on this fixture | Larger (vtables, padding, root wrapper) | Smaller (tags, varints) |
+| Read one field | Offset + load | Must parse up to that field (or the whole message, as timed) |
+| Evolution | Schema + vtable slots | Field numbers, skip unknowns |
+| Mutation | Rebuild the buffer | Rebuild the message and encode |
+| Debugging | Needs a FlatBuffers inspector | Still opaque without the `.proto`, but smaller |
+
+If the document is a public log, SwiftProtobuf’s 155 bytes and skip rules are the reason it exists. If the document is a large catalogue and the interface only needs three fields, FlatBuffers’ layout is the reason *it* exists.
+
+## Self-check
+
+1. Why can FlatBuffers be both larger and faster on the same record?
+2. Which bytes in the 440-byte image have no counterpart in the 155-byte image?
+3. The runner times FlatBuffers’ domain copy and does not time SwiftProtobuf’s. In which direction does that bias the rank?

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -134,6 +134,21 @@ nav:
           - "C: nanopb vs protobuf-c": theory/401/protobuf-c-nanopb-compare.md
           - "Lab: mini Protobuf encoder": theory/401/lab-mini-protobuf-encoder.md
           - "Same bytes, three runtimes": theory/401/protobuf-cross-language-fidelity.md
+          - "Python: msgspec vs orjson": theory/401/python-msgspec-vs-orjson.md
+          - "Python: msgspec JSON vs MessagePack": theory/401/python-msgspec-json-vs-msgpack.md
+          - "Python: orjson vs json": theory/401/python-orjson-vs-json.md
+          - "Rust: Speedy vs Bincode": theory/401/rust-speedy-vs-bincode.md
+          - "Rust: Speedy vs Postcard": theory/401/rust-speedy-vs-postcard.md
+          - "Rust: rkyv vs Speedy": theory/401/rust-rkyv-vs-speedy.md
+          - "C: custom-binary vs ubj": theory/401/c-custom-binary-vs-ubj.md
+          - "C++: Bitsery vs YAS": theory/401/cpp-bitsery-vs-yas.md
+          - "C++: the simdjson row": theory/401/cpp-simdjson-wrapper.md
+          - "C#: BinaryPack vs Bond": theory/401/csharp-binarypack-vs-bond.md
+          - "Go: kelindar vs Avro": theory/401/go-kelindar-vs-avro.md
+          - "Java: Protostuff vs protobuf": theory/401/java-protostuff-vs-protobuf.md
+          - "JavaScript: JSON vs protobuf": theory/401/javascript-json-vs-protobuf.md
+          - "JavaScript: three Protobuf engines": theory/401/javascript-three-protobufs.md
+          - "Swift: FlatBuffers vs protobuf": theory/401/swift-flatbuffers-vs-protobuf.md
   - Languages:
       # Alphabetical by display name
       - C:


### PR DESCRIPTION
## Summary
- Add one Serialization 401 article per language that follows this suite’s document (*n* = 1) leaders into the timed wrappers and library source, and explains the speed or size gap in ordinary language.
- Add a second wave of control experiments: msgspec JSON vs MessagePack, orjson vs stdlib json, Speedy vs Postcard, rkyv vs Speedy, three JavaScript Protocol Buffers engines, and what the C++ simdjson Results row actually times.
- Hook the pages into Learn → 401 (`mkdocs.yml` + course index).

## Validation
- Tests: analysis 85 passed; python 29 passed; javascript 10 passed; rust 15 passed; C++ prebuilt `cpp_serializer_tests` all roundtrips OK. Java/Maven not on PATH (skipped).
- Benchmarks: skipped (docs-only vs `origin/master`; `detect-changed-langs.sh` reported prose/meta-only).
- Error CSVs: not applicable (no re-bench).
- Analysis: not regenerated (no language runners changed).
- Dashboard: `sync-data.py` ran; gzip recompression churn was **not** committed.

## Notes
- Numbers are cited from committed language Results snapshots as teaching context, not as a universal ranking.
- Several articles document runner bias on purpose (cached encode, `prepare`, `from_bytes` vs in-place access, simdjson + nlohmann second parse).