### PR TITLE
docs: rename Method to Benchmarks and fix site 404 links

### DIFF
--- a/.grok/skills/improve-docs/SKILL.md
+++ b/.grok/skills/improve-docs/SKILL.md
@@ -23,7 +23,7 @@ cd "$(git rev-parse --show-toplevel)"
 
 **Surfaces (default):** root `README.md` + `dashboard/` (built into `docs/dashboard/`).  
 
-When the user asks for **deep** validation, expand to: storefront `docs/index.md`, **all** language overviews, theory level indices (101–401), Method section indices, plus dashboard visuals—still **without** fattening README against `README_EDITING.md`.
+When the user asks for **deep** validation, expand to: storefront `docs/index.md`, **all** language overviews, theory level indices (101–401), Benchmarks section indices, plus dashboard visuals—still **without** fattening README against `README_EDITING.md`.
 
 ---
 
@@ -159,4 +159,4 @@ Do **not** force `PREPARE_PR_BENCH_ALL` for copy/UI-only work.
 
 - **prepare-pr** — test / optional bench / analyze / sync-data / push / PR
 - **clean-logs** — prune logs; unrelated to prose unless disk blocks work
-- Site tabs: Dashboard · Learn · Languages · Method
+- Site tabs: Learn · Languages · Benchmarks · Dashboard · Experiments

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Compare 100+ serialization libraries across **nine languages**.
 | **Numbers** | [Live dashboard](https://leo-gan.github.io/GLD.SerializerBenchmark/dashboard/) |
 | **Experiments** | [One-question tests](https://leo-gan.github.io/GLD.SerializerBenchmark/experiments/) |
 | **Learn** | [Serialization 101–401](https://leo-gan.github.io/GLD.SerializerBenchmark/theory/101/) |
-| **Method** | [How we measure](https://leo-gan.github.io/GLD.SerializerBenchmark/analysis/ANALYSIS_METHODOLOGY/) · [Metrics](https://leo-gan.github.io/GLD.SerializerBenchmark/analysis/METRICS/) |
+| **Benchmarks** | [How we measure](https://leo-gan.github.io/GLD.SerializerBenchmark/analysis/ANALYSIS_METHODOLOGY/) · [Metrics](https://leo-gan.github.io/GLD.SerializerBenchmark/analysis/METRICS/) |
 
 <p align="center">
   <a href="https://leo-gan.github.io/GLD.SerializerBenchmark/dashboard/">

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -31,11 +31,11 @@
     </div>
     <nav id="main-nav" class="main-nav" aria-label="Site and dashboard navigation">
       <ul class="site-links" aria-label="Site sections">
-        <li><a href="./" class="current-section" id="nav-site-dashboard" aria-current="page">Dashboard</a></li>
-        <li><a href="../experiments/" id="nav-site-experiments">Experiments</a></li>
         <li><a href="../theory/101/" id="nav-site-learn">Learn</a></li>
         <li><a href="../c/" id="nav-site-languages">Languages</a></li>
-        <li><a href="../analysis/" id="nav-site-method">Method</a></li>
+        <li><a href="../analysis/" id="nav-site-method">Benchmarks</a></li>
+        <li><a href="./" class="current-section" id="nav-site-dashboard" aria-current="page">Dashboard</a></li>
+        <li><a href="../experiments/" id="nav-site-experiments">Experiments</a></li>
         <li>
           <a
             href="https://github.com/leo-gan/GLD.SerializerBenchmark"
@@ -149,7 +149,7 @@
           <strong>Pareto</strong> = best speed/size trade-offs ·
           <strong>Mode</strong> = bytes vs stream API ·
           <strong>Samples</strong> = which trials after warmup (default drops outliers) ·
-          <a href="../analysis/" id="orientation-method-link">Method</a> ·
+          <a href="../analysis/" id="orientation-method-link">Benchmarks</a> ·
           <a href="../theory/101/" id="orientation-learn-link">Learn 101</a>
         </p>
       </div>

--- a/docs/analysis/ADDING_A_SERIALIZER.md
+++ b/docs/analysis/ADDING_A_SERIALIZER.md
@@ -63,7 +63,7 @@ These keep rankings comparable. Violating them produces “suspicious” numbers
 
 CSV column **`SerializerVersion`** (immediately after `SerializerName`) must show the **installed** package/crate/module version at runtime — not a hard-coded string in most cases.
 
-### Hot path before full matrix (required)
+### Hot path before full matrix (required) {#hot-path-before-full-matrix-required}
 
 A PR that only “compiles and round-trips” is incomplete for this suite. **Correctness and the documented hot path land in the same first PR** — do not wait for a later “performance pass” after published numbers look slow.
 

--- a/docs/analysis/ANALYSIS_METHODOLOGY.md
+++ b/docs/analysis/ANALYSIS_METHODOLOGY.md
@@ -14,7 +14,7 @@ If architecture is the lab setup, methodology is the **lab notebook**: what we k
 | Paradigms | [Serialization categories](serialization_categories.md) |
 | How to regenerate published numbers | [Dashboard](../dashboard/) via `sync-data.py` · [Claims and replication](CLAIMS_AND_REPLICATION.md) |
 
-Defaults live under `statistics:` and `modes:` in [`config/benchmark_config.yaml`](../../config/benchmark_config.yaml). Regeneration is **local** (`analyze-benchmarks`); continuous integration does not re-run analysis for publication.
+Defaults live under `statistics:` and `modes:` in [`config/benchmark_config.yaml`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/config/benchmark_config.yaml). Regeneration is **local** (`analyze-benchmarks`); continuous integration does not re-run analysis for publication.
 
 ---
 
@@ -158,7 +158,7 @@ Published numbers live on the [Dashboard](../dashboard/). Those reports are PR-d
 
 ### Bootstrap confidence interval on the mean
 
-When bootstrap is enabled (default), analysis resamples the total-time series many times using the **[bootstrap](https://en.wikipedia.org/wiki/Bootstrapping_(statistics) "Bootstrapping (statistics) — resampling to estimate uncertainty")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />** (**percentile** method: 2000 iterations, 95% [confidence interval](https://en.wikipedia.org/wiki/Confidence_interval "Confidence interval — range of plausible values for a parameter")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />, seed 42) and reports:
+When bootstrap is enabled (default), analysis resamples the total-time series many times using the **[bootstrap](https://en.wikipedia.org/wiki/Bootstrapping_%28statistics%29 "Bootstrapping (statistics) — resampling to estimate uncertainty")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />** (**percentile** method: 2000 iterations, 95% [confidence interval](https://en.wikipedia.org/wiki/Confidence_interval "Confidence interval — range of plausible values for a parameter")<img src="https://en.wikipedia.org/static/images/icons/wikipedia.png" alt="" width="14" height="14" style="vertical-align: text-bottom; margin-left: 0.15em;" />, seed 42) and reports:
 
 - `total_ci_low_ns`
 - `total_ci_high_ns`
@@ -282,7 +282,7 @@ analyze-benchmarks --save-baseline   # only if check passes (or check not reques
 
 A machine-readable summary is written to `reports/regression_report.json` when you check.
 
-Config lives under `regression:` in [`config/benchmark_config.yaml`](../../config/benchmark_config.yaml).
+Config lives under `regression:` in [`config/benchmark_config.yaml`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/config/benchmark_config.yaml).
 
 ---
 
@@ -373,7 +373,7 @@ Honest methodology includes what the suite **cannot** claim.
 | Interquartile range (IQR) | [en.wikipedia.org/wiki/Interquartile_range](https://en.wikipedia.org/wiki/Interquartile_range) |
 | John Tukey | [en.wikipedia.org/wiki/John_Tukey](https://en.wikipedia.org/wiki/John_Tukey) |
 | Confidence interval | [en.wikipedia.org/wiki/Confidence_interval](https://en.wikipedia.org/wiki/Confidence_interval) |
-| Bootstrapping | [en.wikipedia.org/wiki/Bootstrapping_(statistics)](https://en.wikipedia.org/wiki/Bootstrapping_(statistics)) |
+| Bootstrapping | [en.wikipedia.org/wiki/Bootstrapping_(statistics)](https://en.wikipedia.org/wiki/Bootstrapping_%28statistics%29) |
 | Effect size | [en.wikipedia.org/wiki/Effect_size](https://en.wikipedia.org/wiki/Effect_size) |
 | Cliff’s delta | [Effect size § ordinal data](https://en.wikipedia.org/wiki/Effect_size#Effect_size_for_ordinal_data) |
 | Hedges’ g | [Effect size § Hedges' g](https://en.wikipedia.org/wiki/Effect_size#Hedges'_g) |

--- a/docs/analysis/METRICS.md
+++ b/docs/analysis/METRICS.md
@@ -72,7 +72,7 @@ After warmup drop and optional outlier filter, analysis groups rows by:
 | `total_mean_ns` / `ser_mean_ns` / `deser_mean_ns` | Arithmetic means | medium | no |
 | `total_std_ns` / `*_mad_ns` / `*_cv` | Dispersion (spread) | medium | no (context) |
 | `total_p5_ns` … `total_p99_ns` | Percentiles | medium (p95/p99) / low (others) | no |
-| `total_ci_low_ns` / `total_ci_high_ns` | [Bootstrap](https://en.wikipedia.org/wiki/Bootstrapping_(statistics) "Bootstrapping (statistics)") [confidence interval](https://en.wikipedia.org/wiki/Confidence_interval "Confidence interval") on **mean** total | medium | — |
+| `total_ci_low_ns` / `total_ci_high_ns` | [Bootstrap](https://en.wikipedia.org/wiki/Bootstrapping_%28statistics%29 "Bootstrapping (statistics)") [confidence interval](https://en.wikipedia.org/wiki/Confidence_interval "Confidence interval") on **mean** total | medium | — |
 | `avg_ops_per_sec` | `1e9 / total_mean_ns` | high (display) | **yes** |
 | `runs` / `runs_raw` / `warmup_skipped` / `outliers_removed` | Sample provenance | high | — |
 | `values_clipped` | Rows touched by winsorize (0 for drop filters) | medium | — |

--- a/docs/analysis/architecture.md
+++ b/docs/analysis/architecture.md
@@ -213,7 +213,7 @@ Run modes come from `modes:` in `config/benchmark_config.yaml`. Runners should c
 | `full` | 100 | Publication-quality run |
 | `research` | 500 | High-power statistical study |
 
-**When to pick which mode, and how this differs from I/O mode:** **[Modes — run modes](modes.md#part-2--run-modes-how-heavy-the-experiment-is)**.
+**When to pick which mode, and how this differs from I/O mode:** **[Modes — run modes](modes.md#part-2-run-modes-how-heavy-the-experiment-is)**.
 
 **Warmup policy:** benchmark runners **always log** every successful repetition, including index 0. Analysis drops `RepetitionIndex == 0` when `statistics.exclude_warmup` is true (the configured warmup count is **1**). Outlier filtering is also analysis-only. Raw files under `logs/<lang>/` are never rewritten by the stats pipeline.
 

--- a/docs/analysis/index.md
+++ b/docs/analysis/index.md
@@ -1,8 +1,8 @@
-# Method
+# Benchmarks
 
-This section explains **how this project measures serializers**, not the theory of formats themselves. On the site it lives under the **Method** tab. Live interactive results live under the **Dashboard** tab.
+This section explains **how this project measures serializers**, not the theory of formats themselves. On the site it lives under the **Benchmarks** tab. Live interactive results live under the **Dashboard** tab.
 
-If Learn / Serialization 101 answers *“what is serialization?”*, Method answers *“how do we time it fairly, and what do the numbers mean?”*
+If Learn / Serialization 101 answers *“what is serialization?”*, Benchmarks answers *“how do we time it fairly, and what do the numbers mean?”*
 
 You do not need to be a performance engineer to read these pages. They are written for introductory computer science students and for anyone who wants a clear picture of the suite before diving into tables and plots.
 

--- a/docs/analysis/modes.md
+++ b/docs/analysis/modes.md
@@ -84,7 +84,7 @@ On C#, for **binary** libraries, that string is often **Base64** text of the rea
 
 C#-specific notes: [C# overview — string vs stream](../c-sharp/index.md#string-mode-vs-stream-mode).
 
-### Three levels of “stream” honesty
+### Three levels of “stream” honesty {#three-levels-of-stream-honesty}
 
 Not every “stream mode” row is a deep, true streaming API.
 
@@ -133,7 +133,7 @@ If stream and bytes (or string) times are almost the same, check the language **
 
 ---
 
-## Part 2 — Run modes (how heavy the experiment is)
+## Part 2 — Run modes (how heavy the experiment is) {#part-2-run-modes-how-heavy-the-experiment-is}
 
 ### Why several run modes?
 

--- a/docs/analysis/test_data_configuration.md
+++ b/docs/analysis/test_data_configuration.md
@@ -6,11 +6,11 @@ Think of it as the **shared homework assignment**. Each language implements the 
 
 | Resource | Path |
 |----------|------|
-| Type catalog | [`schemas/data_catalog_v2.yaml`](../../schemas/data_catalog_v2.yaml) |
-| Run configs | [`config/library/`](../../config/library/) |
-| Wire schemas | [`schemas/v2/`](../../schemas/v2/) |
-| Default matrix | [`config/library/default.yaml`](../../config/library/default.yaml) |
-| Smoke matrix | [`config/library/smoke.yaml`](../../config/library/smoke.yaml) |
+| Type catalog | [`schemas/data_catalog_v2.yaml`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/schemas/data_catalog_v2.yaml) |
+| Run configs | [`config/library/`](https://github.com/leo-gan/GLD.SerializerBenchmark/tree/master/config/library) |
+| Wire schemas | [`schemas/v2/`](https://github.com/leo-gan/GLD.SerializerBenchmark/tree/master/schemas/v2) |
+| Default matrix | [`config/library/default.yaml`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/config/library/default.yaml) |
+| Smoke matrix | [`config/library/smoke.yaml`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/config/library/smoke.yaml) |
 
 **Type ids:** `message` · `document` · `telemetry` · `strings` · `event`
 
@@ -203,8 +203,8 @@ Prefer this wrapper over a package-level stream of top-level `repeated` messages
 
 | File | Matrix |
 |------|--------|
-| [`config/library/smoke.yaml`](../../config/library/smoke.yaml) | `message`, `telemetry` × `[1]` |
-| [`config/library/default.yaml`](../../config/library/default.yaml) | five types × `[1, 100]` |
+| [`config/library/smoke.yaml`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/config/library/smoke.yaml) | `message`, `telemetry` × `[1]` |
+| [`config/library/default.yaml`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/config/library/default.yaml) | five types × `[1, 100]` |
 
 Resolve a config to see the expanded cell list:
 

--- a/docs/c-sharp/index.md
+++ b/docs/c-sharp/index.md
@@ -11,7 +11,7 @@ In the .NET ecosystem, serialization has evolved dramatically over the past deca
 
 - Directory: `c-sharp/` (repository root)
 - Output: monorepo `logs/csharp/YYYY-MM-DD-HHMMSS.csv` (`Language=csharp`, times in **nanoseconds**)
-- Registration: [`c-sharp/src/Program.cs`](../../c-sharp/src/Program.cs)
+- Registration: [`c-sharp/src/Program.cs`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/c-sharp/src/Program.cs)
 - **Not in this suite:** Wire; Apex.Serialization (crashes on .NET 8); FluentSerializer (unsuitable for suite graphs)
 
 ## Serializers
@@ -67,7 +67,7 @@ These rows stay in the matrix for history and size noise, but **Dashboard number
 | **ExtendedXmlSerializer** | ExtendedXml of `{ TypeName, Json }` where `Json` is Newtonsoft of the domain object | `ToDomain` deserializes JSON | **Adapted** — UTF-8 `StreamWriter` of the XML string |
 | **Migrant** | Migrant of the same JSON envelope POCO | `ToDomain` deserializes JSON | **Native Migrant stream** of the envelope only; **string mode** is Base64 of those bytes |
 
-Source: [`ExtendedXmlSerializerSer.cs`](../../c-sharp/src/Serializers/ExtendedXmlSerializerSer.cs), [`MigrantSerializerSer.cs`](../../c-sharp/src/Serializers/MigrantSerializerSer.cs).
+Source: [`ExtendedXmlSerializerSer.cs`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/c-sharp/src/Serializers/ExtendedXmlSerializerSer.cs), [`MigrantSerializerSer.cs`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/c-sharp/src/Serializers/MigrantSerializerSer.cs).
 
 **Compare fairly:** use **MS XmlSerializer** / **YAXLib** / **MS DataContract** for real XML-ish paths; use **Ceras**, **MemoryPack**, **NetSerializer**, etc. for binary domain graphs — not Migrant’s envelope row.
 
@@ -92,7 +92,7 @@ When stream ≈ string within a few percent on the Dashboard, check which kind a
 
 ### Caveats
 
-- Most codecs serialize domain types **directly** (attributes on V2 models: `[DataContract]`, `[ProtoContract]`, `[Schema]`, `[MemoryPackable]`, …). Domain models live in [`c-sharp/src/TestData/V2/Models.cs`](../../c-sharp/src/TestData/V2/Models.cs).
+- Most codecs serialize domain types **directly** (attributes on V2 models: `[DataContract]`, `[ProtoContract]`, `[Schema]`, `[MemoryPackable]`, …). Domain models live in [`c-sharp/src/TestData/V2/Models.cs`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/c-sharp/src/TestData/V2/Models.cs).
 - **Library-native prepare (still real domain or codegen forms):** Google.Protobuf (`IMessage`), ZeroFormatter (`KeyTuple` on net8), FlatSharp (tables via map), CsvHelper (row lists). These are **not** JSON envelopes.
 - **Envelope exceptions:** ExtendedXmlSerializer and Migrant only — see above.
 - **Apex.Serialization** removed (crashes on .NET 8 `FieldInfoModifier`); **FluentSerializer** removed (cannot encode nested graphs / long strings reliably). **System.Text.Json** included.
@@ -102,7 +102,7 @@ When stream ≈ string within a few percent on the Dashboard, check which kind a
 - Failures: `logs/csharp/<ts>.errors.csv` (per run).
 - Rankings: use generated reports (`analyze-benchmarks`), not this list. Prefer [same category](../analysis/serialization_categories.md) and same I/O mode.
 
-Benchmark runner: [`c-sharp/README.md`](../../c-sharp/README.md). Categories & format trade-offs: [Serialization Categories](../analysis/serialization_categories.md).
+Benchmark runner: [`c-sharp/README.md`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/c-sharp/README.md). Categories & format trade-offs: [Serialization Categories](../analysis/serialization_categories.md).
 
 ## Numbers
 

--- a/docs/c/index.md
+++ b/docs/c/index.md
@@ -13,8 +13,8 @@ C serialization is fragmented: each library owns its own object model (DOM trees
 - Logs: `logs/c/YYYY-MM-DD-HHMMSS.csv`
 - Build: CMake, C11 (+ C++17 for Google libprotobuf)
 - Deps: `c/scripts/fetch-and-build-deps.sh`; Google protobuf: `cpp/scripts/setup-protobuf-sysroot.sh`
-- Registration: [`c/src/register_serializers.c`](../../c/src/register_serializers.c)
-- **Domain shape:** map-style codecs use a single visitor in [`c/src/v2_codec.c`](../../c/src/v2_codec.c) (`v2_write_fixture` / `v2_read_fixture`). Wrappers implement library ops only—they do not hard-code V2 field graphs.
+- Registration: [`c/src/register_serializers.c`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/c/src/register_serializers.c)
+- **Domain shape:** map-style codecs use a single visitor in [`c/src/v2_codec.c`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/c/src/v2_codec.c) (`v2_write_fixture` / `v2_read_fixture`). Wrappers implement library ops only—they do not hard-code V2 field graphs.
 
 ## Serializers
 
@@ -30,7 +30,7 @@ C serialization is fragmented: each library owns its own object model (DOM trees
 | tinycbor, libcbor, libcbor-stream, qcbor, zcbor | Binary/schema | Native CBOR map encode via visitor ops (`libcbor` = DOM API, `libcbor-stream` = streaming `cbor_encode_*`); decode via each library's native walker (tinycbor buffer walker, libcbor `cbor_load`). Do not read `libcbor-stream` deserialize as a streaming decoder. |
 | ubj | Binary | In-tree UBJSON markers around suite V2 binary payload (`bin_*`) |
 
-Pins: [`c/third_party/VERSIONS.md`](../../c/third_party/VERSIONS.md).
+Pins: [`c/third_party/VERSIONS.md`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/c/third_party/VERSIONS.md).
 
 ### Caveats
 

--- a/docs/cpp/index.md
+++ b/docs/cpp/index.md
@@ -12,9 +12,9 @@ C++ serialization spans **header-only JSON** (nlohmann, RapidJSON, ArduinoJson, 
 - Directory: `cpp/` (repository root)
 - Output: monorepo `logs/cpp/YYYY-MM-DD-HHMMSS.csv` (`Language=cpp`, times in **nanoseconds**)
 - Runner: `cpp/scripts/run-benchmarks.sh {smoke|all-single|full|research}`
-- Build: CMake **C++20**, deps via `FetchContent` → `cpp/third_party/` (pins in [`cpp/third_party/VERSIONS.md`](../../cpp/third_party/VERSIONS.md))
+- Build: CMake **C++20**, deps via `FetchContent` → `cpp/third_party/` (pins in [`cpp/third_party/VERSIONS.md`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/cpp/third_party/VERSIONS.md))
 - Official Protobuf: `cpp/scripts/setup-protobuf-sysroot.sh` (libprotobuf 3.12 + protoc, no root install)
-- Registration: [`cpp/src/register.cpp`](../../cpp/src/register.cpp)
+- Registration: [`cpp/src/register.cpp`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/cpp/src/register.cpp)
 
 ## Serializers
 
@@ -124,7 +124,7 @@ Some projects are C libraries with a pure C API. They are valid from C++ via `ex
 - Stream mode is **native** where the library exposes streams/buffers and the benchmark runner uses them (`VecOutStream`/`VecInStream`, Cap’n Proto `writeMessage`, msgpack packer/unpacker, etc.); others are **adapted** (stream path = bytes path).
 - First CMake configure downloads pinned deps into `cpp/third_party/` (network required once).
 
-Also: [`cpp/README.md`](../../cpp/README.md). [Serialization Categories](../analysis/serialization_categories.md).
+Also: [`cpp/README.md`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/cpp/README.md). [Serialization Categories](../analysis/serialization_categories.md).
 
 ## Numbers
 

--- a/docs/go/index.md
+++ b/docs/go/index.md
@@ -12,7 +12,7 @@ Go’s serialization landscape mixes **stdlib** codecs (`encoding/json`, `encodi
 - Directory: `go/` (repository root)
 - Output: monorepo `logs/go/YYYY-MM-DD-HHMMSS.csv` (`Language=go`, times in **nanoseconds**)
 - Runner: `go/scripts/run-benchmarks.sh {smoke|all-single|full|research}` or `go build && ./bin/serializer-benchmark-go <reps>`
-- Registration: [`go/serializers/registry.go`](../../go/serializers/registry.go)
+- Registration: [`go/serializers/registry.go`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/go/serializers/registry.go)
 
 ## Serializers
 
@@ -57,7 +57,7 @@ for rep:
 - **Stream adapted** only for **protobuf** and **linkedin/goavro** (bytes-only libraries; OCF/gRPC would change wire format). All other registered Go codecs use **native** stream APIs.
 - **mongo-bson** uses official Encoder/Decoder + `UseJSONStructTags` (no JSON map bridge).
 
-Also: [`go/README.md`](../../go/README.md) (call-path table). [Serialization Categories](../analysis/serialization_categories.md).
+Also: [`go/README.md`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/go/README.md) (call-path table). [Serialization Categories](../analysis/serialization_categories.md).
 
 ## Numbers
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ ideally one format family), not to crown a single global winner.
 | One-question tests (why we do not only use the big table) | **[Experiments](experiments/)** |
 | Course on formats and trade-offs (101–401) | **[Learn](theory/101/)** |
 | Per-language library lists and caveats | **[Languages](c/)** (sidebar: C, C#, C++, …) |
-| Methodology, metrics, how to add a codec | **[Method](analysis/)** |
+| Methodology, metrics, how to add a codec | **[Benchmarks](analysis/)** |
 
 ---
 
@@ -80,4 +80,4 @@ Then return to the **[Dashboard](dashboard/)** with clearer questions.
 - Payload shape changes costs a great deal.  
 - Numbers on this site are from **this** suite’s runners and analysis—not a universal ranking of all software.
 
-Full methodology: [Method overview](analysis/) · [Analysis methodology](analysis/ANALYSIS_METHODOLOGY/) · [Claims and replication](analysis/CLAIMS_AND_REPLICATION/).
+Full methodology: [Benchmarks overview](analysis/) · [Analysis methodology](analysis/ANALYSIS_METHODOLOGY/) · [Claims and replication](analysis/CLAIMS_AND_REPLICATION/).

--- a/docs/java/index.md
+++ b/docs/java/index.md
@@ -12,7 +12,7 @@ Java’s serialization landscape spans **JSON** (Jackson, Gson, Fastjson2, DSL-J
 - Directory: `java/` (repository root)
 - Output: monorepo `logs/java/YYYY-MM-DD-HHMMSS.csv` (`Language=java`, times in **nanoseconds**)
 - Runner: `java/scripts/run-benchmarks.sh {smoke|all-single|full|research}`
-- Registration: [`java/src/main/java/benchmark/serializers/Registry.java`](../../java/src/main/java/benchmark/serializers/Registry.java)
+- Registration: [`java/src/main/java/benchmark/serializers/Registry.java`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/java/src/main/java/benchmark/serializers/Registry.java)
 - Requires **JDK 17+** (benchmark runner targets 21) and **Maven 3.9+**
 
 ## Serializers
@@ -56,7 +56,7 @@ for rep:
 - Stream mode is **native** only where noted; others are adapted bytes+buffer.
 - Some JSON codecs (e.g. **jsoniter**) shorten floating-point digits; fidelity uses float tolerance.
 
-Also: [`java/README.md`](../../java/README.md). [Serialization Categories](../analysis/serialization_categories.md).
+Also: [`java/README.md`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/java/README.md). [Serialization Categories](../analysis/serialization_categories.md).
 
 ## Numbers
 

--- a/docs/javascript/index.md
+++ b/docs/javascript/index.md
@@ -12,7 +12,7 @@ Node benchmarks run on V8 with `performance.now()` converted to nanoseconds.
 - `javascript/` (repository root)
 - Logs: `logs/javascript/YYYY-MM-DD-HHMMSS.csv`
 - Requires Node ≥ 18
-- Registration: modular under [`javascript/src/serializers/`](../../javascript/src/serializers/)
+- Registration: modular under [`javascript/src/serializers/`](https://github.com/leo-gan/GLD.SerializerBenchmark/tree/master/javascript/src/serializers)
 - `prepare()` compiles schemas / reuses encoder instances outside timed loops
 - Protobuf codegen: `npm run generate:protobuf` (protobuf-es + google-protobuf; needs suite protoc sysroot for jspb stubs)
 
@@ -54,7 +54,7 @@ Node benchmarks run on V8 with `performance.now()` converted to nanoseconds.
 - **devalue** is a framework-oriented value codec (SvelteKit), not a portable wire standard.
 - **prepare()** builds native messages and compiles schemas outside the timed path.
 
-Also: [`javascript/README.md`](../../javascript/README.md).
+Also: [`javascript/README.md`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/javascript/README.md).
 
 ## Numbers
 

--- a/docs/javascripts/languages-nav.js
+++ b/docs/javascripts/languages-nav.js
@@ -81,7 +81,7 @@
           (el) => el.classList && el.classList.contains("md-nav__item")
         );
         // Language rows only: Overview-only, or Overview + leftover Results.
-        // Do not compact Learn 101/201/301/401 or Method (they also have an Overview child).
+        // Do not compact Learn 101/201/301/401 or Benchmarks (they also have an Overview child).
         const labels = items.map((item) => linkLabel(pageAnchor(item)));
         const leftoverResults = labels.includes("Results");
         if (!(items.length === 1 || (items.length === 2 && leftoverResults))) return;

--- a/docs/python/index.md
+++ b/docs/python/index.md
@@ -12,7 +12,7 @@ Python's dynamic nature makes serialization uniquely challenging. While it excel
 - Directory: `python/` (repository root)
 - Output: monorepo `logs/python/YYYY-MM-DD-HHMMSS.csv` (`Language=python`, times in **nanoseconds**)
 - Runner: `python/scripts/run-benchmarks.sh` (or project docs for modes)
-- Registration: [`python/src/benchmark/runner.py`](../../python/src/benchmark/runner.py)
+- Registration: [`python/src/benchmark/runner.py`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/python/src/benchmark/runner.py)
 - Modes: `bytes` and `stream`
 
 ## Serializers
@@ -65,7 +65,7 @@ FlatBuffers is the exception where Builder construction *is* the serialize API (
 - `tracemalloc` under-counts C/Rust extension allocations.
 - Fidelity is semantic, not strict type identity (dict vs dataclass, enum vs int, datetime ms truncation).
 
-Benchmark runner: [`python/README.md`](../../python/README.md). [Serialization Categories](../analysis/serialization_categories.md).
+Benchmark runner: [`python/README.md`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/python/README.md). [Serialization Categories](../analysis/serialization_categories.md).
 
 ## Numbers
 

--- a/docs/rust/index.md
+++ b/docs/rust/index.md
@@ -12,7 +12,7 @@ Rust serialization is dominated by the **serde** data model: libraries implement
 - Directory: `rust/` (repository root)
 - Output: monorepo `logs/rust/YYYY-MM-DD-HHMMSS.csv` (`Language=rust`, times in **nanoseconds**)
 - Runner: `rust/scripts/run-benchmarks.sh {smoke|all-single|full|research}` or `cargo run --release -- <reps>`
-- Registration: [`rust/src/serializers/mod.rs`](../../rust/src/serializers/mod.rs) (family modules under `serializers/`)
+- Registration: [`rust/src/serializers/mod.rs`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/rust/src/serializers/mod.rs) (family modules under `serializers/`)
 
 ## Serializers
 
@@ -55,7 +55,7 @@ These notes explain odd-looking correctness or speed edges on Rust only:
 - **flatbuffers / capnp:** not registered yet (codegen weight); flexbuffers partially covers FB-family schemaless use.
 - Stream mode is **native** only where noted; others are adapted bytes+cursor.
 
-Also: [`rust/README.md`](../../rust/README.md). [Serialization Categories](../analysis/serialization_categories.md).
+Also: [`rust/README.md`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/rust/README.md). [Serialization Categories](../analysis/serialization_categories.md).
 
 ## How to rank
 

--- a/docs/swift/index.md
+++ b/docs/swift/index.md
@@ -12,7 +12,7 @@ Swift’s serialization stack mixes **Codable** codecs (Foundation JSON/plist, I
 - Directory: `swift/`
 - Output: `logs/swift/YYYY-MM-DD-HHMMSS.csv` (`Language=swift`, times in **nanoseconds**)
 - Runner: `swift/scripts/run-benchmarks.sh {smoke|all-single|full|research}`
-- Registration: [`swift/Sources/SerializerBenchmarkCore/Serializers/Registry.swift`](../../swift/Sources/SerializerBenchmarkCore/Serializers/Registry.swift)
+- Registration: [`swift/Sources/SerializerBenchmarkCore/Serializers/Registry.swift`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/swift/Sources/SerializerBenchmarkCore/Serializers/Registry.swift)
 
 ## Serializers
 
@@ -50,7 +50,7 @@ fidelity                         # untimed, float-tolerant
 - Cap’n Proto has no maintained first-class Swift codegen; the benchmark runner uses the **official C++ library** via `CapnpBridge` (requires `libcapnp` / `libkj`, typically under `~/.local`).
 - TOML uses mattt/swift-toml (toml++); Linux builds may need GCC 11 `libstdc++` include flags (set in `run-benchmarks.sh`).
 
-Also: [`swift/README.md`](../../swift/README.md).
+Also: [`swift/README.md`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/swift/README.md).
 
 ## Numbers
 

--- a/docs/theory/101/index.md
+++ b/docs/theory/101/index.md
@@ -6,7 +6,7 @@ Welcome to Serialization 101. This course is a starting point for anyone who wan
 |------|--|
 | **This track** | Three lenses below · then [201 mechanisms](../201/index.md) |
 | **See numbers** | [Dashboard](../../dashboard/) · language **Overview** for roster |
-| **How we measure** | [Method](../../analysis/index.md) |
+| **How we measure** | [Benchmarks](../../analysis/index.md) |
 
 By the end of this theory track you should be able to:
 
@@ -15,7 +15,7 @@ By the end of this theory track you should be able to:
 3. Choose a format for a specific kind of work by using the right lens. One lens is data work. Another lens is services and systems.
 4. Connect the ideas in these pages to measured libraries in this multi-language benchmark suite.
 
-Theory alone does not tell you what to ship in production. Use this course to build vocabulary and judgment. Then check real numbers on the [Dashboard](../../dashboard/). Language **Overview** pages list the roster and caveats. For how those numbers are produced, see [Method](../../analysis/index.md).
+Theory alone does not tell you what to ship in production. Use this course to build vocabulary and judgment. Then check real numbers on the [Dashboard](../../dashboard/). Language **Overview** pages list the roster and caveats. For how those numbers are produced, see [Benchmarks](../../analysis/index.md).
 
 ---
 

--- a/docs/theory/201/index.md
+++ b/docs/theory/201/index.md
@@ -90,4 +90,4 @@ Install notes live in the [notebooks README](../notebooks/README.md).
 
 - **Core path:** [Serialization 301](../301/index.md) — production judgment when several constraints pull at once.
 - **Implementer elective:** [Serialization 401](../401/index.md) — wire formats, language-specific paths, and a hands-on lab.
-- Related reference pages: [Serialization categories](../../analysis/serialization_categories.md), [Engineering](../101/engineer_perspective.md), [Data science](../101/data_science_perspective.md), [Method](../../analysis/index.md), and the [Dashboard](../../dashboard/).
+- Related reference pages: [Serialization categories](../../analysis/serialization_categories.md), [Engineering](../101/engineer_perspective.md), [Data science](../101/data_science_perspective.md), [Benchmarks](../../analysis/index.md), and the [Dashboard](../../dashboard/).

--- a/docs/theory/301/index.md
+++ b/docs/theory/301/index.md
@@ -6,7 +6,7 @@
 |------|--|
 | **Prereqs** | [101](../101/index.md) · [201](../201/index.md) |
 | **Implementers** | [401 elective](../401/index.md) |
-| **Measure** | [Dashboard](../../dashboard/) · [using this suite](using-this-suite.md) · [Method](../../analysis/index.md) |
+| **Measure** | [Dashboard](../../dashboard/) · [using this suite](using-this-suite.md) · [Benchmarks](../../analysis/index.md) |
 
 In this course you will not re-learn wire encoding from scratch. Instead you will practice **judgment under constraints**. A first-year computer science student who has finished [Serialization 101](../101/index.md) and [Serialization 201](../201/index.md) should be able to follow every article. The technical depth stays. The language aims to teach rather than to impress.
 
@@ -60,7 +60,7 @@ By the end of this course you should be able to:
 | **301 (this course)** | Production judgment — what to ship under real constraints |
 | [401](../401/index.md) | Implementer elective — wire formats, language paths, and a hands-on lab |
 
-The default path through the program is **101, then 201, then 301**. For measured evidence on this project’s benchmark runner, use the [Dashboard](../../dashboard/). For how the suite measures, see [Method](../../analysis/index.md).
+The default path through the program is **101, then 201, then 301**. For measured evidence on this project’s benchmark runner, use the [Dashboard](../../dashboard/). For how the suite measures, see [Benchmarks](../../analysis/index.md).
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,10 +12,10 @@ theme:
   name: material
   custom_dir: docs_theme
   features:
-    # Header tabs: Dashboard | Experiments | Learn | Languages | Method
+    # Header tabs: Learn | Languages | Benchmarks | Dashboard | Experiments
     - navigation.tabs
     - navigation.tabs.sticky
-    # Left sidebar: sections under the active tab (Languages, Learn, Method)
+    # Left sidebar: sections under the active tab (Learn, Languages, Benchmarks)
     - navigation.sections
     - navigation.tracking
     - navigation.instant
@@ -91,11 +91,9 @@ extra_css:
 extra_javascript:
   - javascripts/languages-nav.js
 
-# Top tabs: Dashboard | Experiments | Learn | Languages | Method
+# Top tabs: Learn | Languages | Benchmarks | Dashboard | Experiments
 # Nested items appear in the left sidebar under the active tab (Material has no true ▾ dropdown).
 nav:
-  - Dashboard: dashboard/
-  - Experiments: experiments/index.md
   - Learn:
       - 101:
           - Overview: theory/101/index.md
@@ -180,14 +178,16 @@ nav:
           - Overview: rust/index.md
       - Swift:
           - Overview: swift/index.md
-  - Method:
+  - Benchmarks:
       - Overview: analysis/index.md
       - Architecture: analysis/architecture.md
       - Modes: analysis/modes.md
-      - Adding a Language: analysis/ADDING_A_LANGUAGE.md
-      - Adding a Serializer: analysis/ADDING_A_SERIALIZER.md
       - Categories: analysis/serialization_categories.md
       - Methodology: analysis/ANALYSIS_METHODOLOGY.md
       - Metrics: analysis/METRICS.md
       - Claims and replication: analysis/CLAIMS_AND_REPLICATION.md
       - Test Data: analysis/test_data_configuration.md
+      - Adding a Serializer: analysis/ADDING_A_SERIALIZER.md
+      - Adding a Language: analysis/ADDING_A_LANGUAGE.md
+  - Dashboard: dashboard/
+  - Experiments: experiments/index.md


### PR DESCRIPTION
## Summary

Rename the **Method** tab to **Benchmarks**, reorder the top nav, and fix links that 404 on the published site because they pointed at files outside the MkDocs `docs/` tree.

## Nav

Top tabs are now: **Learn · Languages · Benchmarks · Dashboard · Experiments**.

Under Benchmarks, **Adding a Serializer** and **Adding a Language** are the last two sidebar items.

## Link fixes

- **Benchmarks / Test Data** (and Methodology config links): `../../schemas/…` and `../../config/…` now go to GitHub `blob`/`tree` on `master`.
- Wikipedia “Bootstrapping (statistics)” URLs were truncated at the first `)`; encoded as `%28statistics%29`.
- Modes heading anchors that used an em dash / quotes now have explicit ids.
- **Language Overview** pages: registration files, READMEs, and other runner/source links now use GitHub URLs the same way.

Storefront, README, Learn 101/201/301, and the Dashboard header say **Benchmarks** instead of **Method**.