### PR TITLE
fix(harness): apply small call-path notes from library authors

### DIFF
--- a/c-sharp/src/Serializers/ExtendedXmlSerializerSer.cs
+++ b/c-sharp/src/Serializers/ExtendedXmlSerializerSer.cs
@@ -27,7 +27,7 @@ namespace GLD.SerializerBenchmark.Serializers
     internal class ExtendedXmlSerializerSer : SerDeser
     {
         private readonly IExtendedXmlSerializer _serializer =
-            new ConfigurationContainer().UseAutoFormatting().Create();
+            new ConfigurationContainer().Create();
         private XmlEnvelope _native;
 
         public override string Name => "ExtendedXmlSerializer";

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -134,7 +134,7 @@ if(EXISTS ${TP}/QCBOR/src/qcbor_encode.c)
     ${TP}/QCBOR/src/ieee754.c
     src/serializers/ser_qcbor.c)
   list(APPEND BENCH_INCLUDES ${TP}/QCBOR/inc)
-  add_compile_definitions(HAS_QCBOR=1)
+  add_compile_definitions(HAS_QCBOR=1 QCBOR_DISABLE_ENCODE_USAGE_GUARDS=1)
   message(STATUS "serializer: qcbor REAL")
 endif()
 

--- a/c/src/serializers/ser_qcbor.c
+++ b/c/src/serializers/ser_qcbor.c
@@ -11,91 +11,44 @@ static int prep(test_data_kind_t k, const test_fixture_t *fx) { (void)k;(void)fx
 
 typedef struct {
     QCBOREncodeContext *ctx;
-    char pending_key[64];
-    int has_key;
-    int in_array_depth; /* when >0 and no key, add bare value */
 } qcw;
 
 static int w_begin_map(void *ctx, int n) {
     (void)n;
-    qcw *c = ctx;
-    if (c->has_key) {
-        QCBOREncode_OpenMapInMapSZ(c->ctx, c->pending_key);
-        c->has_key = 0;
-    } else if (c->in_array_depth > 0) {
-        QCBOREncode_OpenMap(c->ctx);
-    } else {
-        QCBOREncode_OpenMap(c->ctx);
-    }
+    QCBOREncode_OpenMap(((qcw *)ctx)->ctx);
     return 0;
 }
 static int w_end_map(void *ctx) {
-    qcw *c = ctx;
-    QCBOREncode_CloseMap(c->ctx);
+    QCBOREncode_CloseMap(((qcw *)ctx)->ctx);
     return 0;
 }
 static int w_begin_array(void *ctx, int n) {
     (void)n;
-    qcw *c = ctx;
-    if (c->has_key) {
-        QCBOREncode_OpenArrayInMapSZ(c->ctx, c->pending_key);
-        c->has_key = 0;
-    } else {
-        QCBOREncode_OpenArray(c->ctx);
-    }
-    c->in_array_depth++;
+    QCBOREncode_OpenArray(((qcw *)ctx)->ctx);
     return 0;
 }
 static int w_end_array(void *ctx) {
-    qcw *c = ctx;
-    QCBOREncode_CloseArray(c->ctx);
-    if (c->in_array_depth > 0) c->in_array_depth--;
+    QCBOREncode_CloseArray(((qcw *)ctx)->ctx);
     return 0;
 }
 static int w_key(void *ctx, const char *k) {
-    qcw *c = ctx;
-    snprintf(c->pending_key, sizeof c->pending_key, "%s", k);
-    c->has_key = 1;
+    QCBOREncode_AddSZString(((qcw *)ctx)->ctx, k);
     return 0;
 }
 static int w_bool(void *ctx, int v) {
-    qcw *c = ctx;
-    if (c->has_key) {
-        QCBOREncode_AddBoolToMapSZ(c->ctx, c->pending_key, v);
-        c->has_key = 0;
-    } else {
-        QCBOREncode_AddBool(c->ctx, v);
-    }
+    QCBOREncode_AddBool(((qcw *)ctx)->ctx, v);
     return 0;
 }
 static int w_i64(void *ctx, int64_t v) {
-    qcw *c = ctx;
-    if (c->has_key) {
-        QCBOREncode_AddInt64ToMapSZ(c->ctx, c->pending_key, v);
-        c->has_key = 0;
-    } else {
-        QCBOREncode_AddInt64(c->ctx, v);
-    }
+    QCBOREncode_AddInt64(((qcw *)ctx)->ctx, v);
     return 0;
 }
 static int w_f64(void *ctx, double v) {
-    qcw *c = ctx;
-    if (c->has_key) {
-        QCBOREncode_AddDoubleToMapSZ(c->ctx, c->pending_key, v);
-        c->has_key = 0;
-    } else {
-        QCBOREncode_AddDouble(c->ctx, v);
-    }
+    QCBOREncode_AddDouble(((qcw *)ctx)->ctx, v);
     return 0;
 }
 static int w_str(void *ctx, const char *s) {
-    qcw *c = ctx;
-    if (c->has_key) {
-        QCBOREncode_AddSZStringToMapSZ(c->ctx, c->pending_key, s ? s : "");
-        c->has_key = 0;
-    } else {
-        QCBOREncode_AddSZString(c->ctx, s ? s : "");
-    }
+    QCBOREncode_AddSZString(((qcw *)ctx)->ctx, s ? s : "");
     return 0;
 }
 

--- a/java/src/main/java/benchmark/serializers/JacksonSer.java
+++ b/java/src/main/java/benchmark/serializers/JacksonSer.java
@@ -34,7 +34,7 @@ public final class JacksonSer implements BenchSerializer {
   public JacksonSer() {
     mapper = new ObjectMapper();
     // Field-visible POJOs (public fields); no pretty print.
-    mapper.findAndRegisterModules();
+    // Do not findAndRegisterModules(): that pulls arbitrary classpath modules.
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
   }

--- a/java/src/main/java/benchmark/serializers/JacksonYamlSer.java
+++ b/java/src/main/java/benchmark/serializers/JacksonYamlSer.java
@@ -27,7 +27,7 @@ public final class JacksonYamlSer implements BenchSerializer {
     YAMLFactory factory =
         new YAMLFactory().disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER);
     mapper = new ObjectMapper(factory);
-    mapper.findAndRegisterModules();
+    // YAMLFactory is explicit; do not findAndRegisterModules().
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
   }

--- a/java/src/main/java/benchmark/serializers/KryoSer.java
+++ b/java/src/main/java/benchmark/serializers/KryoSer.java
@@ -78,7 +78,6 @@ public final class KryoSer implements BenchSerializer {
   public byte[] serializeBytes(Fixture fx) {
     baos.reset();
     output.setOutputStream(baos);
-    output.reset();
     kryo.writeClassAndObject(output, fx.value);
     output.flush();
     return baos.toByteArray();
@@ -93,7 +92,6 @@ public final class KryoSer implements BenchSerializer {
   @Override
   public int serializeStream(Fixture fx, OutputStream out) {
     output.setOutputStream(out);
-    output.reset();
     kryo.writeClassAndObject(output, fx.value);
     output.flush();
     return (int) output.total();

--- a/kotlin/src/main/kotlin/benchmark/serializers/JacksonCborSer.kt
+++ b/kotlin/src/main/kotlin/benchmark/serializers/JacksonCborSer.kt
@@ -35,6 +35,7 @@ class JacksonCborSer : BenchSerializer {
             writer = mapper.writerFor(fx.value.javaClass)
             reader = mapper.readerFor(fx.value.javaClass)
         }
+        reader.readValue(writer.writeValueAsBytes(fx.value))
     }
 
     override fun serializeBytes(fx: Fixture): ByteArray = writer.writeValueAsBytes(fx.value)

--- a/kotlin/src/main/kotlin/benchmark/serializers/JacksonCborSer.kt
+++ b/kotlin/src/main/kotlin/benchmark/serializers/JacksonCborSer.kt
@@ -35,7 +35,7 @@ class JacksonCborSer : BenchSerializer {
             writer = mapper.writerFor(fx.value.javaClass)
             reader = mapper.readerFor(fx.value.javaClass)
         }
-        reader.readValue(writer.writeValueAsBytes(fx.value))
+        reader.readValue<Any>(writer.writeValueAsBytes(fx.value))
     }
 
     override fun serializeBytes(fx: Fixture): ByteArray = writer.writeValueAsBytes(fx.value)

--- a/kotlin/src/main/kotlin/benchmark/serializers/JacksonKotlinSer.kt
+++ b/kotlin/src/main/kotlin/benchmark/serializers/JacksonKotlinSer.kt
@@ -40,7 +40,7 @@ class JacksonKotlinSer : BenchSerializer {
             reader = mapper.readerFor(fx.value.javaClass)
         }
         // Untimed: build the deserializer graph + kotlin-reflect (otherwise first timed readValue pays it).
-        reader.readValue(writer.writeValueAsBytes(fx.value))
+        reader.readValue<Any>(writer.writeValueAsBytes(fx.value))
     }
 
     override fun serializeBytes(fx: Fixture): ByteArray = writer.writeValueAsBytes(fx.value)

--- a/kotlin/src/main/kotlin/benchmark/serializers/JacksonKotlinSer.kt
+++ b/kotlin/src/main/kotlin/benchmark/serializers/JacksonKotlinSer.kt
@@ -39,6 +39,8 @@ class JacksonKotlinSer : BenchSerializer {
             writer = mapper.writerFor(fx.value.javaClass)
             reader = mapper.readerFor(fx.value.javaClass)
         }
+        // Untimed: build the deserializer graph + kotlin-reflect (otherwise first timed readValue pays it).
+        reader.readValue(writer.writeValueAsBytes(fx.value))
     }
 
     override fun serializeBytes(fx: Fixture): ByteArray = writer.writeValueAsBytes(fx.value)

--- a/kotlin/src/main/kotlin/benchmark/serializers/KryoSer.kt
+++ b/kotlin/src/main/kotlin/benchmark/serializers/KryoSer.kt
@@ -62,7 +62,6 @@ class KryoSer : BenchSerializer {
     override fun serializeBytes(fx: Fixture): ByteArray {
         baos.reset()
         output.setOutputStream(baos)
-        output.reset()
         kryo.writeClassAndObject(output, fx.value)
         output.flush()
         return baos.toByteArray()

--- a/kotlin/src/main/kotlin/benchmark/serializers/KryoSer.kt
+++ b/kotlin/src/main/kotlin/benchmark/serializers/KryoSer.kt
@@ -74,7 +74,6 @@ class KryoSer : BenchSerializer {
 
     override fun serializeStream(fx: Fixture, out: OutputStream): Int {
         output.setOutputStream(out)
-        output.reset()
         kryo.writeClassAndObject(output, fx.value)
         output.flush()
         return output.total().toInt()

--- a/kotlin/src/main/kotlin/benchmark/serializers/MsgpackSer.kt
+++ b/kotlin/src/main/kotlin/benchmark/serializers/MsgpackSer.kt
@@ -35,7 +35,7 @@ class MsgpackSer : BenchSerializer {
             writer = mapper.writerFor(fx.value.javaClass)
             reader = mapper.readerFor(fx.value.javaClass)
         }
-        reader.readValue(writer.writeValueAsBytes(fx.value))
+        reader.readValue<Any>(writer.writeValueAsBytes(fx.value))
     }
 
     override fun serializeBytes(fx: Fixture): ByteArray = writer.writeValueAsBytes(fx.value)

--- a/kotlin/src/main/kotlin/benchmark/serializers/MsgpackSer.kt
+++ b/kotlin/src/main/kotlin/benchmark/serializers/MsgpackSer.kt
@@ -35,6 +35,7 @@ class MsgpackSer : BenchSerializer {
             writer = mapper.writerFor(fx.value.javaClass)
             reader = mapper.readerFor(fx.value.javaClass)
         }
+        reader.readValue(writer.writeValueAsBytes(fx.value))
     }
 
     override fun serializeBytes(fx: Fixture): ByteArray = writer.writeValueAsBytes(fx.value)


### PR DESCRIPTION
## Summary
- Walked the 28 open fairness-review issues that already had author replies.
- Applied the small wrapper fixes: drop Jackson `findAndRegisterModules`, Kryo `reset` after `setOutputStream`, ExtendedXml `UseAutoFormatting`; untimed Kotlin Jackson/CBOR/msgpack prepare probe; QCBOR `AddSZString` keys + `QCBOR_DISABLE_ENCODE_USAGE_GUARDS`.
- Replied on every thread. Closed the ones that were done. Left open the items that still need a larger change (nanopb, zcbor decode, bitcode inner-struct, ForyKotlin, dsl-json compiled converters, zpp_bits buffer reuse, cbor2 `load(BytesIO)` question).

## Validation
- Local compile of QCBOR/Jackson/Kryo not re-run on this host (Java 8 default; Kotlin needs JDK 21). CI smoke will cover it.