### PR TITLE
perf(mojo): vendor one-pass float, 4-digit SWAR, and ctz scan

### DIFF
--- a/mojo/src/bench/gldjson_ser.mojo
+++ b/mojo/src/bench/gldjson_ser.mojo
@@ -368,7 +368,7 @@ struct GldJsonSer:
         return "mojo-json"
 
     def serialize_bytes(self, fx: Fixture) raises -> List[Byte]:
-        var cap = 2048
+        var cap = 1024
         if fx.n > 1:
             cap = 65536
         var w = WireWriter(capacity=cap)
@@ -447,6 +447,7 @@ struct GldJsonSer:
         )
         var r = WireReader(data)
         if fx.type_id == "message":
+            out.messages = List[Message](capacity=fx.n)
             if fx.n == 1:
                 out.messages.append(_dec_msg(r))
             else:
@@ -463,6 +464,7 @@ struct GldJsonSer:
                 r.eat_here(93)
                 _close(r)
         elif fx.type_id == "document":
+            out.documents = List[Document](capacity=fx.n)
             if fx.n == 1:
                 out.documents.append(_dec_doc(r))
             else:
@@ -479,6 +481,7 @@ struct GldJsonSer:
                 r.eat_here(93)
                 _close(r)
         elif fx.type_id == "telemetry":
+            out.telemetries = List[Telemetry](capacity=fx.n)
             if fx.n == 1:
                 out.telemetries.append(_dec_tel(r))
             else:
@@ -495,6 +498,7 @@ struct GldJsonSer:
                 r.eat_here(93)
                 _close(r)
         elif fx.type_id == "strings":
+            out.strings = List[Strings](capacity=fx.n)
             if fx.n == 1:
                 out.strings.append(_dec_str(r))
             else:
@@ -511,6 +515,7 @@ struct GldJsonSer:
                 r.eat_here(93)
                 _close(r)
         else:
+            out.events = List[Event](capacity=fx.n)
             if fx.n == 1:
                 out.events.append(_dec_ev(r))
             else:

--- a/mojo/vendor/gldjson_src/gldjson_runtime/datum.mojo
+++ b/mojo/vendor/gldjson_src/gldjson_runtime/datum.mojo
@@ -117,6 +117,7 @@ def write_float_list(mut w: WireWriter, items: List[Float64], options: EncodeOpt
     w.write_byte(Byte(91))
     var i = 0
     if options.mode != EncodeOptions.PRETTY:
+        w.ensure(2 + len(items) * 24)
         while i < len(items):
             if i > 0:
                 w.write_byte(Byte(44))
@@ -159,6 +160,7 @@ def write_string_list(mut w: WireWriter, items: List[String], options: EncodeOpt
     w.write_byte(Byte(91))
     var i = 0
     if options.mode != EncodeOptions.PRETTY:
+        w.ensure(2 + len(items) * 24)
         while i < len(items):
             if i > 0:
                 w.write_byte(Byte(44))

--- a/mojo/vendor/gldjson_src/gldjson_wire/number.mojo
+++ b/mojo/vendor/gldjson_src/gldjson_wire/number.mojo
@@ -69,6 +69,9 @@ def write_int_digits(mut dest: List[Byte], mut pos: Int, v: Int64):
     write_int_known(dest, pos, v, n)
 
 
+comptime _DIGIT_PAIRS = "00010203040506070809101112131415161718192021222324252627282930313233343536373839404142434445464748495051525354555657585960616263646566676869707172737475767778798081828384858687888990919293949596979899"
+
+
 def write_int_known(mut dest: List[Byte], mut pos: Int, v: Int64, n: Int):
     if v == Int64(0):
         dest[pos] = Byte(48)
@@ -90,11 +93,12 @@ def write_int_known(mut dest: List[Byte], mut pos: Int, v: Int64, n: Int):
         mag = -v
     var write = start + n
     var x = mag
+    var pairs = _DIGIT_PAIRS.as_bytes()
     while x >= Int64(100):
         var r = Int(x % Int64(100))
         write -= 2
-        dest[write] = Byte(48 + r // 10)
-        dest[write + 1] = Byte(48 + r % 10)
+        dest[write] = pairs[r * 2]
+        dest[write + 1] = pairs[r * 2 + 1]
         x = x // Int64(100)
     write -= 1
     dest[write] = Byte(48 + Int(x % Int64(10)))
@@ -125,13 +129,33 @@ def _load_u64_at[origin: ImmOrigin](data: Span[Byte, origin], pos: Int) -> UInt6
     return data.unsafe_ptr().unsafe_offset(pos).unsafe_bitcast[UInt64]()[]
 
 
+def _load_u32_at[origin: ImmOrigin](data: Span[Byte, origin], pos: Int) -> UInt32:
+    return data.unsafe_ptr().unsafe_offset(pos).unsafe_bitcast[UInt32]()[]
+
+
+def _is_four_digits(w: UInt32) -> Bool:
+    """Same 8-digit SWAR test, 4-byte lane. Needs 4 readable bytes."""
+    return (
+        (w & UInt32(0xF0F0F0F0))
+        | (((w + UInt32(0x06060606)) & UInt32(0xF0F0F0F0)) >> UInt32(4))
+    ) == UInt32(0x33333333)
+
+
+def _parse_four_digits(w: UInt32) -> UInt64:
+    """4-digit SWAR. Multiplies stay in UInt64; UInt32 overflows on 9999."""
+    var v = UInt64(w & UInt32(0x0F0F0F0F))
+    v = (v * UInt64(2561)) >> UInt64(8)
+    v = (v & UInt64(0x00FF00FF)) * UInt64(6553601) >> UInt64(16)
+    return v & UInt64(0xFFFF)
+
+
 def encoded_float_len(v: Float64) -> Int:
     if v != v:
         return 0
     if _int_valued_float(v):
         return encoded_int_len(Int64(v)) + 2
-    var s = _float_text(v)
-    return s.byte_length()
+    # Over-estimate. String(v) used to allocate on every size pass.
+    return 24
 
 
 def _write_short_decimal(mut dest: List[Byte], mut pos: Int, v: Float64) -> Bool:
@@ -228,8 +252,7 @@ def write_float_digits(mut dest: List[Byte], mut pos: Int, v: Float64) raises De
         dest[pos + 1] = Byte(48)
         pos += 2
         return
-    if _write_short_decimal(dest, pos, v):
-        return
+    # Skip _write_short_decimal: 7 exact-scale probes never hit random suite floats.
     if _write_round_decimal(dest, pos, v):
         return
     var s = _float_text(v)
@@ -264,17 +287,20 @@ def _write_round_decimal(mut dest: List[Byte], mut pos: Int, v: Float64) -> Bool
         dest[pos] = Byte(48)
         pos += 1
         return True
-    var tmp = scale // Int64(10)
-    var end = pos
-    var f = frac
-    var k = 0
-    while k < 9:
-        dest[end] = Byte(48 + Int(f // tmp))
-        end += 1
-        f = f % tmp
-        tmp = tmp // Int64(10)
-        k += 1
-    while end > pos + 1 and Int(dest[end - 1]) == 48:
+    # yyjson/ember digit-pair write of the 9-digit fraction, then strip zeros.
+    var start_f = pos
+    var write = start_f + 9
+    var fx = frac
+    var pairs = _DIGIT_PAIRS.as_bytes()
+    while write > start_f + 1:
+        var r = Int(fx % Int64(100))
+        write -= 2
+        dest[write] = pairs[r * 2]
+        dest[write + 1] = pairs[r * 2 + 1]
+        fx = fx // Int64(100)
+    dest[start_f] = Byte(48 + Int(fx))
+    var end = start_f + 9
+    while end > start_f + 1 and Int(dest[end - 1]) == 48:
         end -= 1
     pos = end
     return True
@@ -299,14 +325,15 @@ def parse_number[
         raise DecodeError(DecodeError.KIND_NUMBER, start)
     var acc = Int64(0)
     var overflow = False
+    var nd = 0
     if c == 48:
         pos += 1
+        nd = 1
         if pos < len(data):
             var n = Int(data[pos])
             if is_digit(n):
                 raise DecodeError(DecodeError.KIND_NUMBER, start)
     else:
-        var nd = 0
         while pos + 8 <= len(data):
             var w = _load_u64_at(data, pos)
             if not _is_eight_digits(w):
@@ -317,6 +344,16 @@ def parse_number[
             else:
                 overflow = True
             pos += 8
+        while pos + 4 <= len(data):
+            var w4 = _load_u32_at(data, pos)
+            if not _is_four_digits(w4):
+                break
+            nd += 4
+            if nd <= 18:
+                acc = acc * Int64(10000) + Int64(_parse_four_digits(w4))
+            else:
+                overflow = True
+            pos += 4
         while pos < len(data):
             var d = Int(data[pos]) - 48
             if d < 0 or d > 9:
@@ -328,22 +365,69 @@ def parse_number[
                 overflow = True
             pos += 1
     var is_int = True
+    var frac = 0
+    var exp = 0
     if pos < len(data) and Int(data[pos]) == 46:
         is_int = False
         pos += 1
         if pos >= len(data) or not is_digit(Int(data[pos])):
             raise DecodeError(DecodeError.KIND_NUMBER, start)
-        while pos < len(data) and is_digit(Int(data[pos])):
+        var fs = pos
+        while pos + 8 <= len(data):
+            var w = _load_u64_at(data, pos)
+            if not _is_eight_digits(w):
+                break
+            nd += 8
+            if nd <= 18:
+                acc = acc * Int64(100000000) + Int64(_parse_eight_digits(w))
+            else:
+                overflow = True
+            pos += 8
+        while pos + 4 <= len(data):
+            var w4 = _load_u32_at(data, pos)
+            if not _is_four_digits(w4):
+                break
+            nd += 4
+            if nd <= 18:
+                acc = acc * Int64(10000) + Int64(_parse_four_digits(w4))
+            else:
+                overflow = True
+            pos += 4
+        while pos < len(data):
+            var d = Int(data[pos]) - 48
+            if d < 0 or d > 9:
+                break
+            nd += 1
+            if nd <= 18:
+                acc = acc * Int64(10) + Int64(d)
+            else:
+                overflow = True
             pos += 1
+        frac = pos - fs
     if pos < len(data) and (Int(data[pos]) == 101 or Int(data[pos]) == 69):
         is_int = False
         pos += 1
+        var eneg = False
         if pos < len(data) and (Int(data[pos]) == 43 or Int(data[pos]) == 45):
+            eneg = Int(data[pos]) == 45
             pos += 1
         if pos >= len(data) or not is_digit(Int(data[pos])):
             raise DecodeError(DecodeError.KIND_NUMBER, start)
-        while pos < len(data) and is_digit(Int(data[pos])):
+        var ev = 0
+        var ed = 0
+        while pos < len(data):
+            var d = Int(data[pos]) - 48
+            if d < 0 or d > 9:
+                break
+            ev = ev * 10 + d
+            ed += 1
             pos += 1
+        if ed == 0:
+            raise DecodeError(DecodeError.KIND_NUMBER, start)
+        if eneg:
+            exp = -ev
+        else:
+            exp = ev
     var tok = NumberTok(
         is_int=is_int,
         is_neg=neg,
@@ -363,6 +447,18 @@ def parse_number[
         if ok:
             return tok
     tok.is_int = False
+    if not overflow and nd > 0:
+        var p = exp - frac
+        if p >= -22 and p <= 22:
+            var f = Float64(acc)
+            if p > 0:
+                f = f * _pow10f(p)
+            elif p < 0:
+                f = f / _pow10f(-p)
+            if neg:
+                f = -f
+            tok.f = f
+            return tok
     var fv = 0.0
     if _try_fast_float(data, start, pos, fv):
         tok.f = fv
@@ -405,6 +501,17 @@ def parse_int[
                 pos = start
                 return parse_number(data, pos).i
             pos += 8
+        while pos + 4 <= len(data):
+            var w4 = _load_u32_at(data, pos)
+            if not _is_four_digits(w4):
+                break
+            nd += 4
+            if nd <= 18:
+                acc = acc * Int64(10000) + Int64(_parse_four_digits(w4))
+            else:
+                pos = start
+                return parse_number(data, pos).i
+            pos += 4
         while pos < len(data):
             var d = Int(data[pos]) - 48
             if d < 0 or d > 9:
@@ -427,12 +534,54 @@ def parse_int[
 
 
 def _pow10f(k: Int) -> Float64:
-    var p = 1.0
-    var i = 0
-    while i < k:
-        p = p * 10.0
-        i += 1
-    return p
+    """EmberJson POWER_OF_TEN values. If-chain: InlineArray needs materialize."""
+    if k == 0:
+        return 1.0
+    if k == 1:
+        return 10.0
+    if k == 2:
+        return 100.0
+    if k == 3:
+        return 1000.0
+    if k == 4:
+        return 10000.0
+    if k == 5:
+        return 100000.0
+    if k == 6:
+        return 1000000.0
+    if k == 7:
+        return 10000000.0
+    if k == 8:
+        return 100000000.0
+    if k == 9:
+        return 1000000000.0
+    if k == 10:
+        return 1.0e10
+    if k == 11:
+        return 1.0e11
+    if k == 12:
+        return 1.0e12
+    if k == 13:
+        return 1.0e13
+    if k == 14:
+        return 1.0e14
+    if k == 15:
+        return 1.0e15
+    if k == 16:
+        return 1.0e16
+    if k == 17:
+        return 1.0e17
+    if k == 18:
+        return 1.0e18
+    if k == 19:
+        return 1.0e19
+    if k == 20:
+        return 1.0e20
+    if k == 21:
+        return 1.0e21
+    if k == 22:
+        return 1.0e22
+    return 1.0
 
 
 def _try_fast_float[
@@ -464,6 +613,15 @@ def _try_fast_float[
                 return False
             acc = acc * Int64(100000000) + Int64(_parse_eight_digits(w))
             i += 8
+        while i + 4 <= end:
+            var w4 = _load_u32_at(data, i)
+            if not _is_four_digits(w4):
+                break
+            nd += 4
+            if nd > 18:
+                return False
+            acc = acc * Int64(10000) + Int64(_parse_four_digits(w4))
+            i += 4
         while i < end:
             var d = Int(data[i]) - 48
             if d < 0 or d > 9:
@@ -485,6 +643,15 @@ def _try_fast_float[
                 return False
             acc = acc * Int64(100000000) + Int64(_parse_eight_digits(w))
             i += 8
+        while i + 4 <= end:
+            var w4 = _load_u32_at(data, i)
+            if not _is_four_digits(w4):
+                break
+            nd += 4
+            if nd > 18:
+                return False
+            acc = acc * Int64(10000) + Int64(_parse_four_digits(w4))
+            i += 4
         while i < end:
             var d = Int(data[i]) - 48
             if d < 0 or d > 9:

--- a/mojo/vendor/gldjson_src/gldjson_wire/simdscan.mojo
+++ b/mojo/vendor/gldjson_src/gldjson_wire/simdscan.mojo
@@ -1,3 +1,4 @@
+from std.bit import count_trailing_zeros
 from std.collections import Span
 from std.memory.unsafe import pack_bits
 
@@ -6,14 +7,10 @@ comptime SCAN_W = 16
 
 
 def _first_set(bits: Int) -> Int:
-    var b = bits
-    var off = 0
-    while off < SCAN_W:
-        if (b & 1) != 0:
-            return off
-        b >>= 1
-        off += 1
-    return SCAN_W
+    """EmberJson / simdjson: ctz, not a 16-step scalar walk."""
+    if bits == 0:
+        return SCAN_W
+    return Int(count_trailing_zeros(UInt32(bits)))
 
 
 def skip_ws_span[origin: ImmOrigin](data: Span[Byte, origin], mut pos: Int):
@@ -26,7 +23,7 @@ def skip_ws_span[origin: ImmOrigin](data: Span[Byte, origin], mut pos: Int):
         return
     var ptr = data.unsafe_ptr()
     while pos + SCAN_W <= n:
-        var chunk = ptr.load[width=SCAN_W](pos)
+        var chunk = ptr.unsafe_load[width=SCAN_W](pos)
         var non = (
             chunk.ne(SIMD[DType.uint8, SCAN_W](32))
             .__and__(chunk.ne(SIMD[DType.uint8, SCAN_W](9)))
@@ -49,14 +46,30 @@ def skip_ws_span[origin: ImmOrigin](data: Span[Byte, origin], mut pos: Int):
 def first_escape_or_quote[origin: ImmOrigin](data: Span[Byte, origin], start: Int) -> Int:
     """Index of the first `"`, `\\`, or control byte at or after `start`.
     Returns `len(data)` if none (caller treats that as EOF)."""
+    var ascii = True
+    return scan_plain_string(data, start, ascii)
+
+
+def scan_plain_string[
+    origin: ImmOrigin
+](data: Span[Byte, origin], start: Int, mut ascii: Bool) -> Int:
+    """Quote/escape/control index. Sets `ascii` False on any byte >= 128.
+
+    SIMD first when 16 bytes remain (mid-object always does). Scalar-first-16
+    was slower on the official strings suite.
+    """
+    ascii = True
     var n = len(data)
     var i = start
     var ptr = data.unsafe_ptr()
     var q = SIMD[DType.uint8, SCAN_W](34)
     var sl = SIMD[DType.uint8, SCAN_W](92)
     var thirty_two = SIMD[DType.uint8, SCAN_W](32)
+    var high = SIMD[DType.uint8, SCAN_W](128)
     while i + SCAN_W <= n:
-        var chunk = ptr.load[width=SCAN_W](i)
+        var chunk = ptr.unsafe_load[width=SCAN_W](i)
+        if Int(pack_bits(chunk.ge(high))) != 0:
+            ascii = False
         var hit = chunk.eq(q).__or__(chunk.eq(sl)).__or__(chunk.lt(thirty_two))
         var bits = Int(pack_bits(hit))
         if bits != 0:
@@ -64,6 +77,8 @@ def first_escape_or_quote[origin: ImmOrigin](data: Span[Byte, origin], start: In
         i += SCAN_W
     while i < n:
         var c = Int(data[i])
+        if c >= 128:
+            ascii = False
         if c == 34 or c == 92 or c < 32:
             return i
         i += 1
@@ -78,7 +93,7 @@ def needs_escape_bytes[origin: ImmOrigin](data: Span[Byte, origin]) -> Bool:
     var sl = SIMD[DType.uint8, SCAN_W](92)
     var thirty_two = SIMD[DType.uint8, SCAN_W](32)
     while i + SCAN_W <= n:
-        var chunk = ptr.load[width=SCAN_W](i)
+        var chunk = ptr.unsafe_load[width=SCAN_W](i)
         var hit = chunk.eq(q).__or__(chunk.eq(sl)).__or__(chunk.lt(thirty_two))
         if Int(pack_bits(hit)) != 0:
             return True

--- a/mojo/vendor/gldjson_src/gldjson_wire/string.mojo
+++ b/mojo/vendor/gldjson_src/gldjson_wire/string.mojo
@@ -3,7 +3,7 @@ from std.memory import unsafe_memcpy
 
 from gldjson_runtime.error import DecodeError
 from gldjson_wire.classify import MAX_ITEM_BYTES, hex_digit
-from gldjson_wire.simdscan import first_escape_or_quote, needs_escape_bytes
+from gldjson_wire.simdscan import needs_escape_bytes, scan_plain_string
 from gldjson_wire.utf8 import string_from_utf8
 
 
@@ -103,8 +103,8 @@ def parse_string[
         raise DecodeError(DecodeError.KIND_SYNTAX, pos)
     var start = pos
     pos += 1
-    # Fast path: SIMD scan to the first quote, backslash, or control byte.
-    var scan = first_escape_or_quote(data, pos)
+    var ascii = True
+    var scan = scan_plain_string(data, pos, ascii)
     var escaped = scan < len(data) and Int(data[scan]) == 92
     if scan < len(data) and Int(data[scan]) < 32:
         raise DecodeError(DecodeError.KIND_ESCAPE, scan)
@@ -112,13 +112,6 @@ def parse_string[
         var n = scan - pos
         if n > MAX_ITEM_BYTES:
             raise DecodeError(DecodeError.KIND_RANGE, start)
-        var ascii = True
-        var i = pos
-        while i < scan:
-            if Int(data[i]) >= 128:
-                ascii = False
-                break
-            i += 1
         var s: String
         if ascii:
             s = String(unsafe_from_utf8=data[pos:scan])


### PR DESCRIPTION
## Summary

- Vendor gld-json one-pass float parse, 4-digit SWAR, Ember `count_trailing_zeros` SIMD scan, digit-pair itoa, and skip of the short-dtoa exact search
- n=1 encode cap 1024 (512 + list `ensure` resized mid-encode)
- Pre-size decode lists to `n`

## Measure (official all-single `2026-09-09-160305` vs #145)

| suite | n | op | #145 | now | vs Ember |
| --- | --- | --- | --- | --- | --- |
| message | 1 | deser | 406 | **348** | **1.55×** |
| telemetry | 1 | deser | 1678 | **1233** | **1.35×** |
| telemetry | 100 | deser | 167450 | **106745** | **1.48×** |
| telemetry | 1 | ser | 2020 | **1319** | **1.27×** |
| telemetry | 100 | ser | 195051 | **117007** | **1.53×** |
| strings | 1 | deser | 2264 | 2314 | 0.51× |

Fidelity 1.0. Strings deser is still heap-bound (32 `String`s). Version stays 0.2.0.

## Validation

- `pixi run test` in `mojo/` (roundtrip ok)
- Official `./mojo/scripts/run-benchmarks.sh all-single json` stem `2026-09-09-160305`