### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/analysis/pyproject.toml
+++ b/analysis/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "benchmark-analysis"
-version = "0.2.0"
+version = "0.3.0"
 description = "Benchmark analysis and reporting tools"
 requires-python = ">=3.12"
 authors = [

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serializer-benchmark-javascript",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "serializer-benchmark-javascript",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.12.1",
         "@bufbuild/protoc-gen-es": "^2.12.1",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serializer-benchmark-javascript",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Node.js harness for cross-language serializer benchmark",
   "type": "module",
   "main": "src/runner.js",

--- a/mojo/pixi.toml
+++ b/mojo/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "serializer-benchmark-mojo"
-version = "0.1.0"
+version = "0.3.0"
 description = "Mojo serializer benchmark runner for Data Model v2"
 authors = ["GLD.SerializerBenchmark"]
 channels = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "seriailizer-benchmark"
-version = "0.2.0"
+version = "0.3.0"
 description = "Multi-language serializer benchmark suite"
 requires-python = ">=3.12"
 authors = [

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "serializer-benchmark"
-version = "0.2.0"
+version = "0.3.0"
 description = "Python serializer benchmark suite matching the C# benchmark design"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "serializer-benchmark-rust"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bincode",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serializer-benchmark-rust"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Rust harness for the Multi-Language Serializer Benchmark"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Minor version bump **0.2.0 → 0.3.0** after the compliance catalog, language runners, and Dashboard heatmap landed.
- Align `mojo/pixi.toml` (was 0.1.0). Dashboard was already 0.3.0.

## Validation
- analysis 90, python 32, javascript 10, dashboard 20 — pass
- Version-only; no behavior change

## Notes
- Does not create the GitHub Release (that follows this merge).