### PR TITLE
perf(mojo): pre-size 2048-byte n=1 buffers and faster strings

### DIFF
--- a/mojo/src/bench/gldjson_ser.mojo
+++ b/mojo/src/bench/gldjson_ser.mojo
@@ -155,6 +155,7 @@ def _enc_doc(d: Document, mut w: WireWriter):
 
 def _dec_doc[origin: ImmOrigin](mut r: WireReader[origin]) raises DecodeError -> Document:
     var d = Document()
+    d.items = List[DocumentItem](capacity=8)
     r.eat(123)
     _need32(r, 5, UInt32(577005858))
     _byte(r, 4, 58)
@@ -302,6 +303,7 @@ def _enc_ev(e: Event, mut w: WireWriter):
 
 def _dec_ev[origin: ImmOrigin](mut r: WireReader[origin]) raises DecodeError -> Event:
     var e = Event()
+    e.attrs = List[EventAttr](capacity=4)
     r.eat(123)
     _need64(r, 11, UInt64(7592915514267428130))
     _byte(r, 8, 100)
@@ -366,7 +368,7 @@ struct GldJsonSer:
         return "mojo-json"
 
     def serialize_bytes(self, fx: Fixture) raises -> List[Byte]:
-        var cap = 256
+        var cap = 2048
         if fx.n > 1:
             cap = 65536
         var w = WireWriter(capacity=cap)

--- a/mojo/vendor/gldjson_src/gldjson_runtime/datum.mojo
+++ b/mojo/vendor/gldjson_src/gldjson_runtime/datum.mojo
@@ -116,11 +116,19 @@ def read_float_here[origin: ImmOrigin](mut r: WireReader[origin]) raises DecodeE
 def write_float_list(mut w: WireWriter, items: List[Float64], options: EncodeOptions):
     w.write_byte(Byte(91))
     var i = 0
+    if options.mode != EncodeOptions.PRETTY:
+        while i < len(items):
+            if i > 0:
+                w.write_byte(Byte(44))
+            w.write_float(items[i])
+            i += 1
+        w.write_byte(Byte(93))
+        return
     while i < len(items):
         w.write_member_sep(options, i == 0)
         w.write_float(items[i])
         i += 1
-    if options.mode == EncodeOptions.PRETTY and len(items) > 0:
+    if len(items) > 0:
         w.write_byte(Byte(10))
         w.write_indent(options)
     w.write_byte(Byte(93))
@@ -129,11 +137,19 @@ def write_float_list(mut w: WireWriter, items: List[Float64], options: EncodeOpt
 def write_int_list(mut w: WireWriter, items: List[Int64], options: EncodeOptions):
     w.write_byte(Byte(91))
     var i = 0
+    if options.mode != EncodeOptions.PRETTY:
+        while i < len(items):
+            if i > 0:
+                w.write_byte(Byte(44))
+            w.write_int(items[i])
+            i += 1
+        w.write_byte(Byte(93))
+        return
     while i < len(items):
         w.write_member_sep(options, i == 0)
         w.write_int(items[i])
         i += 1
-    if options.mode == EncodeOptions.PRETTY and len(items) > 0:
+    if len(items) > 0:
         w.write_byte(Byte(10))
         w.write_indent(options)
     w.write_byte(Byte(93))
@@ -142,11 +158,19 @@ def write_int_list(mut w: WireWriter, items: List[Int64], options: EncodeOptions
 def write_string_list(mut w: WireWriter, items: List[String], options: EncodeOptions):
     w.write_byte(Byte(91))
     var i = 0
+    if options.mode != EncodeOptions.PRETTY:
+        while i < len(items):
+            if i > 0:
+                w.write_byte(Byte(44))
+            w.write_string(items[i])
+            i += 1
+        w.write_byte(Byte(93))
+        return
     while i < len(items):
         w.write_member_sep(options, i == 0)
         w.write_string(items[i])
         i += 1
-    if options.mode == EncodeOptions.PRETTY and len(items) > 0:
+    if len(items) > 0:
         w.write_byte(Byte(10))
         w.write_indent(options)
     w.write_byte(Byte(93))
@@ -155,13 +179,13 @@ def write_string_list(mut w: WireWriter, items: List[String], options: EncodeOpt
 def read_float_list[
     origin: ImmOrigin
 ](mut r: WireReader[origin]) raises DecodeError -> List[Float64]:
-    var out = List[Float64]()
+    var out = List[Float64](capacity=32)
     r.eat(91)
     if r.peek() == 93:
         r.eat(93)
         return out^
     while True:
-        out.append(read_float(r))
+        out.append(read_float_here(r))
         var s = r.peek()
         if s == 93:
             r.eat(93)
@@ -174,13 +198,13 @@ def read_float_list[
 def read_int_list[
     origin: ImmOrigin
 ](mut r: WireReader[origin]) raises DecodeError -> List[Int64]:
-    var out = List[Int64]()
+    var out = List[Int64](capacity=32)
     r.eat(91)
     if r.peek() == 93:
         r.eat(93)
         return out^
     while True:
-        out.append(r.read_number().i)
+        out.append(r.read_int_here())
         var s = r.peek()
         if s == 93:
             r.eat(93)
@@ -193,13 +217,13 @@ def read_int_list[
 def read_string_list[
     origin: ImmOrigin
 ](mut r: WireReader[origin]) raises DecodeError -> List[String]:
-    var out = List[String]()
+    var out = List[String](capacity=32)
     r.eat(91)
     if r.peek() == 93:
         r.eat(93)
         return out^
     while True:
-        out.append(r.read_string())
+        out.append(r.read_string_here())
         var s = r.peek()
         if s == 93:
             r.eat(93)

--- a/mojo/vendor/gldjson_src/gldjson_wire/string.mojo
+++ b/mojo/vendor/gldjson_src/gldjson_wire/string.mojo
@@ -112,7 +112,18 @@ def parse_string[
         var n = scan - pos
         if n > MAX_ITEM_BYTES:
             raise DecodeError(DecodeError.KIND_RANGE, start)
-        var s = string_from_utf8(data[pos:scan], start)
+        var ascii = True
+        var i = pos
+        while i < scan:
+            if Int(data[i]) >= 128:
+                ascii = False
+                break
+            i += 1
+        var s: String
+        if ascii:
+            s = String(unsafe_from_utf8=data[pos:scan])
+        else:
+            s = string_from_utf8(data[pos:scan], start)
         pos = scan + 1
         return s^
     var out = List[Byte]()

--- a/mojo/vendor/gldjson_src/gldjson_wire/writer.mojo
+++ b/mojo/vendor/gldjson_src/gldjson_wire/writer.mojo
@@ -4,7 +4,7 @@ from std.memory import unsafe_memcpy
 from gldjson_runtime.error import DecodeError
 from gldjson_runtime.options import EncodeOptions
 from gldjson_wire.number import encoded_float_len, encoded_int_len, write_float_digits, write_int_digits
-from gldjson_wire.string import encoded_string_len, write_string_escaped
+from gldjson_wire.string import encoded_string_len, needs_escape, write_string_escaped
 
 
 struct WireWriter(Movable):
@@ -56,6 +56,16 @@ struct WireWriter(Movable):
         )
         self.pos += n
 
+    def write_u64(mut self, w: UInt64):
+        self.ensure(8)
+        self.buf.unsafe_ptr().unsafe_offset(self.pos).unsafe_bitcast[UInt64]()[] = w
+        self.pos += 8
+
+    def write_u32(mut self, w: UInt32):
+        self.ensure(4)
+        self.buf.unsafe_ptr().unsafe_offset(self.pos).unsafe_bitcast[UInt32]()[] = w
+        self.pos += 4
+
     def write_literal(mut self, s: String):
         self.write_bytes(s.as_bytes())
 
@@ -97,8 +107,21 @@ struct WireWriter(Movable):
             self.write_literal("0")
 
     def write_string(mut self, s: String):
-        var n = encoded_string_len(s)
-        self.ensure(n)
+        var b = s.as_bytes()
+        var n = len(b)
+        if not needs_escape(b):
+            self.ensure(n + 2)
+            self.buf[self.pos] = Byte(34)
+            if n > 0:
+                unsafe_memcpy(
+                    dest=self.buf.unsafe_ptr().unsafe_offset(self.pos + 1),
+                    src=b.unsafe_ptr(),
+                    count=n,
+                )
+            self.buf[self.pos + n + 1] = Byte(34)
+            self.pos += n + 2
+            return
+        self.ensure(encoded_string_len(s))
         write_string_escaped(self.buf, self.pos, s)
 
     def write_indent(mut self, options: EncodeOptions):


### PR DESCRIPTION
## Summary
- Official n=1 writer capacity 256 → 2048 (payloads are 411–491 bytes)
- Re-vendor gld-json #8: single-scan string write, ASCII decode, reserved lists
- Document items / event attrs reserved

Official all-single vs #143 (median skip warmup):

| cell | #143 ser/des | now ser/des | Ember | vs Ember |
|---|---:|---:|---:|---:|
| message n=1 | 258 / 484 | **256 / 418** | 248 / 540 | 0.97× / **1.29×** |
| document n=1 | 2144 / 1563 | **555 / 1273** | 502 / 1615 | 0.90× / **1.27×** |
| strings n=1 | 2257 / 4835 | **658 / 2894** | 595 / 1147 | 0.90× / 0.40× |
| event n=1 | 786 / 1841 | **369 / 1144** | 331 / 949 | 0.90× / 0.83× |
| message n=100 | 16576 / 39155 | **16303 / 32895** | 19613 / 31738 | **1.20×** / 0.96× |

Fidelity 1.0. 7/20 official cells now beat Ember. 1.5× floor still not met.

## Validation
- mojo `test_roundtrip.mojo` ok
- all-single json stem `2026-09-09-150051`