### PR TITLE
perf(mojo): vendor Ember/sonic 8-digit SWAR and two-digit itoa

### DIFF
--- a/mojo/vendor/gldjson_src/gldjson_runtime/datum.mojo
+++ b/mojo/vendor/gldjson_src/gldjson_runtime/datum.mojo
@@ -186,6 +186,14 @@ def read_float_list[
         return out^
     while True:
         out.append(read_float_here(r))
+        if r.pos < len(r.data):
+            var c = Int(r.data[r.pos])
+            if c == 93:
+                r.pos += 1
+                return out^
+            if c == 44:
+                r.pos += 1
+                continue
         var s = r.peek()
         if s == 93:
             r.eat(93)
@@ -205,6 +213,14 @@ def read_int_list[
         return out^
     while True:
         out.append(r.read_int_here())
+        if r.pos < len(r.data):
+            var c = Int(r.data[r.pos])
+            if c == 93:
+                r.pos += 1
+                return out^
+            if c == 44:
+                r.pos += 1
+                continue
         var s = r.peek()
         if s == 93:
             r.eat(93)
@@ -224,6 +240,14 @@ def read_string_list[
         return out^
     while True:
         out.append(r.read_string_here())
+        if r.pos < len(r.data):
+            var c = Int(r.data[r.pos])
+            if c == 93:
+                r.pos += 1
+                return out^
+            if c == 44:
+                r.pos += 1
+                continue
         var s = r.peek()
         if s == 93:
             r.eat(93)

--- a/mojo/vendor/gldjson_src/gldjson_wire/number.mojo
+++ b/mojo/vendor/gldjson_src/gldjson_wire/number.mojo
@@ -64,6 +64,12 @@ def encoded_int_len(v: Int64) -> Int:
 
 
 def write_int_digits(mut dest: List[Byte], mut pos: Int, v: Int64):
+    """yyjson two-digit write. `encoded_int_len` already counted digits."""
+    var n = encoded_int_len(v)
+    write_int_known(dest, pos, v, n)
+
+
+def write_int_known(mut dest: List[Byte], mut pos: Int, v: Int64, n: Int):
     if v == Int64(0):
         dest[pos] = Byte(48)
         pos += 1
@@ -77,27 +83,46 @@ def write_int_digits(mut dest: List[Byte], mut pos: Int, v: Int64):
             pos += 1
             i += 1
         return
+    var start = pos
     var mag = v
     if v < Int64(0):
         dest[pos] = Byte(45)
-        pos += 1
         mag = -v
-    var end = pos
+    var write = start + n
     var x = mag
-    while True:
-        end += 1
-        x = x // Int64(10)
-        if x == Int64(0):
-            break
-    var write = end
-    x = mag
-    while True:
+    while x >= Int64(100):
+        var r = Int(x % Int64(100))
+        write -= 2
+        dest[write] = Byte(48 + r // 10)
+        dest[write + 1] = Byte(48 + r % 10)
+        x = x // Int64(100)
+    write -= 1
+    dest[write] = Byte(48 + Int(x % Int64(10)))
+    if x >= Int64(10):
         write -= 1
-        dest[write] = Byte(48 + Int(x % Int64(10)))
-        x = x // Int64(10)
-        if x == Int64(0):
-            break
-    pos = end
+        dest[write] = Byte(48 + Int(x // Int64(10)))
+    pos = start + n
+
+
+def _is_eight_digits(w: UInt64) -> Bool:
+    """EmberJson / simdjson: all 8 bytes are ASCII digits. Needs 8 readable bytes."""
+    return (
+        (w & UInt64(0xF0F0F0F0F0F0F0F0))
+        | (((w + UInt64(0x0606060606060606)) & UInt64(0xF0F0F0F0F0F0F0F0)) >> UInt64(4))
+    ) == UInt64(0x3333333333333333)
+
+
+def _parse_eight_digits(w: UInt64) -> UInt64:
+    """sonic-cpp / EmberJson SWAR 8-digit accumulate."""
+    var val = w
+    val = (val & UInt64(0x0F0F0F0F0F0F0F0F)) * UInt64(2561) >> UInt64(8)
+    val = (val & UInt64(0x00FF00FF00FF00FF)) * UInt64(6553601) >> UInt64(16)
+    val = (val & UInt64(0x0000FFFF0000FFFF)) * UInt64(42949672960001) >> UInt64(32)
+    return val
+
+
+def _load_u64_at[origin: ImmOrigin](data: Span[Byte, origin], pos: Int) -> UInt64:
+    return data.unsafe_ptr().unsafe_offset(pos).unsafe_bitcast[UInt64]()[]
 
 
 def encoded_float_len(v: Float64) -> Int:
@@ -282,6 +307,16 @@ def parse_number[
                 raise DecodeError(DecodeError.KIND_NUMBER, start)
     else:
         var nd = 0
+        while pos + 8 <= len(data):
+            var w = _load_u64_at(data, pos)
+            if not _is_eight_digits(w):
+                break
+            nd += 8
+            if nd <= 18:
+                acc = acc * Int64(100000000) + Int64(_parse_eight_digits(w))
+            else:
+                overflow = True
+            pos += 8
         while pos < len(data):
             var d = Int(data[pos]) - 48
             if d < 0 or d > 9:
@@ -359,6 +394,17 @@ def parse_int[
         if pos < len(data) and is_digit(Int(data[pos])):
             raise DecodeError(DecodeError.KIND_NUMBER, start)
     else:
+        while pos + 8 <= len(data):
+            var w = _load_u64_at(data, pos)
+            if not _is_eight_digits(w):
+                break
+            nd += 8
+            if nd <= 18:
+                acc = acc * Int64(100000000) + Int64(_parse_eight_digits(w))
+            else:
+                pos = start
+                return parse_number(data, pos).i
+            pos += 8
         while pos < len(data):
             var d = Int(data[pos]) - 48
             if d < 0 or d > 9:
@@ -409,6 +455,15 @@ def _try_fast_float[
         i += 1
         nd = 1
     else:
+        while i + 8 <= end:
+            var w = _load_u64_at(data, i)
+            if not _is_eight_digits(w):
+                break
+            nd += 8
+            if nd > 18:
+                return False
+            acc = acc * Int64(100000000) + Int64(_parse_eight_digits(w))
+            i += 8
         while i < end:
             var d = Int(data[i]) - 48
             if d < 0 or d > 9:
@@ -421,6 +476,15 @@ def _try_fast_float[
     if i < end and Int(data[i]) == 46:
         i += 1
         var fs = i
+        while i + 8 <= end:
+            var w = _load_u64_at(data, i)
+            if not _is_eight_digits(w):
+                break
+            nd += 8
+            if nd > 18:
+                return False
+            acc = acc * Int64(100000000) + Int64(_parse_eight_digits(w))
+            i += 8
         while i < end:
             var d = Int(data[i]) - 48
             if d < 0 or d > 9:

--- a/mojo/vendor/gldjson_src/gldjson_wire/writer.mojo
+++ b/mojo/vendor/gldjson_src/gldjson_wire/writer.mojo
@@ -3,7 +3,12 @@ from std.memory import unsafe_memcpy
 
 from gldjson_runtime.error import DecodeError
 from gldjson_runtime.options import EncodeOptions
-from gldjson_wire.number import encoded_float_len, encoded_int_len, write_float_digits, write_int_digits
+from gldjson_wire.number import (
+    encoded_float_len,
+    encoded_int_len,
+    write_float_digits,
+    write_int_known,
+)
 from gldjson_wire.string import encoded_string_len, needs_escape, write_string_escaped
 
 
@@ -97,7 +102,12 @@ struct WireWriter(Movable):
     def write_int(mut self, v: Int64):
         var n = encoded_int_len(v)
         self.ensure(n)
-        write_int_digits(self.buf, self.pos, v)
+        write_int_known(self.buf, self.pos, v, n)
+
+    def finish_keep(deinit self, mut n: Int) -> List[Byte]:
+        """Return the buffer without shrinking. glaze reused-dest path."""
+        n = self.pos
+        return self.buf^
 
     def write_float(mut self, v: Float64):
         self.ensure(32)


### PR DESCRIPTION
## Summary
- Re-vendor gld-json #9 (SWAR 8-digit parse, two-digit itoa, compact list commas)
- Dest-reuse on the official writer was measured and dropped (extra memcpy)

Official all-single vs #144 (median skip warmup):

| cell | #144 deser | now deser | Ember | vs Ember |
|---|---:|---:|---:|---:|
| message n=1 | 418 | **406** | 537 | **1.32×** |
| telemetry n=1 | 2490 | **1678** | 1527 | 0.91× |
| telemetry n=100 | 238209 | **167450** | 148684 | 0.89× |
| strings n=1 | 2894 | **2264** | 1086 | 0.48× |
| strings n=100 | 301922 | **224586** | 102005 | 0.45× |

Fidelity 1.0. Stem `2026-09-09-153729`.

## Validation
- mojo `test_roundtrip.mojo` ok