### PR TITLE
docs: add per-language runtime primers

### DIFF
--- a/docs/analysis/ADDING_A_LANGUAGE.md
+++ b/docs/analysis/ADDING_A_LANGUAGE.md
@@ -154,7 +154,7 @@ Honor `LOG_DIR` and `BENCHMARK_RUN_CONFIG` so lab experiments can point at `expe
 
 ## 6. Documentation
 
-- `docs/<lang>/index.md` — ecosystem overview, registered inventory, caveats.
+- `docs/<lang>/index.md` — ecosystem overview, a short **Runtime** section (what the platform is, what this suite targets, what changes the numbers, gotchas), registered inventory, caveats. Match the headings used by the existing language pages.
 - After benchmarks: run `analyze-benchmarks` (unpublished `reports/<docs_dir>/results.md`) and pack Dashboard data (step 8).
 - Register Overview under the **Languages** tab as a one-child nest in `mkdocs.yml`. The sidebar injects a Dashboard sibling.
 - Keep **Supported languages** lists alphabetical by display name (README, docs analysis index, MkDocs Languages).

--- a/docs/c-sharp/index.md
+++ b/docs/c-sharp/index.md
@@ -7,6 +7,48 @@ C#
 
 In the .NET ecosystem, serialization has evolved dramatically over the past decade. With modern .NET memory primitives (`Span<T>`, `Memory<T>`) and source generators, the landscape shifted from heavy reflection-based engines to lower-allocation, code-generated libraries.
 
+## Runtime
+
+### What it is
+
+C# is a programming language. It runs on **.NET**, a platform made of a virtual machine and a standard library. The virtual machine is called the **CLR** (Common Language Runtime). C# compiles first to an intermediate form named **IL**. The first time a method actually runs, the CLR translates that IL into native machine code. That late translation is called **JIT** (just-in-time compilation). Memory that the program no longer uses is reclaimed by a **garbage collector (GC)**. The programmer does not free objects by hand.
+
+The label “.NET 8” names the **target framework**: the set of runtime APIs the compiled program is allowed to call. The **SDK** is the compiler and the rest of the build tools. In this suite those two version numbers are not the same.
+
+| | This suite |
+|---|---|
+| Target | `net8.0` (.NET 8 APIs) |
+| Host SDK | .NET SDK **9+** (SDK 8 targeting pack also installed) |
+| Prepare | `./scripts/install-host-requirements.sh csharp` installs into `~/.dotnet` |
+| Run | `dotnet build` and `dotnet run -c Release` through `c-sharp/scripts/run-benchmarks.sh` |
+| Memory | Tracing garbage collector. No Docker. |
+
+### What this suite runs
+
+The project file targets `net8.0`, so the finished program uses the .NET 8 API surface. The machine that builds it still needs .NET SDK 9 or newer, because LightProto’s source generator requires Roslyn 4.14. A **source generator** is a compiler plugin that writes extra C# while the project builds. If only SDK 8 is installed, the project compiles, but LightProto never generates its parsers and every LightProto cell fails.
+
+We build and run in the **Release** configuration, which turns on optimizations. The **Debug** configuration is slower, and the Dashboard numbers do not come from it. The `dotnet` tools live under the user’s home directory. There is no Docker container.
+
+### What changes the numbers
+
+The JIT compiles methods on first use, so the earliest repetitions are often slower than later ones. Analysis may drop those warmup rows. Creating many temporary strings or buffers makes the garbage collector pause the process. A library that looks faster on average can still lose on the slowest requests (the **latency tail**).
+
+Modern codecs such as MemoryPack, FlatSharp, and SpanJson avoid extra copies by using `Span<T>`: a window over memory that already exists, rather than a new array. Source generators (MemoryPack, LightProto) write the encode and decode methods at build time. They therefore need a new enough SDK even when the target framework is still net8. Libraries that discover types by **reflection** (inspecting objects at run time) are simpler to write and usually allocate more.
+
+### Suite-specific gotchas
+
+Apex.Serialization was removed because it crashes on .NET 8. ZeroFormatter’s dynamic IL path is also broken on net8, so the suite uses `KeyTuple` shapes instead.
+
+On the **string** path, binary codecs usually encode the payload as Base64. That extra encode and decode runs inside the timer. See [string vs stream](#string-mode-vs-stream-mode).
+
+ExtendedXmlSerializer and Migrant do not serialize the suite objects as native XML or binary. They serialize a JSON envelope. See [envelope codecs](#envelope-codecs-not-native-domain-wire).
+
+These times cannot be ranked against another language. The runtimes and garbage collectors are different.
+
+### Where to go next
+
+The steps to install the toolchain and run the benchmark are in [`c-sharp/README.md`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/c-sharp/README.md). Microsoft’s overview of the platform is [What is .NET](https://learn.microsoft.com/dotnet/core/introduction). For how garbage collection shows up in latency, see [Latency tails and GC](../theory/301/latency-tails-and-gc.md).
+
 ## Benchmark runner
 
 - Directory: `c-sharp/` (repository root)
@@ -110,15 +152,3 @@ Measured numbers for this language live on the
 [Dashboard](../dashboard/?lang=csharp&data=document@n=1&mode=bytes)
 (pre-filtered). Claim level is **L1** (one machine, one session) —
 see [Claims and replication](../analysis/CLAIMS_AND_REPLICATION.md).
-
-## The Power of `Span<T>` and `Memory<T>`
-
-Historically, reading a byte array meant copying parts of it into new arrays. Modern serializers can create a window over existing memory without allocating new objects. Serializers in this suite that lean on modern layouts include **MemoryPack** and **FlatSharp** (among others).
-
-## AOT and Source Generators
-
-Reflection is slow and breaks down in AOT scenarios. Source generators produce hard-coded serialization methods at build time. In this suite, **MemoryPack** is the clearest example of that approach.
-
-## The Garbage Collector (GC) Pressure
-
-In high-throughput .NET applications, a common bottleneck is Garbage Collection from temporary strings or buffers. Choosing a serializer is often as much about allocations as about raw CPU time.

--- a/docs/c/index.md
+++ b/docs/c/index.md
@@ -7,6 +7,40 @@ C
 
 C serialization is fragmented: each library owns its own object model (DOM trees, streams, generated structs).
 
+## Runtime
+
+### What it is
+
+C has **no virtual machine**. `gcc` or `clang` compiles C11 to a native binary. Memory is **manual**: each library allocates and frees, or the benchmark runner does. There is no just-in-time compiler to warm up, and no garbage collector to pause the process. A C microsecond is therefore not the same kind of number as a C# or Python microsecond.
+
+| | This suite |
+|---|---|
+| Language | **C11** through CMake. C++17 is used only for Google libprotobuf. |
+| Build | CMake in the **Release** configuration |
+| Prepare | `cmake`, `curl`, and `c/scripts/fetch-and-build-deps.sh` |
+| Run | `c/scripts/run-benchmarks.sh` |
+| Memory | Manual allocation. No garbage collector. |
+
+### What this suite runs
+
+Third-party libraries are downloaded and built as static dependencies the first time you run the tree. Official Google protobuf uses the shared C++ sysroot created by `cpp/scripts/setup-protobuf-sysroot.sh`. A serializer is registered only when CMake actually linked it. The configure log prints `serializer: … REAL` for those rows.
+
+### What changes the numbers
+
+The choice of compiler and its optimization flags (`-O`) changes the numbers more than almost anything else. A CMake **Debug** build is not comparable to the Dashboard. Each library has its own object model: a DOM tree, a stream, or a generated struct. The suite visitor in `v2_codec.c` walks the fields so wrappers do not hard-code the V2 graph.
+
+### Suite-specific gotchas
+
+Stream mode is **adapted** for every row. The timed path writes or reads a full buffer through `fmemopen`, which is an in-memory `FILE*`. It is not each library’s own incremental stream API.
+
+`nanopb`, `protobuf-c`, and `protobuf-wire` currently time a shared in-tree proto3 helper. They are not full code-generated stacks for those libraries. See [caveats](#caveats).
+
+C rows and C++ rows are not the same runtime. See [C vs C++](../cpp/index.md#c-vs-c-clear-separation).
+
+### Where to go next
+
+The steps to install the toolchain and run the benchmark are in [`c/README.md`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/c/README.md). The language reference is [C on cppreference](https://en.cppreference.com/w/c).
+
 ## Benchmark runner
 
 - `c/` (repository root)

--- a/docs/cpp/index.md
+++ b/docs/cpp/index.md
@@ -7,6 +7,41 @@ C++
 
 C++ serialization spans **header-only JSON** (nlohmann, RapidJSON, ArduinoJson, **glaze**), **SIMD parse** (simdjson), **C libraries callable from C++** (yyjson), **schemaless binary** (MessagePack, cereal, bitsery, zpp_bits, CBOR/BSON via jsoncons), and **schema / zero-copy** families (official **libprotobuf**, in-tree Protobuf wire, FlatBuffers, FlexBuffers).
 
+## Runtime
+
+### What it is
+
+C++ compiles to **native machine code**. There is no virtual machine. This runner requires **C++20**. Memory is mostly handled by **RAII** (Resource Acquisition Is Initialization): an object frees its resources in its destructor when it goes out of scope. That is still not a garbage collector. Leaks and extra copies remain the programmer’s problem, and the library’s.
+
+| | This suite |
+|---|---|
+| Language | **C++20** (required) |
+| Build | CMake 3.16 or newer, **Release** configuration, `g++` or `clang++` |
+| Dependencies | CMake `FetchContent` downloads into `cpp/third_party/` (network needed once) |
+| Prepare | A C++20 compiler and cmake. Check with `./scripts/check-host-requirements.sh cpp`. |
+| Run | `cpp/scripts/run-benchmarks.sh` |
+| Memory | RAII and the heap. No garbage collector. |
+
+### What this suite runs
+
+The first CMake configure downloads the pinned third-party libraries. Official protobuf is a separate sysroot created by `cpp/scripts/setup-protobuf-sysroot.sh`. It is not the system `libprotobuf`. **glaze** is pinned to v2.9.5 because glaze v3 and later require C++23.
+
+### What changes the numbers
+
+The compiler’s optimization level changes the numbers more than almost anything else. Header-only JSON (nlohmann) and SIMD parse (simdjson) are different designs. They belong in the same ranking only when you stay inside one family.
+
+A C library called from C++, such as yyjson, is a C++ *call path*. It is not a second measurement of the C suite. See [C vs C++](#c-vs-c-clear-separation).
+
+### Suite-specific gotchas
+
+**simdjson** is optimized for parse. Serialize in this suite is prepared minified JSON, so that row does not claim a SIMD encoder.
+
+These times cannot be ranked against C, C#, or Python as one contest.
+
+### Where to go next
+
+The steps to install the toolchain and run the benchmark are in [`cpp/README.md`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/cpp/README.md). The language reference is [C++ on cppreference](https://en.cppreference.com/w/cpp).
+
 ## Benchmark runner
 
 - Directory: `cpp/` (repository root)

--- a/docs/go/index.md
+++ b/docs/go/index.md
@@ -7,6 +7,38 @@ Go
 
 Go’s serialization landscape mixes **stdlib** codecs (`encoding/json`, `encoding/gob`), a competitive **JSON performance tier** (sonic, goccy, jsoniter, segmentio, ugorji), **schemaless binary** (MessagePack, CBOR, kelindar/binary, BSON), **text documents** (YAML, TOML), and **schema/IDL** stacks (protobuf, Avro).
 
+## Runtime
+
+### What it is
+
+Go compiles to **native machine code** before the process starts. There is no Java-style virtual machine and no intermediate language such as .NET IL. The compiler still embeds a small **runtime** in every binary. That runtime includes a concurrent garbage collector, a scheduler for goroutines (Go’s lightweight threads), and the stacks those goroutines use. You do not install a separate “Go VM” in order to run the benchmark.
+
+| | This suite |
+|---|---|
+| Language / module | Go **1.24** (`go.mod` toolchain `go1.24.13`) |
+| Host bootstrap | Go **1.22 or newer**. `GOTOOLCHAIN=auto` may download 1.24. |
+| Prepare | `./scripts/install-host-requirements.sh go` installs into `~/.local/go` |
+| Run | `go/scripts/run-benchmarks.sh` runs `go build` and then the binary |
+| Memory | Concurrent garbage collector inside the Go runtime |
+
+### What this suite runs
+
+The runner is a normal `go build` of the `go/` tree with the compiler’s default optimizations. The install script only needs a bootstrap compiler. If that bootstrap is older than the version pinned in `go.mod`, the Go toolchain setting `GOTOOLCHAIN=auto` downloads the exact version the module asks for.
+
+### What changes the numbers
+
+Go’s garbage collector is designed for short pauses, but allocation still matters. Rows that reuse an `Encoder`, an `EncMode`, or a buffer — sonic’s `Pretouch`, ugorji Handles — often pull ahead of `encoding/json` for that reason. SIMD libraries such as sonic also depend on the host CPU. `encoding/gob` and `kelindar/binary` are Go-only wire formats.
+
+### Suite-specific gotchas
+
+**protobuf** and **linkedin/goavro** have no native stream API in this suite. Their stream rows are **adapted**: the timed path is still bytes, then a write or read of those bytes.
+
+These times cannot be ranked against another language.
+
+### Where to go next
+
+The steps to install the toolchain and run the benchmark are in [`go/README.md`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/go/README.md). The language overview is the [Go documentation](https://go.dev/doc/).
+
 ## Benchmark runner
 
 - Directory: `go/` (repository root)

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ ideally one format family), not to crown a single global winner.
 | Interactive charts, Pareto trade-offs, compare lab | **[Dashboard](dashboard/)** |
 | One-question tests (why we do not only use the big table) | **[Experiments](experiments/)** |
 | Course on formats and trade-offs (101–401) | **[Learn](theory/101/)** |
-| Per-language library lists and caveats | **[Languages](c/)** (sidebar: C, C#, C++, …) |
+| Per-language runtime primer, library lists, and caveats | **[Languages](c/)** (sidebar: C, C#, C++, …) |
 | Methodology, metrics, how to add a codec | **[Benchmarks](analysis/)** |
 
 ---

--- a/docs/java/index.md
+++ b/docs/java/index.md
@@ -7,13 +7,51 @@ Java
 
 Java’s serialization landscape spans **JSON** (Jackson, Gson, Fastjson2, DSL-JSON, Moshi, jsoniter), **high-performance native binary** (Kryo, Apache Fory, Protostuff, Hessian2, `java.io`), **portable binary** (MessagePack, CBOR, Smile, Ion, BSON), and **schema/IDL** stacks (Protocol Buffers, Avro).
 
+## Runtime
+
+### What it is
+
+Java compiles to **bytecode**, which is an intermediate instruction set. A **Java Virtual Machine (JVM)** then runs that bytecode. The JVM used here is HotSpot. It starts by interpreting bytecode and later **JIT**-compiles (just-in-time compiles) hot methods into native machine code. Unused objects are reclaimed by a **garbage collector**.
+
+The **JDK** (Java Development Kit) includes both the compiler (`javac`) and the JVM. A **JRE** (Java Runtime Environment) is the virtual machine without the compiler. This suite needs a JDK because it compiles the runner before it times anything.
+
+| | This suite |
+|---|---|
+| Target | Java **21** (`maven.compiler.release`) |
+| Host JDK | JDK **17 or newer** is accepted. The install script places **Temurin 21**. |
+| Build | Maven **3.9 or newer** |
+| Prepare | `./scripts/install-host-requirements.sh java` installs into `~/.local/jdk-21` and `~/.local/maven` |
+| Run | `java/scripts/run-benchmarks.sh` (`mvn package`) |
+| Memory | JVM garbage collector (HotSpot) |
+
+### What this suite runs
+
+We compile and run as Java 21. [Kotlin](../kotlin/) uses the same kind of JVM. Java is built with Maven. Kotlin is built with the Gradle wrapper that lives inside `kotlin/`.
+
+### What changes the numbers
+
+The first repetitions pay for JIT warmup. Later repetitions are closer to the steady state the Dashboard reports. Reusing mappers and buffers, such as Jackson’s `ObjectMapper` and Kryo’s `Output`, keeps allocation down. Libraries that use reflection, and the built-in `java.io` serialization, allocate more. Those formats are also not portable to other languages.
+
+These milliseconds cannot be ranked against C# or Python. The virtual machines are different.
+
+### Suite-specific gotchas
+
+**kryo**, **fory**, **hessian**, **protostuff**, and **java-serialization** encode JVM object graphs. They are not universal cross-language wires.
+
+Some JSON codecs shorten floating-point digits. Fidelity checks use a numeric tolerance for that reason.
+
+Stream mode is native only where the serializer table says so. Elsewhere the stream path is the bytes path written through a buffer.
+
+### Where to go next
+
+The steps to install the toolchain and run the benchmark are in [`java/README.md`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/java/README.md). Oracle’s overview is [Java SE 21](https://docs.oracle.com/en/java/javase/21/). For garbage collection and latency, see [Latency tails and GC](../theory/301/latency-tails-and-gc.md).
+
 ## Benchmark runner
 
 - Directory: `java/` (repository root)
 - Output: monorepo `logs/java/YYYY-MM-DD-HHMMSS.csv` (`Language=java`, times in **nanoseconds**)
 - Runner: `java/scripts/run-benchmarks.sh {smoke|all-single|full|research}`
 - Registration: [`java/src/main/java/benchmark/serializers/Registry.java`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/java/src/main/java/benchmark/serializers/Registry.java)
-- Requires **JDK 17+** (benchmark runner targets 21) and **Maven 3.9+**
 
 ## Serializers
 

--- a/docs/javascript/index.md
+++ b/docs/javascript/index.md
@@ -7,11 +7,46 @@ JavaScript
 
 Node benchmarks run on V8 with `performance.now()` converted to nanoseconds.
 
+## Runtime
+
+### What it is
+
+This suite measures **Node.js**, not JavaScript running in a web browser. Node.js is a command-line host that embeds the **V8** JavaScript engine, which is the same engine Chrome uses. V8 **JIT**-compiles (just-in-time compiles) hot functions into native code and reclaims unused objects with a garbage collector. Node also provides `Buffer`, `require`/`import`, and native addons written in C++.
+
+| | This suite |
+|---|---|
+| Host | **Node.js 18 or newer** and npm |
+| Engine | V8 inside Node.js, not a browser |
+| Prepare | Install Node with your package manager, then run `npm install` in `javascript/` |
+| Run | `javascript/scripts/run-benchmarks.sh` |
+| Memory | V8 garbage collector |
+
+### What this suite runs
+
+`package.json` requires Node 18 or newer. Timing uses `performance.now()` and converts the result to nanoseconds. There is **no stream mode**. Every codec is timed on in-memory buffers only.
+
+### What changes the numbers
+
+V8 compiles hot functions after they have run a few times, so early repetitions can be slower than later ones. Libraries that reuse an `Encoder` or `Packr` instance, such as `cbor-x` and `msgpackr`, avoid setup work on every call. `v8-serialize` is a Node-only format. It is not JSON and it is not portable to other languages. Optional native addons such as `simdjson` are left out of a run when they are not installed.
+
+Calling `JSON.stringify` in a browser on the same payload is a different environment from this Node runner.
+
+### Suite-specific gotchas
+
+**devalue** is a framework value codec used by tools such as SvelteKit. It is not a portable wire format.
+
+The row named **simdjson-parse+JSON.stringify** uses SIMD only for parse. Serialize is still the standard `JSON.stringify`.
+
+These times cannot be ranked against another language, or against a browser.
+
+### Where to go next
+
+The steps to install Node and run the benchmark are in [`javascript/README.md`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/javascript/README.md). The platform overview is [Introduction to Node.js](https://nodejs.org/en/learn/getting-started/introduction-to-nodejs).
+
 ## Benchmark runner
 
 - `javascript/` (repository root)
 - Logs: `logs/javascript/YYYY-MM-DD-HHMMSS.csv`
-- Requires Node ≥ 18
 - Registration: modular under [`javascript/src/serializers/`](https://github.com/leo-gan/GLD.SerializerBenchmark/tree/master/javascript/src/serializers)
 - `prepare()` compiles schemas / reuses encoder instances outside timed loops
 - Protobuf codegen: `npm run generate:protobuf` (protobuf-es + google-protobuf; needs suite protoc sysroot for jspb stubs)

--- a/docs/kotlin/index.md
+++ b/docs/kotlin/index.md
@@ -7,13 +7,49 @@ Kotlin
 
 Kotlin’s serialization landscape spans the **kotlinx.serialization format family** (JSON, CBOR, ProtoBuf, Properties, HOCON) plus **kaml** YAML on the same `@Serializable` types; **JVM JSON** (Jackson Kotlin, Moshi codegen vs reflection, Gson); **high-performance JVM binary** (Kryo, Apache Fory, Protostuff); **portable binary** (Jackson CBOR, MessagePack, Obor, KBson, Amazon Ion); **text** (tomlkt); and **schema/IDL** stacks (protobuf-java, protobuf-kotlin, FlatBuffers, Cap'n Proto, Avro4k, Apache Avro, Thrift).
 
+## Runtime
+
+### What it is
+
+Kotlin is a programming language. This runner targets the **same JVM** as [Java](../java/): bytecode on HotSpot, just-in-time compilation, and garbage collection. Kotlin can also compile to native code or to JavaScript. This suite does not measure those backends. It measures Kotlin running on the JVM.
+
+| | This suite |
+|---|---|
+| Target | JVM **21** (`jvmToolchain(21)`), Kotlin **2.1** |
+| Host JDK | JDK **17 or newer** is accepted. The same Temurin 21 install as Java is used. |
+| Build | Gradle wrapper in `kotlin/` (not Maven) |
+| Prepare | `./scripts/install-host-requirements.sh kotlin` |
+| Run | `kotlin/scripts/run-benchmarks.sh` (`./gradlew shadowJar`) |
+| Memory | JVM garbage collector (HotSpot) |
+
+### What this suite runs
+
+Kotlin 2.1 compiles to Java 21 bytecode. The Gradle wrapper is checked into `kotlin/`, so you do not install Gradle yourself. Domain types are `@Serializable` data classes with `@JvmField`, so JVM reflection codecs such as Jackson, Kryo, and Moshi see public fields.
+
+### What changes the numbers
+
+Warmup and garbage collection work the same way as on Java: the first repetitions pay for JIT compilation, and later ones are closer to steady state. **kotlinx.serialization** generates encode and decode methods at compile time. **moshi-codegen** uses KSP (Kotlin Symbol Processing) to generate an adapter. **moshi-reflect** uses reflection on the same types and is slower.
+
+Sharing a JVM with Java does not make the Java and Kotlin rows one measurement. The wrappers and the domain types are different.
+
+### Suite-specific gotchas
+
+**kryo**, **fory**, and **protostuff** encode JVM object graphs. They are not portable to other languages.
+
+When a cell has more than one instance, the TOML, HOCON, and BSON rows wrap the payload as `{ batch = [...] }`. Those formats cannot use a bare array as the document root.
+
+Kotlin times cannot be ranked against Java, or against any other language, as a single contest.
+
+### Where to go next
+
+The steps to install the toolchain and run the benchmark are in [`kotlin/README.md`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/kotlin/README.md). JetBrains’ overview is [Kotlin/JVM](https://kotlinlang.org/docs/jvm-get-started.html). For garbage collection and latency, see [Latency tails and GC](../theory/301/latency-tails-and-gc.md).
+
 ## Benchmark runner
 
 - Directory: `kotlin/` (repository root)
 - Output: monorepo `logs/kotlin/YYYY-MM-DD-HHMMSS.csv` (`Language=kotlin`, times in **nanoseconds**)
 - Runner: `kotlin/scripts/run-benchmarks.sh {smoke|all-single|full|research}`
 - Registration: [`kotlin/src/main/kotlin/benchmark/serializers/Registry.kt`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/kotlin/src/main/kotlin/benchmark/serializers/Registry.kt)
-- Requires **JDK 17+** (benchmark runner targets 21). Gradle wrapper is in-tree.
 
 ## Serializers
 

--- a/docs/php/index.md
+++ b/docs/php/index.md
@@ -7,6 +7,38 @@ PHP
 
 PHP’s suite rows cover **stdlib JSON**, **native `serialize`**, optional **PECL** binaries (igbinary, MessagePack, LibYAML, SIMDJSON, MongoDB BSON), **official google/protobuf**, **Symfony** and **JMS** JSON (plus Symfony XML), **Avro**, **CBOR**, and **pure-PHP MessagePack / YAML** as userland baselines.
 
+## Runtime
+
+### What it is
+
+PHP is often described as a language for web pages. This suite runs the **CLI** (command-line) binary, not PHP-FPM or Apache. The engine is **Zend**. It compiles a script to opcodes, which are an intermediate instruction set, and then executes those opcodes. The short, request-scoped life cycle of a web page does not apply here. One process runs many timed repetitions.
+
+| | This suite |
+|---|---|
+| Language | PHP **8.2 or newer** (`composer.json`). The install script offers a static **8.3** CLI. |
+| Packages | Composer (`composer install`) |
+| Prepare | `./scripts/install-host-requirements.sh php` installs into `~/.local/php` |
+| Run | `php/scripts/run-benchmarks.sh` |
+| Memory | Zend allocator, plus a garbage collector for cyclic structures |
+
+### What this suite runs
+
+The install script’s static CLI is built **without PECL extensions**. PECL is the usual way to add C extensions such as `igbinary`, `msgpack`, `yaml`, `simdjson`, and `mongodb` to PHP. Those rows register only when the matching extension is actually loaded. A missing row on the Dashboard often means this PHP binary was built without that extension. It does not mean the library is slow.
+
+### What changes the numbers
+
+PECL and other C extensions are typically much faster than pure-PHP packages such as `rybakit/msgpack` and `symfony/yaml`. `google/protobuf` reports `+ext` or `+php` in the version column, depending on which implementation loaded. The built-in `serialize` format works only in PHP.
+
+### Suite-specific gotchas
+
+A host that has the PECL rows and a host that does not are not the same matrix. Compare them only after you know which extensions were loaded.
+
+These times cannot be ranked against another language.
+
+### Where to go next
+
+The steps to install the toolchain and run the benchmark are in [`php/README.md`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/php/README.md). The language overview is [What is PHP?](https://www.php.net/manual/en/intro-whatis.php).
+
 ## Benchmark runner
 
 - Directory: `php/` (repository root)

--- a/docs/python/index.md
+++ b/docs/python/index.md
@@ -7,6 +7,44 @@ Python
 
 Python's dynamic nature makes serialization uniquely challenging. While it excels at developer productivity, the runtime overhead of object instantiation and the Global Interpreter Lock (GIL) can severely bottleneck high-throughput data processing pipelines.
 
+## Runtime
+
+### What it is
+
+This suite measures **CPython**, the usual C implementation of the Python interpreter. Other implementations such as PyPy are not used here. CPython compiles source to bytecode and then runs that bytecode in a virtual machine. Almost every value is a heap object with a type pointer and a reference count. That design makes Python easy to write and expensive to decode into, because even a small integer is a full object.
+
+The **Global Interpreter Lock (GIL)** is a lock that lets only one thread run Python bytecode at a time inside a process. If a decode takes 10 ms of Python bytecode, the whole process is blocked for those 10 ms, unless the library releases the GIL while it works in C, C++, or Rust.
+
+| | This suite |
+|---|---|
+| Interpreter | CPython **3.12 or newer**. Not PyPy or Jython. |
+| Host toolchain | [uv](https://docs.astral.sh/uv/) (`uv sync`) |
+| Prepare | `./scripts/install-host-requirements.sh python` |
+| Run | `python/scripts/run-benchmarks.sh` |
+| Memory | Reference counting plus a cyclic garbage collector. The GIL is present. |
+
+### What this suite runs
+
+`python/pyproject.toml` requires Python 3.12 or newer. The `uv` tool creates a local virtual environment and installs the packages listed in the lock file. The benchmark runner is ordinary CPython on the command line. It is not a web server such as FastAPI or Flask.
+
+### What changes the numbers
+
+Libraries with a C or Rust core, such as `orjson`, `msgspec`, and `protobuf`, spend most of the timed path outside the interpreter. They can release the GIL while they parse bytes. Pure-Python paths, such as `dill` serialize and the official FlatBuffers Builder, stay inside the virtual machine and look much slower.
+
+Deserializing into a `dict` is usually cheaper than building a class or a Pydantic model, because constructing Python objects is itself expensive. The `tracemalloc` tool under-counts allocations that happen inside C or Rust extensions.
+
+### Suite-specific gotchas
+
+The official FlatBuffers Python package builds with a pure-Python Builder. The C++ and Rust FlatBuffers libraries are a different speed class. This suite measures the Python binding. See [caveats](#why-flatbuffers-and-dill-opss-look-low).
+
+`pickle`, `cloudpickle`, and `dill` work only in Python. Loading untrusted input with them can run arbitrary code.
+
+These times cannot be ranked against another language.
+
+### Where to go next
+
+The steps to install the toolchain and run the benchmark are in [`python/README.md`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/python/README.md). The language overview is [The Python interpreter](https://docs.python.org/3/tutorial/interpreter.html). For the GIL and garbage collection in latency, see [Latency tails and GC](../theory/301/latency-tails-and-gc.md).
+
 ## Benchmark runner
 
 - Directory: `python/` (repository root)
@@ -73,25 +111,3 @@ Measured numbers for this language live on the
 [Dashboard](../dashboard/?lang=python&data=document@n=1&mode=bytes)
 (pre-filtered). Claim level is **L1** (one machine, one session) —
 see [Claims and replication](../analysis/CLAIMS_AND_REPLICATION.md).
-
-## The Global Interpreter Lock (GIL)
-
-In CPython, the GIL prevents multiple native threads from executing Python bytecodes simultaneously. This has massive implications for serialization in multithreaded web servers (like FastAPI or Flask).
-If a JSON payload takes 10ms to deserialize, the entire Python process is blocked for that 10ms.
-
-**The Solution:** The fastest Python serializers are written in C, C++, or Rust. They release the GIL while parsing the raw bytes and only reacquire it at the very end when they must instantiate the Python dictionary or object, allowing true concurrent processing.
-
-## Object Instantiation Overhead
-
-In Python, every object (even a simple integer) is a full-fledged heap-allocated structure with a reference count and a type pointer. Dictionaries have significant memory overhead compared to C structs.
-
-*   **Dicts vs. Classes:** Deserializing into a standard Python `dict` is generally much faster than instantiating custom classes or Pydantic models.
-*   **Slots:** If you must deserialize into classes, using `__slots__` reduces memory footprint and slightly speeds up attribute assignment.
-
-## Pickling vs. Standard Formats
-
-`pickle` is Python's built-in serialization format. It is deeply integrated into the language and can serialize almost arbitrary Python objects, including functions and classes.
-
-*   **Security:** `pickle` is notoriously insecure. Unpickling malicious data can execute arbitrary code on your machine.
-*   **Interoperability:** `pickle` is entirely Python-specific.
-*   **Performance:** While the C implementation in modern Python is fast, it is often outperformed by specialized binary serializers like `msgpack` or `orjson`.

--- a/docs/rust/index.md
+++ b/docs/rust/index.md
@@ -7,6 +7,40 @@ Rust
 
 Rust serialization is dominated by the **serde** data model: libraries implement `Serialize`/`Deserialize` once, then plug in format backends. A second tier (**rkyv**, FlatBuffers, Cap’n Proto) targets zero-copy access.
 
+## Runtime
+
+### What it is
+
+Rust compiles to **native machine code**. There is no virtual machine and no garbage collector. Memory is released when values go out of scope. That rule is called **ownership**. Because of it, a Rust microsecond is a different kind of number from a C#, Java, or Python microsecond.
+
+| | This suite |
+|---|---|
+| Edition | Rust **2021** |
+| Host toolchain | `rustc` and `cargo`, usually installed with rustup |
+| Prepare | `./scripts/install-host-requirements.sh rust` |
+| Run | `cargo build --release` through `rust/scripts/run-benchmarks.sh` |
+| Memory | Ownership. No garbage collector. |
+
+### What this suite runs
+
+The `--release` flag turns on optimizations. A `cargo run` without `--release` uses the Debug profile and is not comparable to the Dashboard. `prost` code is generated at build time by `build.rs`. Most rows go through **serde**, which is Rust’s shared serialize-and-deserialize trait. A few libraries (`minicbor`, `rkyv`, `nanoserde`, `speedy`, `prost`) use their own traits instead.
+
+### What changes the numbers
+
+Building without `--release` is the error that changes the numbers the most, because Debug Rust is far slower than optimized Rust. After that, the useful comparison is still inside one family: JSON with JSON, not JSON with a zero-copy schema codec.
+
+`rkyv` deserialize on the timed path **builds owned values** so the suite can check fidelity. A pure zero-copy `access` of the archived bytes would be faster and is not what this row measures. `simd-json` only accelerates parse; serialize still goes through `serde_json`.
+
+### Suite-specific gotchas
+
+Stream mode is native only where the serializer table says so. Elsewhere the stream path is the bytes path written through a cursor.
+
+These times cannot be ranked against a garbage-collected language as one contest.
+
+### Where to go next
+
+The steps to install the toolchain and run the benchmark are in [`rust/README.md`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/rust/README.md). The language overview is [The Rust Book](https://doc.rust-lang.org/book/).
+
 ## Benchmark runner
 
 - Directory: `rust/` (repository root)

--- a/docs/swift/index.md
+++ b/docs/swift/index.md
@@ -7,6 +7,40 @@ Swift
 
 Swift’s serialization stack mixes **Codable** codecs (Foundation JSON/plist, IkigaJSON, MessagePack, CBOR, BSON, YAML, XML) with **schema/IDL** stacks (SwiftProtobuf, FlatBuffers, Avro, Cap’n Proto).
 
+## Runtime
+
+### What it is
+
+Swift compiles to **native machine code**. Memory is managed with **ARC** (Automatic Reference Counting). An object is freed when the last reference to it goes away. That is not the same as the tracing garbage collector used by .NET or the JVM. Swift is not treated here as an Apple-only language. This runner is built and timed on **Linux** as well.
+
+| | This suite |
+|---|---|
+| Tools | Swift **5.10 or newer** (`Package.swift`). The install script places Swift **6.x** under `~/.local/swift`. |
+| Build | Swift Package Manager (`swift build -c release`) |
+| Prepare | `./scripts/install-host-requirements.sh swift` |
+| Run | `swift/scripts/run-benchmarks.sh` |
+| Memory | Automatic reference counting, not a tracing garbage collector |
+
+### What this suite runs
+
+The runner is built in the **release** configuration, which turns on optimizations. Codable wrappers never import the suite types. They see a type-erased `Fixture` value instead. Schema codecs (Protobuf, FlatBuffers, Avro, Cap’n Proto) convert between the suite objects and each library’s native type **outside** the timer.
+
+### What changes the numbers
+
+ARC still has a cost: every extra retain and release is work. Foundation JSON on Linux is not the same binary as Foundation JSON on Apple platforms. **Cap’n Proto** in this suite is the official **C++** library, reached through `CapnpBridge` and `libcapnp` / `libkj` under `~/.local`. It is not a pure-Swift runtime.
+
+### Suite-specific gotchas
+
+Stream mode is **adapted** for every registered codec. The timed path is still bytes, then a write or read of those bytes.
+
+Linux TOML builds may need GCC 11 `libstdc++` include flags. The run script already sets those flags.
+
+These times cannot be ranked against another language.
+
+### Where to go next
+
+The steps to install the toolchain and run the benchmark are in [`swift/README.md`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/swift/README.md). The language overview is [About Swift](https://www.swift.org/about/).
+
 ## Benchmark runner
 
 - Directory: `swift/`

--- a/docs/zig/index.md
+++ b/docs/zig/index.md
@@ -7,13 +7,47 @@ Zig
 
 Zig is in this suite because **comptime reflection** (`@typeInfo`) is a different implementation model from Java/Kotlin runtime reflection, C# source generation, or Rust derive macros. The runner times official `std.json` (typed `parseFromSlice` versus streaming `Scanner` / `parseFromTokenSource`) against an in-tree comptime byte-packed baseline, against **serde.zig**, a format-agnostic framework that uses the same `@typeInfo` walk for JSON, MessagePack, YAML, TOML, and ZON, and against **schema codecs** (Protocol Buffers, FlatBuffers, Cap’n Proto) generated from the shared suite IDLs.
 
+## Runtime
+
+### What it is
+
+Zig compiles to **native machine code**. There is no hidden virtual machine and no garbage collector. Allocation is explicit: the benchmark runner passes allocators in. **Comptime** means the compiler can run Zig code while it builds. `@typeInfo` walks a struct at compile time instead of using Java-style reflection at run time.
+
+| | This suite |
+|---|---|
+| Compiler | Zig **0.16.x**. Version 0.15 or 0.17 will not build this tree. |
+| Prepare | `./scripts/install-host-requirements.sh zig` installs into `~/.local/zig` |
+| Run | `zig/scripts/run-benchmarks.sh` (`zig build`) |
+| Memory | Explicit allocators. No garbage collector. |
+
+### What this suite runs
+
+Zig still changes in breaking ways between minor versions, so the host script installs 0.16.x and the checker rejects any other series. The Zig binary does not start Python. Cap’n Proto uses the official C++ library, because Zig 0.16 has no native Cap’n Proto plugin.
+
+### What changes the numbers
+
+Building without optimizations is the error that changes the numbers the most, because an unoptimized Zig binary is far slower than a release build. Codecs that use comptime, such as `std.json`, serde.zig, and `comptime-bin`, generate the field walk while the program compiles.
+
+A `@bitCast` of a live suite value is not a valid encoding. Slices inside that value are pointers, not payload bytes. See [Not a `@bitCast`](#not-a-bitcast-of-the-whole-fixture).
+
+### Suite-specific gotchas
+
+The `capnproto` row needs `libcapnp` and `libkj` under `~/.local`.
+
+Some serde.zig rows support only the **message** and **strings** data types.
+
+These times cannot be ranked against another language.
+
+### Where to go next
+
+The steps to install the toolchain and run the benchmark are in [`zig/README.md`](https://github.com/leo-gan/GLD.SerializerBenchmark/blob/master/zig/README.md). The language overview is [Zig overview](https://ziglang.org/learn/overview/).
+
 ## Benchmark runner
 
 - Directory: `zig/` (repository root)
 - Output: `logs/zig/YYYY-MM-DD-HHMMSS.csv` (`Language=zig`, times in **nanoseconds**)
 - Runner: `zig/scripts/run-benchmarks.sh {smoke|all-single|full|research}`
 - Registration: `zig/src/serializers.zig`
-- Zig version: **0.16.x** (`./scripts/install-host-requirements.sh zig`)
 
 The shell script resolves the run config to JSON. The Zig binary does not spawn Python. Prepare is untimed. The harness owns a reusable output buffer per serializer. Timed I/O is serialize plus deserialize only. Schedule is SHA-256 + SplitMix64 Fisher–Yates (golden vector `C, B, A`).
 


### PR DESCRIPTION
## Summary
- Add a Runtime section at the top of every language page (what the platform is, what this suite runs, what changes the numbers, suite-specific gotchas, and where to go next).
- Fold the leftover C# Span/AOT/GC and Python GIL essays into those sections.
- Require the same skeleton when adding a language.

## Validation
- Tests: analysis 90 passed; python 32 passed; javascript 10 passed; rust 15 passed; C++ roundtrips OK
- Java/Kotlin/PHP tests skipped (JDK 17+/Maven/php vendor not on this host)
- Benchmarks: skipped (docs-only; no benchmark-runner language changes)
- Experiments: skipped
- Error CSVs: skipped
- Analysis: not regenerated
- Dashboard: `sync-data.py` ran; gzip-only recompression restored, not committed

## Notes
- Install/run cookbooks stay in each language README. The new text is orientation for readers who do not already know the runtime.