### PR TITLE
perf(php): use the native integer range of cbor-php 3.3.5

### DIFF
--- a/php/composer.json
+++ b/php/composer.json
@@ -4,13 +4,14 @@
   "type": "project",
   "require": {
     "php": ">=8.2",
+    "ext-gmp": "*",
     "ext-json": "*",
     "ext-zlib": "*",
     "flix-tech/avro-php": "^5.1",
     "google/protobuf": "^4.29",
     "jms/serializer": "^3.32",
     "rybakit/msgpack": "^0.9",
-    "spomky-labs/cbor-php": "^3.0",
+    "spomky-labs/cbor-php": "^3.3.5",
     "symfony/property-access": "^7.2",
     "symfony/serializer": "^7.2",
     "symfony/yaml": "^7.2"

--- a/php/composer.lock
+++ b/php/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1999ce0f40e8c95577accecea5040945",
+    "content-hash": "ac2db59592bb699d15bd925e381632eb",
     "packages": [
         {
             "name": "brick/math",
@@ -626,22 +626,23 @@
         },
         {
             "name": "spomky-labs/cbor-php",
-            "version": "3.3.1",
+            "version": "3.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Spomky-Labs/cbor-php.git",
-                "reference": "b5a453e1dbae9594fa7eb778993d177d2e580d84"
+                "reference": "e2208b2afb71123d95b62891f87befb14fcedc46"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Spomky-Labs/cbor-php/zipball/b5a453e1dbae9594fa7eb778993d177d2e580d84",
-                "reference": "b5a453e1dbae9594fa7eb778993d177d2e580d84",
+                "url": "https://api.github.com/repos/Spomky-Labs/cbor-php/zipball/e2208b2afb71123d95b62891f87befb14fcedc46",
+                "reference": "e2208b2afb71123d95b62891f87befb14fcedc46",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.9|^0.10|^0.11|^0.12|^0.13|^0.14|^0.15|^0.16|^0.17|^0.18|^0.19",
+                "brick/math": "^0.9|^0.10|^0.11|^0.12|^0.13|^0.14|^0.15|^0.16|^0.17|^0.18|^0.19|^0.20",
                 "ext-mbstring": "*",
-                "php": ">=8.0"
+                "php": ">=8.0",
+                "symfony/polyfill-php81": "^1.32"
             },
             "require-dev": {
                 "ext-json": "*",
@@ -650,8 +651,8 @@
                 "symfony/var-dumper": "^6.4|^7.1|^8.0"
             },
             "suggest": {
-                "ext-bcmath": "GMP or BCMath extensions will drastically improve the library performance. BCMath extension needed to handle the Big Float and Decimal Fraction Tags",
-                "ext-gmp": "GMP or BCMath extensions will drastically improve the library performance"
+                "ext-bcmath": "Improves the library performance when ext-gmp is missing, and is required to handle the Big Float and Decimal Fraction Tags (4 and 5)",
+                "ext-gmp": "Strongly recommended when decoding untrusted input: without it, converting the byte string of a Big Number Tag (2 and 3) is quadratic in its length. Also improves the library performance overall"
             },
             "type": "library",
             "autoload": {
@@ -681,7 +682,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Spomky-Labs/cbor-php/issues",
-                "source": "https://github.com/Spomky-Labs/cbor-php/tree/3.3.1"
+                "source": "https://github.com/Spomky-Labs/cbor-php/tree/3.3.5"
             },
             "funding": [
                 {
@@ -693,7 +694,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2026-08-26T13:39:26+00:00"
+            "time": "2026-09-10T08:57:42+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -1100,6 +1101,86 @@
                 }
             ],
             "time": "2026-05-27T06:59:30+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php81",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php81.git",
+                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
+                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php81\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.1+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.38.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-26T12:45:58+00:00"
         },
         {
             "name": "symfony/polyfill-php84",
@@ -1715,6 +1796,7 @@
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.2",
+        "ext-gmp": "*",
         "ext-json": "*",
         "ext-zlib": "*"
     },

--- a/php/src/Serializers/CborSer.php
+++ b/php/src/Serializers/CborSer.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace Benchmark\Serializers;
 
-use CBOR\ByteStringObject;
 use CBOR\Decoder;
 use CBOR\Encoder;
 use CBOR\StringStream;
-use CBOR\Tag\UnsignedBigIntegerTag;
 
 final class CborSer extends BytesSer
 {
@@ -42,33 +40,13 @@ final class CborSer extends BytesSer
 
     public function serializeBytes(mixed $value): string
     {
-        return $this->encoder->encode(self::wrapLargeInts($value));
+        return $this->encoder->encode($value);
     }
 
     public function deserializeBytes(string $data): mixed
     {
         $obj = $this->decoder->decode(StringStream::create($data));
         return self::toPhp($obj->normalize());
-    }
-
-    /** Encoder only accepts 32-bit unsigned ints; tag larger values (RFC 8949 bignums). */
-    private static function wrapLargeInts(mixed $v): mixed
-    {
-        if (is_int($v) && $v > 0xFFFFFFFF) {
-            $hex = dechex($v);
-            if ((strlen($hex) % 2) === 1) {
-                $hex = '0' . $hex;
-            }
-            return UnsignedBigIntegerTag::create(ByteStringObject::create((string) hex2bin($hex)));
-        }
-        if (is_array($v)) {
-            $out = [];
-            foreach ($v as $k => $x) {
-                $out[$k] = self::wrapLargeInts($x);
-            }
-            return $out;
-        }
-        return $v;
     }
 
     /** CBOR normalize() often yields numeric strings for integers. */


### PR DESCRIPTION
Follow-up to [Spomky-Labs/cbor-php#148](https://github.com/Spomky-Labs/cbor-php/issues/148), where you asked whether the `cbor` wrapper is idiomatic. Three changes, each independent, take or leave them.

## 1. `wrapLargeInts()` is no longer needed

The wrapper carries this comment:

> Encoder only accepts 32-bit unsigned ints; tag larger values (RFC 8949 bignums).

That was true when it was written. `Encoder::encode()` accepts the full 64-bit range as of 3.3.5, so the recursive pre-pass over every value before each encode is gone.

## 2. The constraint moves to `^3.3.5`

Your lock resolved 3.3.1, where the pre-pass is still load-bearing, so these two have to move together. The lock is regenerated; the diff adds `symfony/polyfill-php81`, a new transitive dependency, and nothing else.

## 3. `ext-gmp` is declared

brick/math, which cbor-php depends on, picks GMP when it is present and falls back to BCMath or to a pure-PHP calculator otherwise.

The static-php-cli "common" build that `install-host-requirements.sh` fetches does ship `gmp` and `bcmath`, so runs that use it are already in the good configuration. The gap is that `run-benchmarks.sh` falls back to whatever `php` is on `PATH` when `~/.local/php/bin/php` is absent, and does so silently. Declaring the extension makes that fail loudly rather than quietly shifting the row.

## One thing to expect in your results

Dropping the bignum pre-pass makes the payload **202 bytes larger** across the ten cells, 129,180 to 129,382, or +0.16%.

A CBOR `uint64` head is a fixed 9 bytes, while a bignum tag is a variable-length byte string. A millisecond timestamp needs 6 significant bytes, so the tag is 8 bytes against 9 for the native head, one byte cheaper, and there are 202 timestamps in the fixtures (`telemetry.ts` and `event.occurred_at`, at N=1 and N=100).

The native form is still the representative one: it is what any CBOR consumer expects to receive for a PHP integer, and it is what every other implementation in your suite emits for that value. But it is not a size win and I would rather you heard it here than found it in a diff.

`FidelityScore` stays 1.0 on all ten cells.

## Not changed

`toPhp()` is left alone. It is genuinely necessary, since `normalize()` returns numeric strings for integers by design. Worth knowing, though: its heuristic also converts any *text* string that looks like a number, so `"01234"` comes back as `int(1234)`. Nothing in the current fixtures triggers it, and `Runner::fidelity()` compares numerics by float value so it would not flag it either. It would only bite if identifiers, postcodes or phone numbers were added later. The robust version walks the decoded object graph and switches on the major type instead of guessing from the normalized output. Happy to send that separately if you want it, but it is more code and I did not want to bundle it here.

