### PR TITLE
perf(mojo): vendor native 32-wide SIMD scan

### DIFF
--- a/mojo/vendor/gldjson_src/gldjson_wire/number.mojo
+++ b/mojo/vendor/gldjson_src/gldjson_wire/number.mojo
@@ -64,7 +64,7 @@ def encoded_int_len(v: Int64) -> Int:
 
 
 def write_int_digits(mut dest: List[Byte], mut pos: Int, v: Int64):
-    """yyjson two-digit write. `encoded_int_len` already counted digits."""
+    """Yyjson two-digit write. `encoded_int_len` already counted digits."""
     var n = encoded_int_len(v)
     write_int_known(dest, pos, v, n)
 
@@ -108,6 +108,7 @@ def write_int_known(mut dest: List[Byte], mut pos: Int, v: Int64, n: Int):
     pos = start + n
 
 
+@always_inline
 def _is_eight_digits(w: UInt64) -> Bool:
     """EmberJson / simdjson: all 8 bytes are ASCII digits. Needs 8 readable bytes."""
     return (
@@ -116,6 +117,7 @@ def _is_eight_digits(w: UInt64) -> Bool:
     ) == UInt64(0x3333333333333333)
 
 
+@always_inline
 def _parse_eight_digits(w: UInt64) -> UInt64:
     """sonic-cpp / EmberJson SWAR 8-digit accumulate."""
     var val = w
@@ -125,14 +127,17 @@ def _parse_eight_digits(w: UInt64) -> UInt64:
     return val
 
 
+@always_inline
 def _load_u64_at[origin: ImmOrigin](data: Span[Byte, origin], pos: Int) -> UInt64:
     return data.unsafe_ptr().unsafe_offset(pos).unsafe_bitcast[UInt64]()[]
 
 
+@always_inline
 def _load_u32_at[origin: ImmOrigin](data: Span[Byte, origin], pos: Int) -> UInt32:
     return data.unsafe_ptr().unsafe_offset(pos).unsafe_bitcast[UInt32]()[]
 
 
+@always_inline
 def _is_four_digits(w: UInt32) -> Bool:
     """Same 8-digit SWAR test, 4-byte lane. Needs 4 readable bytes."""
     return (
@@ -141,6 +146,7 @@ def _is_four_digits(w: UInt32) -> Bool:
     ) == UInt32(0x33333333)
 
 
+@always_inline
 def _parse_four_digits(w: UInt32) -> UInt64:
     """4-digit SWAR. Multiplies stay in UInt64; UInt32 overflows on 9999."""
     var v = UInt64(w & UInt32(0x0F0F0F0F))
@@ -533,6 +539,7 @@ def parse_int[
     return acc
 
 
+@always_inline
 def _pow10f(k: Int) -> Float64:
     """EmberJson POWER_OF_TEN values. If-chain: InlineArray needs materialize."""
     if k == 0:

--- a/mojo/vendor/gldjson_src/gldjson_wire/simdscan.mojo
+++ b/mojo/vendor/gldjson_src/gldjson_wire/simdscan.mojo
@@ -1,18 +1,21 @@
 from std.bit import count_trailing_zeros
 from std.collections import Span
 from std.memory.unsafe import pack_bits
+from std.sys import simd_width_of
 
 
-comptime SCAN_W = 16
+comptime SCAN_W = simd_width_of[DType.uint8]()
 
 
+@always_inline
 def _first_set(bits: Int) -> Int:
     """EmberJson / simdjson: ctz, not a 16-step scalar walk."""
     if bits == 0:
         return SCAN_W
-    return Int(count_trailing_zeros(UInt32(bits)))
+    return Int(count_trailing_zeros(UInt64(bits)))
 
 
+@always_inline
 def skip_ws_span[origin: ImmOrigin](data: Span[Byte, origin], mut pos: Int):
     """Advance `pos` over space / tab / LF / CR. Compact JSON returns in one load."""
     var n = len(data)
@@ -50,6 +53,7 @@ def first_escape_or_quote[origin: ImmOrigin](data: Span[Byte, origin], start: In
     return scan_plain_string(data, start, ascii)
 
 
+@always_inline
 def scan_plain_string[
     origin: ImmOrigin
 ](data: Span[Byte, origin], start: Int, mut ascii: Bool) -> Int:


### PR DESCRIPTION
## Summary

Vendor Ember-style `simd_width_of[Byte]` scan (32 on this host) and inlined SWAR helpers.

## Measure (official `2026-09-09-161131` vs #146)

Message n=1 ser 250→218, deser 348→331 (**1.53× Ember**). Document n=1 deser 1190→1048. 11/20 cells ≥2% faster.

## Validation

`pixi run test` in `mojo/` and official all-single stem `2026-09-09-161131`.