### PR TITLE
fix(zig): decode into the trial arena instead of a nested one

### DIFF
--- a/zig/build.zig.zon
+++ b/zig/build.zig.zon
@@ -17,8 +17,8 @@
             .hash = "zbor-0.21.0-kr-CoMd7AwAj1t5CJoR8CoYr9CLQCNwBTNZEYYE9SBk0",
         },
         .msgpack_lalinsky = .{
-            .url = "https://github.com/lalinsky/msgpack.zig/archive/refs/heads/master.tar.gz",
-            .hash = "msgpack-0.7.0-ZOu9PAEaAgAM7pv6xQ8PCdm0uiD3cjgQq5SA3SjzodW5",
+            .url = "https://github.com/lalinsky/msgpack.zig/archive/refs/tags/v0.9.0.tar.gz",
+            .hash = "msgpack-0.9.0-ZOu9PEGgAgDvbGsCCi8OPV-n25bHqJniaZYM45BMJT4a",
         },
         .s2s = .{
             .url = "https://github.com/ziglibs/s2s/archive/refs/heads/master.tar.gz",

--- a/zig/src/extra.zig
+++ b/zig/src/extra.zig
@@ -89,24 +89,19 @@ pub fn encodeLalinsky(fx: data.Fixture, out: *buf_mod.Buf) !void {
 
 pub fn decodeLalinsky(allocator: std.mem.Allocator, type_id: []const u8, bytes: []const u8) !data.Fixture {
     if (std.mem.eql(u8, type_id, "message")) {
-        const parsed = try msgpack_l.decodeFromSlice(data.Message, allocator, bytes);
-        return .{ .message = parsed.value };
+        return .{ .message = try msgpack_l.decodeFromSliceLeaky(data.Message, allocator, bytes) };
     }
     if (std.mem.eql(u8, type_id, "document")) {
-        const parsed = try msgpack_l.decodeFromSlice(data.Document, allocator, bytes);
-        return .{ .document = parsed.value };
+        return .{ .document = try msgpack_l.decodeFromSliceLeaky(data.Document, allocator, bytes) };
     }
     if (std.mem.eql(u8, type_id, "telemetry")) {
-        const parsed = try msgpack_l.decodeFromSlice(data.Telemetry, allocator, bytes);
-        return .{ .telemetry = parsed.value };
+        return .{ .telemetry = try msgpack_l.decodeFromSliceLeaky(data.Telemetry, allocator, bytes) };
     }
     if (std.mem.eql(u8, type_id, "strings")) {
-        const parsed = try msgpack_l.decodeFromSlice(data.Strings, allocator, bytes);
-        return .{ .strings = parsed.value };
+        return .{ .strings = try msgpack_l.decodeFromSliceLeaky(data.Strings, allocator, bytes) };
     }
     if (std.mem.eql(u8, type_id, "event")) {
-        const parsed = try msgpack_l.decodeFromSlice(data.Event, allocator, bytes);
-        return .{ .event = parsed.value };
+        return .{ .event = try msgpack_l.decodeFromSliceLeaky(data.Event, allocator, bytes) };
     }
     return error.UnknownTypeId;
 }

--- a/zig/src/json_util.zig
+++ b/zig/src/json_util.zig
@@ -17,34 +17,29 @@ pub fn stringifyFixture(fx: data.Fixture, out: *buf_mod.Buf) !void {
 
 pub fn parseFixture(allocator: std.mem.Allocator, type_id: []const u8, bytes: []const u8) !data.Fixture {
     if (std.mem.eql(u8, type_id, "message")) {
-        const parsed = try std.json.parseFromSlice(data.Message, allocator, bytes, .{
+        return .{ .message = try std.json.parseFromSliceLeaky(data.Message, allocator, bytes, .{
             .allocate = .alloc_always,
-        });
-        return .{ .message = parsed.value };
+        }) };
     }
     if (std.mem.eql(u8, type_id, "document")) {
-        const parsed = try std.json.parseFromSlice(data.Document, allocator, bytes, .{
+        return .{ .document = try std.json.parseFromSliceLeaky(data.Document, allocator, bytes, .{
             .allocate = .alloc_always,
-        });
-        return .{ .document = parsed.value };
+        }) };
     }
     if (std.mem.eql(u8, type_id, "telemetry")) {
-        const parsed = try std.json.parseFromSlice(data.Telemetry, allocator, bytes, .{
+        return .{ .telemetry = try std.json.parseFromSliceLeaky(data.Telemetry, allocator, bytes, .{
             .allocate = .alloc_always,
-        });
-        return .{ .telemetry = parsed.value };
+        }) };
     }
     if (std.mem.eql(u8, type_id, "strings")) {
-        const parsed = try std.json.parseFromSlice(data.Strings, allocator, bytes, .{
+        return .{ .strings = try std.json.parseFromSliceLeaky(data.Strings, allocator, bytes, .{
             .allocate = .alloc_always,
-        });
-        return .{ .strings = parsed.value };
+        }) };
     }
     if (std.mem.eql(u8, type_id, "event")) {
-        const parsed = try std.json.parseFromSlice(data.Event, allocator, bytes, .{
+        return .{ .event = try std.json.parseFromSliceLeaky(data.Event, allocator, bytes, .{
             .allocate = .alloc_always,
-        });
-        return .{ .event = parsed.value };
+        }) };
     }
     return error.UnknownTypeId;
 }
@@ -53,34 +48,29 @@ pub fn parseFixtureScanner(allocator: std.mem.Allocator, type_id: []const u8, by
     var scanner = std.json.Scanner.initCompleteInput(allocator, bytes);
     defer scanner.deinit();
     if (std.mem.eql(u8, type_id, "message")) {
-        const parsed = try std.json.parseFromTokenSource(data.Message, allocator, &scanner, .{
+        return .{ .message = try std.json.parseFromTokenSourceLeaky(data.Message, allocator, &scanner, .{
             .allocate = .alloc_always,
-        });
-        return .{ .message = parsed.value };
+        }) };
     }
     if (std.mem.eql(u8, type_id, "document")) {
-        const parsed = try std.json.parseFromTokenSource(data.Document, allocator, &scanner, .{
+        return .{ .document = try std.json.parseFromTokenSourceLeaky(data.Document, allocator, &scanner, .{
             .allocate = .alloc_always,
-        });
-        return .{ .document = parsed.value };
+        }) };
     }
     if (std.mem.eql(u8, type_id, "telemetry")) {
-        const parsed = try std.json.parseFromTokenSource(data.Telemetry, allocator, &scanner, .{
+        return .{ .telemetry = try std.json.parseFromTokenSourceLeaky(data.Telemetry, allocator, &scanner, .{
             .allocate = .alloc_always,
-        });
-        return .{ .telemetry = parsed.value };
+        }) };
     }
     if (std.mem.eql(u8, type_id, "strings")) {
-        const parsed = try std.json.parseFromTokenSource(data.Strings, allocator, &scanner, .{
+        return .{ .strings = try std.json.parseFromTokenSourceLeaky(data.Strings, allocator, &scanner, .{
             .allocate = .alloc_always,
-        });
-        return .{ .strings = parsed.value };
+        }) };
     }
     if (std.mem.eql(u8, type_id, "event")) {
-        const parsed = try std.json.parseFromTokenSource(data.Event, allocator, &scanner, .{
+        return .{ .event = try std.json.parseFromTokenSourceLeaky(data.Event, allocator, &scanner, .{
             .allocate = .alloc_always,
-        });
-        return .{ .event = parsed.value };
+        }) };
     }
     return error.UnknownTypeId;
 }

--- a/zig/src/serializers.zig
+++ b/zig/src/serializers.zig
@@ -398,7 +398,7 @@ pub fn allSerializers() [17]Serializer {
         },
         .{
             .name = "msgpack.zig",
-            .version = "0.7.0",
+            .version = "0.9.0",
             .stream_mode = .native,
             .native_kind = .direct,
             .ctx = @ptrCast(&msgpack_l_state),


### PR DESCRIPTION
Thanks for the review request in #20 — this came out of looking at the `msgpack.zig` wrapper, but the same issue turned out to affect `std.json` as well, so the fix is general rather than specific to my library.

Two commits: the decode fix, and a dependency pin.

## 1. Decoding into the trial arena instead of a nested one

`runner.zig` already gives every trial a fresh `ArenaAllocator` and frees it after the measurement. But three adapters call the arena-wrapping entry point of their library, which heap-allocates and initialises a **second** arena on every call:

| adapter | call |
|---|---|
| `std.json` | `parseFromSlice` |
| `std.json.scanner` | `parseFromTokenSource` |
| `msgpack.zig` | `decodeFromSlice` |

Each keeps `.value` and drops the wrapper, so the nested arena buys nothing — it is pure per-call overhead inside the timed region. It also leaks in the general case, since the returned `Parsed` is never `deinit`'d; here the trial arena happens to reclaim it.

All three libraries provide a `*Leaky` variant for exactly this. `std.json` says so in the doc comment on `parseFromSlice`:

> If you are using a `std.heap.ArenaAllocator` or similar, consider calling `parseFromSliceLeaky` instead.

Adapters that already take an allocator directly — `zbor`, `s2s`, `std.zon`, `zig-msgpack` — never paid this and are untouched. `.allocate = .alloc_always` is preserved on the `std.json` calls, so string ownership is unchanged.

**Decode improvement:** `std.json` 2–19%, `std.json.scanner` 4–19%, `msgpack.zig` 8–40%.

The spread is the part that matters for how the suite reads. The nested arena is a roughly **fixed** per-call cost, so it lands as a larger *fraction* of a faster decoder. Identical treatment at the source level was therefore not producing equal treatment in the results — it penalised whichever adapter was already quickest. The effect is largest at `data_type_instance_count: 100`, where `deserializeCell` calls the adapter once per item.

## 2. Pinning msgpack.zig to a tag

`build.zig.zon` pointed at `refs/heads/master`, which GitHub redirects to `main`. The suite therefore tracked whatever was on the branch while reporting `0.7.0` in the results — two runs months apart could measure different code under the same label. Now pinned to `refs/tags/v0.9.0`, with the reported version corrected to match.

## Combined effect

`all-single`, Zig 0.16.0, ReleaseFast, median `TimeDeser` over reps 1..9. "was" is this branch's merge-base with the old floating dependency; "now" is both commits applied.

```
cell                      was        now   change  vs pb was  vs pb now
document/N=1              958        875      -9%      0.89x      0.80x
document/N=100          55136      39268     -29%      1.04x      0.73x
event/N=1                 720        586     -18%      0.97x      0.76x
event/N=100             45354      26702     -41%      1.27x      0.74x
message/N=1               493        410     -17%      1.07x      0.90x
message/N=100           14683      10620     -28%      1.27x      0.91x
strings/N=1               771        792       3%      0.61x      0.61x
strings/N=100           60034      58994      -2%      0.65x      0.63x
telemetry/N=1             702        604     -14%      0.79x      0.64x
telemetry/N=100         35312      23485     -33%      0.74x      0.50x
```

Three cells change sign against protobuf — `event/N=100` 1.27x → 0.74x, `message/N=100` 1.27x → 0.91x, `document/N=100` 1.04x → 0.73x.

Encode is unaffected, as expected: nothing here touches it (largest move 2%, within noise).

## Checks

- `protobuf`, `zbor` and `s2s` are untouched; protobuf moves 4.3% median between runs, so the changes above are well outside run-to-run variance
- `FidelityScore` is `1.0` on every row and no `.errors.csv` is produced
- Full `all-single` matrix run before and after on the same machine

## Two things I did not change

**The encode path.** Every adapter in `extra.zig` and `json_util.zig` serialises into a `std.Io.Writer.Allocating` and then copies into the runner's `Buf`. A `std.Io.Writer` implemented over `Buf` would let any adapter that speaks `std.Io.Writer` target it directly — I measured 19–41% on the msgpack encode path alone, and it would lift several rows. Happy to send it separately.

**Cap'n Proto is a hard build dependency.** `build.zig` calls `buildCapnpShared` and `applyCapnp` unconditionally, so the harness cannot be built without `libcapnp`/`libkj` present, even to work on an unrelated adapter. I built Cap'n Proto 1.0.2 from source to test this. A `-Dskip-capnp` flag guarding those few lines would make the Zig harness much easier to contribute to.
